### PR TITLE
refactor: extract delete and archive modals into components

### DIFF
--- a/src/ui/ArchiveModal.tsx
+++ b/src/ui/ArchiveModal.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+import { Box, Text, TextInput, useInput } from 'ink';
+import chalk from 'chalk';
+import type { RepoNode } from '../types';
+import { archiveRepositoryById, unarchiveRepositoryById } from '../github';
+
+interface Props {
+  repo: RepoNode;
+  client: any;
+  width: number;
+  height: number;
+  onCancel: () => void;
+  onUpdated: (id: string, isArchived: boolean) => void;
+}
+
+export default function ArchiveModal({ repo, client, width, height, onCancel, onUpdated }: Props) {
+  const [archiving, setArchiving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [focus, setFocus] = useState<'confirm' | 'cancel'>('confirm');
+
+  useInput((input, key) => {
+    if (key.escape || (input && input.toUpperCase() === 'C')) {
+      onCancel();
+      return;
+    }
+    if (key.leftArrow) {
+      setFocus('confirm');
+      return;
+    }
+    if (key.rightArrow) {
+      setFocus('cancel');
+      return;
+    }
+    if (key.return || (input && input.toUpperCase() === 'Y')) {
+      if (focus === 'cancel') {
+        onCancel();
+        return;
+      }
+      confirm();
+      return;
+    }
+  });
+
+  async function confirm() {
+    try {
+      setArchiving(true);
+      const isArchived = repo.isArchived;
+      const id = (repo as any).id;
+      if (isArchived) await unarchiveRepositoryById(client, id);
+      else await archiveRepositoryById(client, id);
+      onUpdated(id, !isArchived);
+    } catch (e) {
+      setArchiving(false);
+      setError('Failed to update archive state. Check permissions.');
+    }
+  }
+
+  return (
+    <Box height={height} alignItems="center" justifyContent="center">
+      <Box flexDirection="column" borderStyle="round" borderColor={repo.isArchived ? 'green' : 'yellow'} paddingX={3} paddingY={2} width={Math.min(width - 8, 80)}>
+        <Text bold>{repo.isArchived ? 'Unarchive Confirmation' : 'Archive Confirmation'}</Text>
+        <Text color={repo.isArchived ? 'green' : 'yellow'}>{repo.isArchived ? '↺  Unarchive repository?' : '⚠️  Archive repository?'}</Text>
+        <Box height={1}><Text> </Text></Box>
+        <Text>{repo.nameWithOwner}</Text>
+        <Box marginTop={1}>
+          <Text>{repo.isArchived ? 'This will make the repository active again.' : 'This will make the repository read-only.'}</Text>
+        </Box>
+        <Box marginTop={1} flexDirection="row" justifyContent="center" gap={6}>
+          <Box borderStyle="round" borderColor={repo.isArchived ? 'green' : 'yellow'} height={3} width={20} alignItems="center" justifyContent="center">
+            <Text>{focus === 'confirm' ? chalk.bgGreen.white.bold(` ${repo.isArchived ? 'Unarchive' : 'Archive'} `) : chalk.bold[repo.isArchived ? 'green' : 'yellow'](repo.isArchived ? 'Unarchive' : 'Archive')}</Text>
+          </Box>
+          <Box borderStyle="round" borderColor={focus === 'cancel' ? 'white' : 'gray'} height={3} width={20} alignItems="center" justifyContent="center">
+            <Text>{focus === 'cancel' ? chalk.bgGray.white.bold(' Cancel ') : chalk.gray.bold('Cancel')}</Text>
+          </Box>
+        </Box>
+        <Box marginTop={1} flexDirection="row" justifyContent="center">
+          <Text color="gray">Press Enter to {focus === 'confirm' ? (repo.isArchived ? 'Unarchive' : 'Archive') : 'Cancel'} • Y to confirm • C to cancel</Text>
+        </Box>
+        <Box marginTop={1}>
+          <TextInput value="" onChange={() => {}} onSubmit={() => { if (focus === 'confirm') { confirm(); } else { onCancel(); } }} />
+        </Box>
+        {error && (
+          <Box marginTop={1}>
+            <Text color="magenta">{error}</Text>
+          </Box>
+        )}
+        {archiving && (
+          <Box marginTop={1}>
+            <Text color="yellow">{repo.isArchived ? 'Unarchiving...' : 'Archiving...'}</Text>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/DeleteModal.tsx
+++ b/src/ui/DeleteModal.tsx
@@ -1,0 +1,177 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Text, TextInput, useInput } from 'ink';
+import chalk from 'chalk';
+import { deleteRepositoryRest } from '../github';
+import type { RepoNode } from '../types';
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return 'today';
+  if (diffDays === 1) return 'yesterday';
+  if (diffDays < 7) return `${diffDays} days ago`;
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)} weeks ago`;
+  if (diffDays < 365) return `${Math.floor(diffDays / 30)} months ago`;
+  return `${Math.floor(diffDays / 365)} years ago`;
+}
+
+interface Props {
+  repo: RepoNode;
+  token: string;
+  width: number;
+  height: number;
+  onCancel: () => void;
+  onDeleted: (id: string) => void;
+}
+
+export default function DeleteModal({ repo, token, width, height, onCancel, onDeleted }: Props) {
+  const [deleteCode, setDeleteCode] = useState('');
+  const [typedCode, setTypedCode] = useState('');
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmStage, setConfirmStage] = useState(false);
+  const [focus, setFocus] = useState<'delete' | 'cancel'>('delete');
+
+  useEffect(() => {
+    const letters = 'ABDEFGHIJKLMNOPQRSTUVWXYZ';
+    const code = Array.from({ length: 4 }, () => letters[Math.floor(Math.random() * letters.length)]).join('');
+    setDeleteCode(code);
+    setTypedCode('');
+    setConfirmStage(false);
+    setFocus('delete');
+    setError(null);
+    setDeleting(false);
+  }, [repo]);
+
+  useInput((input, key) => {
+    if (key.escape || (input && input.toUpperCase() === 'C')) {
+      onCancel();
+      return;
+    }
+    if (!confirmStage) {
+      return; // TextInput handles typing
+    }
+    if (key.leftArrow) {
+      setFocus('delete');
+      return;
+    }
+    if (key.rightArrow) {
+      setFocus('cancel');
+      return;
+    }
+    if (key.return) {
+      if (focus === 'delete') confirmDelete();
+      else onCancel();
+      return;
+    }
+    if (input && input.toUpperCase() === 'Y') {
+      confirmDelete();
+      return;
+    }
+  });
+
+  async function confirmDelete() {
+    try {
+      setDeleting(true);
+      const [owner, name] = (repo.nameWithOwner || '').split('/');
+      await deleteRepositoryRest(token, owner, name);
+      onDeleted((repo as any).id);
+    } catch (e) {
+      setDeleting(false);
+      setError('Failed to delete repository. Ensure delete_repo scope and admin permissions.');
+    }
+  }
+
+  const langName = repo.primaryLanguage?.name || '';
+  const langColor = repo.primaryLanguage?.color || '#666666';
+
+  return (
+    <Box height={height} alignItems="center" justifyContent="center">
+      <Box flexDirection="column" borderStyle="round" borderColor="red" paddingX={3} paddingY={2} width={Math.min(width - 8, 80)}>
+        <Text bold>Delete Confirmation</Text>
+        <Text color="red">⚠️  Delete repository?</Text>
+        <Box height={2}><Text> </Text></Box>
+        {(() => {
+          let line1 = '';
+          line1 += chalk.white(repo.nameWithOwner);
+          if (repo.isPrivate) line1 += chalk.yellow(' Private');
+          if (repo.isArchived) line1 += chalk.gray.dim(' Archived');
+          if (repo.isFork && repo.parent) line1 += chalk.blue(` Fork of ${repo.parent.nameWithOwner}`);
+          let line2 = '';
+          if (langName) line2 += chalk.hex(langColor)('● ') + chalk.gray(`${langName}  `);
+          line2 += chalk.gray(`★ ${repo.stargazerCount}  ⑂ ${repo.forkCount}  Updated ${formatDate(repo.updatedAt)}`);
+          return (
+            <>
+              <Text>{line1}</Text>
+              <Text>{line2}</Text>
+            </>
+          );
+        })()}
+        <Box marginTop={1}>
+          <Text>
+            Type <Text color="yellow" bold>{deleteCode}</Text> to confirm.
+          </Text>
+        </Box>
+        {!confirmStage && (
+          <Box marginTop={1}>
+            <Text>Confirm code: </Text>
+            <TextInput
+              value={typedCode}
+              onChange={(v) => {
+                const up = (v || '').toUpperCase();
+                const cut = up.slice(0, 4);
+                setTypedCode(cut);
+                if (cut.length < 4) {
+                  setError(null);
+                }
+                if (cut.length === 4) {
+                  if (cut === deleteCode) {
+                    setError(null);
+                    setConfirmStage(true);
+                    setFocus('delete');
+                  } else {
+                    setError('Code does not match');
+                  }
+                }
+              }}
+              onSubmit={() => {}}
+              placeholder={deleteCode}
+            />
+          </Box>
+        )}
+        {confirmStage && (
+          <Box marginTop={1} flexDirection="column">
+            <Text color="red">This action will permanently delete the repository. This cannot be undone.</Text>
+            <Box marginTop={1} flexDirection="row" justifyContent="center" gap={6}>
+              <Box borderStyle="round" borderColor="red" height={3} width={20} alignItems="center" justifyContent="center">
+                <Text>{focus === 'delete' ? chalk.bgRed.white.bold(' Delete ') : chalk.red.bold('Delete')}</Text>
+              </Box>
+              <Box borderStyle="round" borderColor={focus === 'cancel' ? 'white' : 'gray'} height={3} width={20} alignItems="center" justifyContent="center">
+                <Text>{focus === 'cancel' ? chalk.bgGray.white.bold(' Cancel ') : chalk.gray.bold('Cancel')}</Text>
+              </Box>
+            </Box>
+            <Box marginTop={1} flexDirection="row" justifyContent="center">
+              <Text color="gray">Press Enter to {focus === 'delete' ? 'Delete' : 'Cancel'} • Y to confirm • C to cancel</Text>
+            </Box>
+            <Box marginTop={1}>
+              <TextInput value="" onChange={() => {}} onSubmit={() => { if (focus === 'delete') confirmDelete(); else onCancel(); }} />
+            </Box>
+          </Box>
+        )}
+        {error && (
+          <Box marginTop={1}>
+            <Text color="magenta">{error}</Text>
+          </Box>
+        )}
+        {deleting && (
+          <Box marginTop={1}>
+            <Text color="yellow">Deleting...</Text>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/RepoList.tsx
+++ b/src/ui/RepoList.tsx
@@ -2,12 +2,14 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Box, Text, useApp, useInput, useStdout, Spacer, Newline } from 'ink';
 import TextInput from 'ink-text-input';
 import chalk from 'chalk';
-import { makeClient, fetchViewerReposPageUnified, searchRepositoriesUnified, deleteRepositoryRest, archiveRepositoryById, unarchiveRepositoryById, syncForkWithUpstream, purgeApolloCacheFiles, inspectCacheStatus, OwnerAffiliation } from '../github';
+import { makeClient, fetchViewerReposPageUnified, searchRepositoriesUnified, syncForkWithUpstream, purgeApolloCacheFiles, inspectCacheStatus, OwnerAffiliation } from '../github';
 import { getUIPrefs, storeUIPrefs, OwnerContext } from '../config';
 import { makeApolloKey, makeSearchKey, isFresh, markFetched } from '../apolloMeta';
 import type { RepoNode, RateLimitInfo } from '../types';
 import { exec } from 'child_process';
 import OrgSwitcher from './OrgSwitcher';
+import DeleteModal from './DeleteModal';
+import ArchiveModal from './ArchiveModal';
 
 const PAGE_SIZE = (process.env.GH_MANAGER_DEV === '1' || process.env.NODE_ENV === 'development') ? 5 : 15;
 
@@ -162,19 +164,10 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   // Delete modal state
   const [deleteMode, setDeleteMode] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<RepoNode | null>(null);
-  const [deleteCode, setDeleteCode] = useState('');
-  const [typedCode, setTypedCode] = useState('');
-  const [deleting, setDeleting] = useState(false);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
-  const [deleteConfirmStage, setDeleteConfirmStage] = useState(false); // true after code verified
-  const [confirmFocus, setConfirmFocus] = useState<'delete' | 'cancel'>('delete');
 
   // Archive modal state
   const [archiveMode, setArchiveMode] = useState(false);
   const [archiveTarget, setArchiveTarget] = useState<RepoNode | null>(null);
-  const [archiving, setArchiving] = useState(false);
-  const [archiveError, setArchiveError] = useState<string | null>(null);
-  const [archiveFocus, setArchiveFocus] = useState<'confirm' | 'cancel'>('confirm');
 
   // Sync modal state
   const [syncMode, setSyncMode] = useState(false);
@@ -194,9 +187,6 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   function closeArchiveModal() {
     setArchiveMode(false);
     setArchiveTarget(null);
-    setArchiving(false);
-    setArchiveError(null);
-    setArchiveFocus('confirm');
   }
 
   function closeSyncModal() {
@@ -230,35 +220,6 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   function cancelDeleteModal() {
     setDeleteMode(false);
     setDeleteTarget(null);
-    setTypedCode('');
-    setDeleteError(null);
-    setDeleteConfirmStage(false);
-    setDeleting(false);
-    setConfirmFocus('delete');
-  }
-
-  async function confirmDeleteNow() {
-    if (!deleteTarget) return;
-    try {
-      setDeleting(true);
-      // REST: requires owner/repo and a token with delete_repo scope
-      const [owner, repo] = (deleteTarget.nameWithOwner || '').split('/');
-      await deleteRepositoryRest(token, owner, repo);
-      // Remove from items and update counts
-      setItems((prev) => prev.filter((r: any) => r.id !== (deleteTarget as any).id));
-      setTotalCount((c) => Math.max(0, c - 1));
-      setDeleteMode(false);
-      setDeleteTarget(null);
-      setTypedCode('');
-      setDeleteError(null);
-      setDeleting(false);
-      setDeleteConfirmStage(false);
-      // Keep cursor in range
-      setCursor((c) => Math.max(0, Math.min(c, visibleItems.length - 2)));
-    } catch (e: any) {
-      setDeleting(false);
-      setDeleteError('Failed to delete repository. Ensure delete_repo scope and admin permissions.');
-    }
   }
 
   // Filter state
@@ -550,73 +511,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return; // OrgSwitcher component handles its own keyboard input
     }
     
-    // When in delete mode, trap inputs for modal
-    if (deleteMode) {
-      if (key.escape || (input && input.toUpperCase() === 'C')) {
-        cancelDeleteModal();
-        return;
-      }
-      // In final warning stage, support left/right focus and confirm/cancel with Enter
-      if (deleteConfirmStage) {
-        if (key.leftArrow) {
-          setConfirmFocus('delete');
-          return;
-        }
-        if (key.rightArrow) {
-          setConfirmFocus('cancel');
-          return;
-        }
-        if (key.return) {
-          if (confirmFocus === 'delete') confirmDeleteNow();
-          else cancelDeleteModal();
-          return;
-        }
-        if (input && input.toUpperCase() === 'Y') {
-          confirmDeleteNow();
-          return;
-        }
-      }
-      // Let TextInput inside modal handle text and Enter for stage 1
-      return;
-    }
-
-    // When in archive mode, trap inputs for modal
-    if (archiveMode) {
-      if (key.escape || (input && input.toUpperCase() === 'C')) {
-        closeArchiveModal();
-        return;
-      }
-      if (key.leftArrow) {
-        setArchiveFocus('confirm');
-        return;
-      }
-      if (key.rightArrow) {
-        setArchiveFocus('cancel');
-        return;
-      }
-      if (key.return || (input && input.toUpperCase() === 'Y')) {
-        if (archiveFocus === 'cancel') {
-          closeArchiveModal();
-          return;
-        }
-        if (!archiveTarget) return;
-        (async () => {
-          try {
-            setArchiving(true);
-            const isArchived = archiveTarget.isArchived;
-            const id = (archiveTarget as any).id;
-            if (isArchived) await unarchiveRepositoryById(client, id);
-            else await archiveRepositoryById(client, id);
-              setItems(prev => prev.map(r => (r.id === (archiveTarget as any).id ? { ...r, isArchived: !isArchived } : r)));
-            closeArchiveModal();
-          } catch (e) {
-            setArchiving(false);
-            setArchiveError('Failed to update archive state. Check permissions.');
-          }
-        })();
-        return;
-      }
-      // Trap everything else
+    // When delete or archive modals are open, let them handle their own input
+    if (deleteMode || archiveMode) {
       return;
     }
 
@@ -767,14 +663,6 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       if (repo) {
         setDeleteTarget(repo);
         setDeleteMode(true);
-        setTypedCode('');
-        setDeleteError(null);
-        // Generate random 4-char uppercase code excluding 'C'
-        const letters = 'ABDEFGHIJKLMNOPQRSTUVWXYZ';
-        const code = Array.from({ length: 4 }, () => letters[Math.floor(Math.random() * letters.length)]).join('');
-        setDeleteCode(code);
-        setDeleteConfirmStage(false);
-        setConfirmFocus('delete');
       }
       return;
     }
@@ -809,9 +697,6 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       if (repo) {
         setArchiveTarget(repo);
         setArchiveMode(true);
-        setArchiveError(null);
-        setArchiving(false);
-        setArchiveFocus('confirm');
       }
       return;
     }
@@ -1140,215 +1025,31 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       {/* Main content container with border - fixed height */}
       <Box borderStyle="single" borderColor={modalOpen ? 'gray' : 'yellow'} paddingX={1} paddingY={1} marginX={1} height={contentHeight + containerPadding + 2} flexDirection="column">
         {deleteMode && deleteTarget ? (
-          // Centered modal; hide list content while modal is open
-          <Box height={contentHeight} alignItems="center" justifyContent="center">
-            <Box flexDirection="column" borderStyle="round" borderColor="red" paddingX={3} paddingY={2} width={Math.min(terminalWidth - 8, 80)}>
-                      <Text bold>Delete Confirmation</Text>
-                      <Text color="red">⚠️  Delete repository?</Text>
-                      <Box height={2}>
-                        <Text> </Text>
-                      </Box>
-                      {(() => {
-                        const langName = deleteTarget.primaryLanguage?.name || '';
-                        const langColor = deleteTarget.primaryLanguage?.color || '#666666';
-                        let line1 = '';
-                        line1 += chalk.white(deleteTarget.nameWithOwner);
-                        if (deleteTarget.isPrivate) line1 += chalk.yellow(' Private');
-                        if (deleteTarget.isArchived) line1 += chalk.gray.dim(' Archived');
-                        if (deleteTarget.isFork && deleteTarget.parent) line1 += chalk.blue(` Fork of ${deleteTarget.parent.nameWithOwner}`);
-                        let line2 = '';
-                        if (langName) line2 += chalk.hex(langColor)('● ') + chalk.gray(`${langName}  `);
-                        line2 += chalk.gray(`★ ${deleteTarget.stargazerCount}  ⑂ ${deleteTarget.forkCount}  Updated ${formatDate(deleteTarget.updatedAt)}`);
-                        return (
-                          <>
-                            <Text>{line1}</Text>
-                            <Text>{line2}</Text>
-                          </>
-                        );
-                      })()}
-                      <Box marginTop={1}>
-                        <Text>
-                          Type <Text color="yellow" bold>{deleteCode}</Text> to confirm.
-                        </Text>
-                      </Box>
-                      {!deleteConfirmStage && (
-                        <Box marginTop={1}>
-                          <Text>Confirm code: </Text>
-                          <TextInput
-                            value={typedCode}
-                            onChange={(v) => {
-                              const up = (v || '').toUpperCase();
-                              const cut = up.slice(0, 4);
-                              setTypedCode(cut);
-                              if (cut.length < 4) {
-                                setDeleteError(null);
-                              }
-                              if (cut.length === 4) {
-                                if (cut === deleteCode && deleteTarget) {
-                                  setDeleteError(null);
-                                  setDeleteConfirmStage(true);
-                                  setConfirmFocus('delete');
-                                } else {
-                                  setDeleteError('Code does not match');
-                                }
-                              }
-                            }}
-                            onSubmit={() => { /* no-op: auto-advance on 4 chars */ }}
-                            placeholder={deleteCode}
-                          />
-                        </Box>
-                      )}
-              {deleteConfirmStage && (
-                <Box marginTop={1} flexDirection="column">
-                  <Text color="red">
-                    This action will permanently delete the repository. This cannot be undone.
-                  </Text>
-                  {/* Action buttons row (taller buttons; no inline hints) */}
-                  <Box marginTop={1} flexDirection="row" justifyContent="center" gap={6}>
-                    <Box
-                      borderStyle="round"
-                      borderColor="red"
-                      height={3}
-                      width={20}
-                      alignItems="center"
-                      justifyContent="center"
-                      flexDirection="column"
-                    >
-                      <Text>{confirmFocus === 'delete' ? chalk.bgRed.white.bold(' Delete ') : chalk.red.bold('Delete')}</Text>
-                    </Box>
-                    <Box
-                      borderStyle="round"
-                      borderColor={confirmFocus === 'cancel' ? 'white' : 'gray'}
-                      height={3}
-                      width={20}
-                      alignItems="center"
-                      justifyContent="center"
-                      flexDirection="column"
-                    >
-                      <Text>{confirmFocus === 'cancel' ? chalk.bgGray.white.bold(' Cancel ') : chalk.gray.bold('Cancel')}</Text>
-                    </Box>
-                  </Box>
-                  {/* Bottom prompt with dynamic Enter action and key hints (gray) */}
-                  <Box marginTop={1} flexDirection="row" justifyContent="center">
-                    <Text color="gray">
-                      Press Enter to {confirmFocus === 'delete' ? 'Delete' : 'Cancel'} • Y to confirm • C to cancel
-                    </Text>
-                  </Box>
-                  {/* Hidden input to capture Enter key */}
-                          <Box marginTop={1}>
-                            <TextInput
-                              value=""
-                              onChange={() => { /* noop */ }}
-                              onSubmit={() => {
-                                if (confirmFocus === 'delete') confirmDeleteNow();
-                                else cancelDeleteModal();
-                              }}
-                              placeholder=""
-                            />
-                          </Box>
-                </Box>
-              )}
-          {deleteError && (
-            <Box marginTop={1}>
-              <Text color="magenta">{deleteError}</Text>
-            </Box>
-          )}
-                      {deleting && (
-                        <Box marginTop={1}>
-                          <Text color="yellow">Deleting...</Text>
-                        </Box>
-                      )}
-            </Box>
-          </Box>
+          <DeleteModal
+            repo={deleteTarget}
+            token={token}
+            width={terminalWidth}
+            height={contentHeight}
+            onCancel={cancelDeleteModal}
+            onDeleted={(id) => {
+              setItems(prev => prev.filter(r => r.id !== id));
+              setTotalCount(c => Math.max(0, c - 1));
+              cancelDeleteModal();
+              setCursor(c => Math.max(0, Math.min(c, visibleItems.length - 2)));
+            }}
+          />
         ) : archiveMode && archiveTarget ? (
-          <Box height={contentHeight} alignItems="center" justifyContent="center">
-            <Box flexDirection="column" borderStyle="round" borderColor={archiveTarget.isArchived ? 'green' : 'yellow'} paddingX={3} paddingY={2} width={Math.min(terminalWidth - 8, 80)}>
-              <Text bold>{archiveTarget.isArchived ? 'Unarchive Confirmation' : 'Archive Confirmation'}</Text>
-              <Text color={archiveTarget.isArchived ? 'green' : 'yellow'}>
-                {archiveTarget.isArchived ? '↺  Unarchive repository?' : '⚠️  Archive repository?'}
-              </Text>
-              <Box height={1}><Text> </Text></Box>
-              <Text>{archiveTarget.nameWithOwner}</Text>
-              <Box marginTop={1}>
-                <Text>
-                  {archiveTarget.isArchived ? 'This will make the repository active again.' : 'This will make the repository read-only.'}
-                </Text>
-              </Box>
-              <Box marginTop={1} flexDirection="row" justifyContent="center" gap={6}>
-                <Box
-                  borderStyle="round"
-                  borderColor={archiveTarget.isArchived ? 'green' : 'yellow'}
-                  height={3}
-                  width={20}
-                  alignItems="center"
-                  justifyContent="center"
-                  flexDirection="column"
-                >
-                  <Text>
-                    {archiveFocus === 'confirm' ? 
-                      chalk.bgGreen.white.bold(` ${archiveTarget.isArchived ? 'Unarchive' : 'Archive'} `) : 
-                      chalk.bold[archiveTarget.isArchived ? 'green' : 'yellow'](archiveTarget.isArchived ? 'Unarchive' : 'Archive')
-                    }
-                  </Text>
-                </Box>
-                <Box
-                  borderStyle="round"
-                  borderColor={archiveFocus === 'cancel' ? 'white' : 'gray'}
-                  height={3}
-                  width={20}
-                  alignItems="center"
-                  justifyContent="center"
-                  flexDirection="column"
-                >
-                  <Text>
-                    {archiveFocus === 'cancel' ? 
-                      chalk.bgGray.white.bold(' Cancel ') : 
-                      chalk.gray.bold('Cancel')
-                    }
-                  </Text>
-                </Box>
-              </Box>
-              <Box marginTop={1} flexDirection="row" justifyContent="center">
-                <Text color="gray">Press Enter to {archiveFocus === 'confirm' ? (archiveTarget.isArchived ? 'Unarchive' : 'Archive') : 'Cancel'} • Y to confirm • C to cancel</Text>
-              </Box>
-              <Box marginTop={1}>
-                <TextInput
-                  value=""
-                  onChange={() => { /* noop */ }}
-                  onSubmit={() => {
-                    if (archiveFocus === 'confirm') {
-                      (async () => {
-                        try {
-                          setArchiving(true);
-                          const isArchived = archiveTarget.isArchived;
-                          const id = (archiveTarget as any).id;
-                          if (isArchived) await unarchiveRepositoryById(client, id);
-                          else await archiveRepositoryById(client, id);
-                          setItems(prev => prev.map(r => (r.id === (archiveTarget as any).id ? { ...r, isArchived: !isArchived } : r)));
-                          closeArchiveModal();
-                        } catch (e) {
-                          setArchiving(false);
-                          setArchiveError('Failed to update archive state. Check permissions.');
-                        }
-                      })();
-                    } else {
-                      closeArchiveModal();
-                    }
-                  }}
-                />
-              </Box>
-              {archiveError && (
-                <Box marginTop={1}>
-                  <Text color="magenta">{archiveError}</Text>
-                </Box>
-              )}
-              {archiving && (
-                <Box marginTop={1}>
-                  <Text color="yellow">{archiveTarget.isArchived ? 'Unarchiving...' : 'Archiving...'}</Text>
-                </Box>
-              )}
-            </Box>
-          </Box>
+          <ArchiveModal
+            repo={archiveTarget}
+            client={client}
+            width={terminalWidth}
+            height={contentHeight}
+            onCancel={closeArchiveModal}
+            onUpdated={(id, isArchived) => {
+              setItems(prev => prev.map(r => (r.id === id ? { ...r, isArchived } : r)));
+              closeArchiveModal();
+            }}
+          />
         ) : syncMode && syncTarget ? (
           <Box height={contentHeight} alignItems="center" justifyContent="center">
             <Box flexDirection="column" borderStyle="round" borderColor="blue" paddingX={3} paddingY={2} width={Math.min(terminalWidth - 8, 80)}>


### PR DESCRIPTION
## Summary
- extract delete and archive modals from RepoList into standalone components
- wire RepoList to use new DeleteModal and ArchiveModal

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b4d8cc0d908324a2302b11ce0c5ba1