### PR TITLE
refactor: split repository modals into components

### DIFF
--- a/src/ui/ArchiveModal.tsx
+++ b/src/ui/ArchiveModal.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Text, useInput, useStdout } from 'ink';
+import chalk from 'chalk';
+import { archiveRepositoryById, unarchiveRepositoryById, makeClient } from '../github';
+import type { RepoNode } from '../types';
+
+type GraphQLClient = ReturnType<typeof makeClient>;
+
+interface ArchiveModalProps {
+  client: GraphQLClient;
+  repo: RepoNode;
+  onCancel: () => void;
+  onToggled: (id: string, isArchived: boolean) => void;
+}
+
+export default function ArchiveModal({ client, repo, onCancel, onToggled }: ArchiveModalProps) {
+  const { stdout } = useStdout();
+  const [focus, setFocus] = useState<'confirm' | 'cancel'>('confirm');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setFocus('confirm');
+    setError(null);
+    setLoading(false);
+  }, [repo]);
+
+  const confirm = async () => {
+    try {
+      setLoading(true);
+      const id = (repo as any).id;
+      if (repo.isArchived) await unarchiveRepositoryById(client, id);
+      else await archiveRepositoryById(client, id);
+      onToggled(id, !repo.isArchived);
+    } catch {
+      setLoading(false);
+      setError('Failed to update archive state. Check permissions.');
+    }
+  };
+
+  useInput((input, key) => {
+    if (key.escape || (input && input.toUpperCase() === 'C')) { onCancel(); return; }
+    if (key.leftArrow) { setFocus('confirm'); return; }
+    if (key.rightArrow) { setFocus('cancel'); return; }
+    if (key.return || (input && input.toUpperCase() === 'Y')) {
+      if (focus === 'cancel') { onCancel(); return; }
+      confirm();
+    }
+  });
+
+  const width = Math.min((stdout?.columns ?? 80) - 8, 80);
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor={repo.isArchived ? 'green' : 'yellow'} paddingX={3} paddingY={2} width={width}>
+      <Text bold>{repo.isArchived ? 'Unarchive Confirmation' : 'Archive Confirmation'}</Text>
+      <Text color={repo.isArchived ? 'green' : 'yellow'}>
+        {repo.isArchived ? '↺  Unarchive repository?' : '⚠️  Archive repository?'}
+      </Text>
+      <Box height={2}>
+        <Text> </Text>
+      </Box>
+      <Text>{repo.nameWithOwner}</Text>
+      <Box marginTop={1}>
+        <Text>{repo.isArchived ? 'This will make the repository active again.' : 'This will make the repository read-only.'}</Text>
+      </Box>
+      <Box marginTop={1} flexDirection="row" justifyContent="center" gap={6}>
+        <Box
+          borderStyle="round"
+          borderColor={repo.isArchived ? 'green' : 'yellow'}
+          height={3}
+          width={20}
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Text>
+            {focus === 'confirm'
+              ? chalk.bgHex(repo.isArchived ? '#00FF00' : '#FFFF00').black.bold(` ${repo.isArchived ? 'Unarchive' : 'Archive'} `)
+              : chalk.bold[repo.isArchived ? 'green' : 'yellow'](repo.isArchived ? 'Unarchive' : 'Archive')}
+          </Text>
+        </Box>
+        <Box
+          borderStyle="round"
+          borderColor={focus === 'cancel' ? 'white' : 'gray'}
+          height={3}
+          width={20}
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Text>{focus === 'cancel' ? chalk.bgGray.white.bold(' Cancel ') : chalk.gray.bold('Cancel')}</Text>
+        </Box>
+      </Box>
+      <Box marginTop={1} flexDirection="row" justifyContent="center">
+        <Text color="gray">Press Enter to {focus === 'confirm' ? (repo.isArchived ? 'Unarchive' : 'Archive') : 'Cancel'} • Y to confirm • C to cancel</Text>
+      </Box>
+      {error && (
+        <Box marginTop={1}>
+          <Text color="magenta">{error}</Text>
+        </Box>
+      )}
+      {loading && (
+        <Box marginTop={1}>
+          <Text color="yellow">Processing...</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/ui/DeleteModal.tsx
+++ b/src/ui/DeleteModal.tsx
@@ -1,0 +1,175 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Text, useInput, useStdout } from 'ink';
+import TextInput from 'ink-text-input';
+import chalk from 'chalk';
+import { deleteRepositoryRest } from '../github';
+import type { RepoNode } from '../types';
+
+interface DeleteModalProps {
+  token: string;
+  repo: RepoNode;
+  onCancel: () => void;
+  onDeleted: (id: string) => void;
+}
+
+export default function DeleteModal({ token, repo, onCancel, onDeleted }: DeleteModalProps) {
+  const { stdout } = useStdout();
+  const [code, setCode] = useState('');
+  const [typed, setTyped] = useState('');
+  const [confirmStage, setConfirmStage] = useState(false);
+  const [focus, setFocus] = useState<'delete' | 'cancel'>('delete');
+  const [error, setError] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  // Generate random code when repo changes
+  useEffect(() => {
+    const letters = 'ABDEFGHIJKLMNOPQRSTUVWXYZ';
+    const newCode = Array.from({ length: 4 }, () => letters[Math.floor(Math.random() * letters.length)]).join('');
+    setCode(newCode);
+    setTyped('');
+    setConfirmStage(false);
+    setFocus('delete');
+    setError(null);
+    setDeleting(false);
+  }, [repo]);
+
+  const confirmDelete = async () => {
+    try {
+      setDeleting(true);
+      const [owner, name] = repo.nameWithOwner.split('/');
+      await deleteRepositoryRest(token, owner, name);
+      onDeleted((repo as any).id);
+    } catch {
+      setDeleting(false);
+      setError('Failed to delete repository. Ensure delete_repo scope and admin permissions.');
+    }
+  };
+
+  useInput((input, key) => {
+    if (key.escape || (input && input.toUpperCase() === 'C')) {
+      onCancel();
+      return;
+    }
+    if (confirmStage) {
+      if (key.leftArrow) { setFocus('delete'); return; }
+      if (key.rightArrow) { setFocus('cancel'); return; }
+      if (key.return) {
+        if (focus === 'delete') confirmDelete();
+        else onCancel();
+        return;
+      }
+      if (input && input.toUpperCase() === 'Y') {
+        confirmDelete();
+        return;
+      }
+    }
+  });
+
+  const width = Math.min((stdout?.columns ?? 80) - 8, 80);
+  const langName = repo.primaryLanguage?.name || '';
+  const langColor = repo.primaryLanguage?.color || '#666666';
+  let line1 = chalk.white(repo.nameWithOwner);
+  if (repo.isPrivate) line1 += chalk.yellow(' Private');
+  if (repo.isArchived) line1 += chalk.gray.dim(' Archived');
+  if (repo.isFork && repo.parent) line1 += chalk.blue(` Fork of ${repo.parent.nameWithOwner}`);
+  let line2 = '';
+  if (langName) line2 += chalk.hex(langColor)('● ') + chalk.gray(`${langName}  `);
+  line2 += chalk.gray(`★ ${repo.stargazerCount}  ⑂ ${repo.forkCount}  Updated ${formatDate(repo.updatedAt)}`);
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="red" paddingX={3} paddingY={2} width={width}>
+      <Text bold>Delete Confirmation</Text>
+      <Text color="red">⚠️  Delete repository?</Text>
+      <Box height={2}>
+        <Text> </Text>
+      </Box>
+      <Text>{line1}</Text>
+      <Text>{line2}</Text>
+      <Box marginTop={1}>
+        <Text>
+          Type <Text color="yellow" bold>{code}</Text> to confirm.
+        </Text>
+      </Box>
+      {!confirmStage ? (
+        <Box marginTop={1}>
+          <Text>Confirm code: </Text>
+          <TextInput
+            value={typed}
+            onChange={(v) => {
+              const up = (v || '').toUpperCase().slice(0, 4);
+              setTyped(up);
+              if (up.length < 4) {
+                setError(null);
+              }
+              if (up.length === 4) {
+                if (up === code) {
+                  setError(null);
+                  setConfirmStage(true);
+                  setFocus('delete');
+                } else {
+                  setError('Code does not match');
+                }
+              }
+            }}
+            onSubmit={() => { /* no-op */ }}
+            placeholder={code}
+          />
+        </Box>
+      ) : (
+        <>
+          <Box marginTop={1} flexDirection="column">
+            <Text color="red">This action will permanently delete the repository. This cannot be undone.</Text>
+            <Box marginTop={1} flexDirection="row" justifyContent="center" gap={6}>
+              <Box
+                borderStyle="round"
+                borderColor="red"
+                height={3}
+                width={20}
+                alignItems="center"
+                justifyContent="center"
+              >
+                <Text>{focus === 'delete' ? chalk.bgRed.white.bold(' Delete ') : chalk.red.bold('Delete')}</Text>
+              </Box>
+              <Box
+                borderStyle="round"
+                borderColor={focus === 'cancel' ? 'white' : 'gray'}
+                height={3}
+                width={20}
+                alignItems="center"
+                justifyContent="center"
+              >
+                <Text>{focus === 'cancel' ? chalk.bgGray.white.bold(' Cancel ') : chalk.gray.bold('Cancel')}</Text>
+              </Box>
+            </Box>
+            <Box marginTop={1} flexDirection="row" justifyContent="center">
+              <Text color="gray">Press Enter to {focus === 'delete' ? 'Delete' : 'Cancel'} • Y to confirm • C to cancel</Text>
+            </Box>
+          </Box>
+        </>
+      )}
+      {error && (
+        <Box marginTop={1}>
+          <Text color="magenta">{error}</Text>
+        </Box>
+      )}
+      {deleting && (
+        <Box marginTop={1}>
+          <Text color="yellow">Deleting...</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  if (diffDays === 0) return 'today';
+  if (diffDays === 1) return 'yesterday';
+  if (diffDays < 7) return `${diffDays} days ago`;
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)} weeks ago`;
+  if (diffDays < 365) return `${Math.floor(diffDays / 30)} months ago`;
+  return `${Math.floor(diffDays / 365)} years ago`;
+}


### PR DESCRIPTION
## Summary
- extract DeleteModal and ArchiveModal components
- simplify RepoList input handling and modal rendering

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68b4d8cc0d908324a2302b11ce0c5ba1