### PR TITLE
fix(auth,keyboard,ux): retry + cancel flow on rate-limit; shared logout; cache info key = K

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Launch the app, then use the keys below:
 
 ### Repository Actions
 - **Repository info**: `I` to view detailed metadata (size, language, timestamps)
-- **Cache info**: `Ctrl+I` to inspect Apollo cache status
+- **Cache info**: `C` to inspect Apollo cache status
 - **Archive/Unarchive**: `Ctrl+A` with confirmation prompt
 - **Delete repository**: `Del` or `Backspace` (with two-step confirmation modal)
   - Type confirmation code → confirm (Y/Enter)
@@ -287,7 +287,7 @@ Debug mode provides:
 
 2. **API Credits**: Monitor the API counter in the header - it should remain stable when navigating previously loaded data
 
-3. **Cache Inspection**: Press `Ctrl+I` (available anytime) to see:
+3. **Cache Inspection**: Press `C` (available anytime) to see:
    - Cache file location and size
    - Recent cache entries with timestamps
    - Cache age for each query type

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Launch the app, then use the keys below:
 
 ### Repository Actions
 - **Repository info**: `I` to view detailed metadata (size, language, timestamps)
-- **Cache info**: `C` to inspect Apollo cache status
+- **Cache info**: `K` to inspect Apollo cache status
 - **Archive/Unarchive**: `Ctrl+A` with confirmation prompt
 - **Delete repository**: `Del` or `Backspace` (with two-step confirmation modal)
   - Type confirmation code → confirm (Y/Enter)
@@ -287,7 +287,7 @@ Debug mode provides:
 
 2. **API Credits**: Monitor the API counter in the header - it should remain stable when navigating previously loaded data
 
-3. **Cache Inspection**: Press `C` (available anytime) to see:
+3. **Cache Inspection**: Press `K` (available anytime) to see:
    - Cache file location and size
    - Recent cache entries with timestamps
    - Cache age for each query type

--- a/TODOs.md
+++ b/TODOs.md
@@ -375,7 +375,7 @@ Legend:
   - Shows detailed repository metadata
   - Displays size, language, timestamps, visibility
   - Modal overlay with ESC to close
-- [x] Cache inspection (`C`)
+- [x] Cache inspection (`K`)
   - Inspects Apollo cache status
   - Shows cache statistics and health
 - [x] Cache purging on refresh (`R` key)

--- a/TODOs.md
+++ b/TODOs.md
@@ -375,7 +375,7 @@ Legend:
   - Shows detailed repository metadata
   - Displays size, language, timestamps, visibility
   - Modal overlay with ESC to close
-- [x] Cache inspection (`Ctrl+I`)
+- [x] Cache inspection (`C`)
   - Inspects Apollo cache status
   - Shows cache statistics and health
 - [x] Cache purging on refresh (`R` key)

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -137,8 +137,9 @@ export default function App() {
           setWasRateLimited(true);
           setMode('rate_limited');
         } else {
-          // Invalid token or other error: clear token and return to prompt
+          // Invalid token or other error: clear token input and return to prompt
           setError(errorMessage);
+          setInput('');
           setMode('prompt');
           setToken(null);
         }
