### PR TITLE
feat: add Ctrl+L logout option to error state

### DIFF
--- a/src/ui/RepoList.main.tsx
+++ b/src/ui/RepoList.main.tsx
@@ -557,6 +557,39 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   // Organization context handler is defined above (function handleOrgContextChange)
   
   useInput((input, key) => {
+    // Handle input when in error state
+    if (error) {
+      // Quit on 'Q'
+      if (input && input.toUpperCase() === 'Q') {
+        try {
+          const seq = '\x1b[2J\x1b[3J\x1b[H';
+          if (stdout && typeof (stdout as any).write === 'function') (stdout as any).write(seq);
+          else if (typeof process.stdout.write === 'function') process.stdout.write(seq);
+        } catch {}
+        exit();
+        return;
+      }
+      // Retry on 'R'
+      if (input && input.toUpperCase() === 'R') {
+        setCursor(0);
+        setRefreshing(true);
+        setSortingLoading(true);
+        ;(async () => {
+          try { await purgeApolloCacheFiles(); } catch {}
+          fetchPage(null, true, true, undefined, 'network-only');
+        })();
+        return;
+      }
+      // Logout on Ctrl+L
+      if (key.ctrl && (input === 'l' || input === 'L')) {
+        if (onLogout) {
+          onLogout();
+        }
+        return;
+      }
+      return; // Ignore all other inputs in error state
+    }
+    
     // When organization switcher is open, trap inputs for modal
     if (orgSwitcherOpen) {
       return; // OrgSwitcher component handles its own keyboard input
@@ -1087,7 +1120,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     return (
       <Box flexDirection="column" alignItems="center" justifyContent="center" flexGrow={1}>
         <Text color="red">{error}</Text>
-        <Text color="gray" dimColor>Press R to retry or Q to quit</Text>
+        <Text color="gray" dimColor>Press R to retry • Ctrl+L to logout • Q to quit</Text>
       </Box>
     );
   }


### PR DESCRIPTION
## Summary
- Added Ctrl+L keyboard shortcut to logout when the "Failed to load repositories" error occurs
- Updated error message display to include the new logout option
- Implemented keyboard handling for error state in both RepoList components

## Changes
- Modified error message from "Press R to retry or Q to quit" to "Press R to retry • Ctrl+L to logout • Q to quit"
- Added keyboard input handling for error state at the beginning of the `useInput` hook
- Handles three keys in error state:
  - **Q**: Quit the application
  - **R**: Retry fetching repositories  
  - **Ctrl+L**: Logout (calls the onLogout callback)

## Motivation
When users encounter a "Failed to load repositories. Check network or token." error, they previously had to quit the app (Q) and restart to try a different authentication method. Now they can press Ctrl+L to logout and re-authenticate without restarting the application.

## Test Plan
- [x] Build the project successfully
- [x] Error message displays the new Ctrl+L option
- [x] Ctrl+L triggers logout when in error state
- [x] R still works for retry
- [x] Q still works for quit

🤖 Generated with [Claude Code](https://claude.ai/code)