### PR TITLE
fix: add missing hasInternalRepos state variable

### DIFF
--- a/src/ui/RepoList.tsx
+++ b/src/ui/RepoList.tsx
@@ -119,6 +119,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   // Visibility modal state
   const [visibilityMode, setVisibilityMode] = useState(false);
   const [isEnterpriseOrg, setIsEnterpriseOrg] = useState(false);
+  const [hasInternalRepos, setHasInternalRepos] = useState(false);
   
   // Change visibility modal state
   const [changeVisibilityMode, setChangeVisibilityMode] = useState(false);


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes the runtime error `setHasInternalRepos is not defined` that was preventing repositories from loading.

### Problem
The application was throwing an error when trying to fetch repositories because the `hasInternalRepos` state variable was referenced but never declared.

### Solution
Added the missing state declaration:
```typescript
const [hasInternalRepos, setHasInternalRepos] = useState(false);
```

### Testing
- ✅ Application now loads repositories without errors
- ✅ Organization switching works correctly
- ✅ Visibility filtering functions properly

This is a critical fix that should be merged immediately to restore functionality.