@@ -187,8 +188,10 @@ export default function App() {
       if (wasRateLimited) {
         setMode('rate_limited');
       } else {
+        // Return to prompt; ensure input box is cleared
         setMode('prompt');
         setToken(null);
+        setInput('');
       }
     }
   });

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -149,6 +149,7 @@ export default function App() {
   // Handle logout from child components
   const handleLogout = () => {
     try { clearStoredToken(); } catch {}
+    setRateLimitReset(null);
     setToken(null);
     setViewer(null);
     setInput(''); // Clear the token input field
@@ -162,17 +163,15 @@ export default function App() {
     }
     
     if (mode === 'rate_limited') {
-      if (key.escape || input === 'q') {
+      const ch = (input || '').toLowerCase();
+      if (key.escape || ch === 'q') {
         exit();
-      } else if (input === 'r') {
+      } else if (ch === 'r') {
         // Retry with current token
         setMode('validating');
-      } else if (input === 'l') {
+      } else if (ch === 'l') {
         // Logout - go back to authentication
-        setToken(null);
-        setInput('');
-        setRateLimitReset(null);
-        setMode('prompt');
+        handleLogout();
       }
     }
     

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -128,13 +128,15 @@ export default function App() {
         }
         
         if (isRateLimit) {
+          // Keep token in memory so Retry can revalidate immediately
           setRateLimitReset(resetTime);
           setMode('rate_limited');
         } else {
+          // Invalid token or other error: clear token and return to prompt
           setError(errorMessage);
           setMode('prompt');
+          setToken(null);
         }
-        setToken(null);
       }
     })();
   }, [mode, token]);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -262,9 +262,9 @@ export default function App() {
             <Box marginTop={2} flexDirection="column" gap={1}>
               <Text bold>What would you like to do?</Text>
               <Box flexDirection="column" paddingLeft={2}>
-                <Text><Text color="cyan" bold>r</Text> - Retry now {rateLimitReset && formatResetTime(rateLimitReset) !== 'Now (should be reset)' ? '(likely to fail until reset)' : '(should work now)'}</Text>
-                <Text><Text color="cyan" bold>l</Text> - Logout and use a different token</Text>
-                <Text><Text color="gray" bold>q/Esc</Text> - Quit application</Text>
+                <Text><Text color="cyan" bold>R</Text> - Retry now {rateLimitReset && formatResetTime(rateLimitReset) !== 'Now (should be reset)' ? '(likely to fail until reset)' : '(should work now)'}</Text>
+                <Text><Text color="cyan" bold>L</Text> - Logout and use a different token</Text>
+                <Text><Text color="gray" bold>Q/Esc</Text> - Quit application</Text>
               </Box>
             </Box>
             

--- a/src/ui/RepoList.main.tsx
+++ b/src/ui/RepoList.main.tsx
@@ -856,8 +856,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return;
     }
     
-    // Cache inspection (Ctrl+I)
-    if (key.ctrl && (input === 'i' || input === 'I')) {
+    // Cache inspection (C)
+    if (input && input.toUpperCase() === 'C') {
       (async () => {
         try {
           await inspectCacheStatus();
@@ -1685,7 +1685,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         </Box>
         <Box width={terminalWidth} justifyContent="center">
           <Text color="gray" dimColor={modalOpen ? true : undefined}>
-            Del/Ctrl+Backspace Delete • Ctrl+A Un/Archive • Ctrl+U Sync Fork • I Info • Ctrl+I Cache • Ctrl+L Logout • R Refresh • Q Quit
+            Del/Ctrl+Backspace Delete • Ctrl+A Un/Archive • Ctrl+U Sync Fork • I Info • C Cache • Ctrl+L Logout • R Refresh • Q Quit
           </Text>
         </Box>
       </Box>

--- a/src/ui/RepoList.main.tsx
+++ b/src/ui/RepoList.main.tsx
@@ -856,8 +856,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return;
     }
     
-    // Cache inspection (C)
-    if (input && input.toUpperCase() === 'C') {
+    // Cache inspection (K)
+    if (input && input.toUpperCase() === 'K') {
       (async () => {
         try {
           await inspectCacheStatus();
@@ -1685,7 +1685,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         </Box>
         <Box width={terminalWidth} justifyContent="center">
           <Text color="gray" dimColor={modalOpen ? true : undefined}>
-            Del/Ctrl+Backspace Delete • Ctrl+A Un/Archive • Ctrl+U Sync Fork • I Info • C Cache • Ctrl+L Logout • R Refresh • Q Quit
+            Del/Ctrl+Backspace Delete • Ctrl+A Un/Archive • Ctrl+U Sync Fork • I Info • K Cache • Ctrl+L Logout • R Refresh • Q Quit
           </Text>
         </Box>
       </Box>

--- a/src/ui/RepoList.tsx
+++ b/src/ui/RepoList.tsx
@@ -888,8 +888,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return;
     }
     
-    // Cache inspection (Ctrl+I)
-    if (key.ctrl && (input === 'i' || input === 'I')) {
+    // Cache inspection (Ctrl+I). Note: many terminals send Tab for Ctrl+I.
+    if ((key.ctrl && (input === 'i' || input === 'I')) || input === "\t") {
       (async () => {
         try {
           await inspectCacheStatus();
@@ -1743,7 +1743,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         {/* Line 3: Action controls */}
         <Box width={terminalWidth} justifyContent="center">
           <Text color="gray" dimColor={modalOpen ? true : undefined}>
-            I Info • Ctrl+I Cache Info • Ctrl+A Un/Archive • Del/Backspace Delete • Ctrl+S Sync Fork
+            I Info • Ctrl+I/Tab Cache Info • Ctrl+A Un/Archive • Del/Backspace Delete • Ctrl+S Sync Fork
           </Text>
         </Box>
       </Box>

--- a/src/ui/RepoList.tsx
+++ b/src/ui/RepoList.tsx
@@ -888,8 +888,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return;
     }
     
-    // Cache inspection (C)
-    if (input && input.toUpperCase() === 'C') {
+    // Cache inspection (K)
+    if (input && input.toUpperCase() === 'K') {
       (async () => {
         try {
           await inspectCacheStatus();
@@ -1743,7 +1743,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         {/* Line 3: Action controls */}
         <Box width={terminalWidth} justifyContent="center">
           <Text color="gray" dimColor={modalOpen ? true : undefined}>
-            I Info • C Cache Info • Ctrl+A Un/Archive • Del/Backspace Delete • Ctrl+S Sync Fork
+            I Info • K Cache Info • Ctrl+A Un/Archive • Del/Backspace Delete • Ctrl+S Sync Fork
           </Text>
         </Box>
       </Box>

--- a/src/ui/RepoList.tsx
+++ b/src/ui/RepoList.tsx
@@ -888,8 +888,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return;
     }
     
-    // Cache inspection (Ctrl+I). Note: many terminals send Tab for Ctrl+I.
-    if ((key.ctrl && (input === 'i' || input === 'I')) || input === "\t") {
+    // Cache inspection (C)
+    if (input && input.toUpperCase() === 'C') {
       (async () => {
         try {
           await inspectCacheStatus();
@@ -1743,7 +1743,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         {/* Line 3: Action controls */}
         <Box width={terminalWidth} justifyContent="center">
           <Text color="gray" dimColor={modalOpen ? true : undefined}>
-            I Info • Ctrl+I/Tab Cache Info • Ctrl+A Un/Archive • Del/Backspace Delete • Ctrl+S Sync Fork
+            I Info • C Cache Info • Ctrl+A Un/Archive • Del/Backspace Delete • Ctrl+S Sync Fork
           </Text>
         </Box>
       </Box>


### PR DESCRIPTION
Summary
- Fixes retry (“R”) on rate-limit: keep token in memory so validation actually runs instead of hanging on “Validating token…”.
- Esc during validation now returns to the previous Rate Limit screen (when coming from there) instead of the token prompt.
- Rate-limit modal’s Logout uses the shared logout flow, ensuring stored token is cleared consistently.
- Token prompt input is cleared whenever we return to it (including non-rate-limit validation errors and cancel paths).
- Cache Info key changed from Ctrl+I/Tab to “K” (reserves “C” for cancel in modals). Help/footer and docs updated accordingly.
- Display-only labels in rate-limit modal changed to uppercase R / L / Q.

Details
- src/ui/App.tsx
  - Add `wasRateLimited` flag; remember origin state for Esc handling during validation.
  - Keep token on rate-limit so Retry revalidates; clear token only on non-rate-limit errors.
  - Rate-limit modal now calls `handleLogout()` (shared) to clear stored token.
  - Clear `input` when returning to prompt to avoid showing token text.
- src/ui/RepoList.tsx and src/ui/RepoList.main.tsx
  - Cache Info handler now maps to ‘K’; footer text updated.
- Docs
  - README.md and TODOs.md updated to reflect ‘K’ for Cache Info.

Why
- Ctrl+I maps to Tab in many terminals and conflicted with modal controls. ‘K’ avoids conflicts and is explicit.
- Users canceling validation after Retry should return to the previous Rate Limit screen, not the token prompt.
- Consistent logout ensures local token storage is cleared and UX is predictable.

Testing
- Build (`pnpm build`) and run (`node dist/index.js`):
  - On Rate Limit screen: R retries; Esc during validating returns to Rate Limit; L logs out (returns to prompt with empty input).
  - In main screen: K opens Cache Info.

Docs
- Updated help/footer strings and README.
