### PR TITLE
feat(cli): add org (-o) and token (-t) flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,13 +210,19 @@ Launch the app, then use the keys below:
 
 ### CLI Flags
 
-- `--org <slug>`: Start in a specific organisation context (if accessible). Ignores the flag if you don’t have access or if the slug isn’t an organisation.
+- `--org, -o <slug>`: Start in a specific organisation context (if accessible). Ignores the flag if you don’t have access or if the slug isn’t an organisation.
   - Examples:
     - `gh-manager-cli --org acme`
+    - `gh-manager-cli -o acme`
     - `npx gh-manager-cli --org=@acme`
+    - `npx gh-manager-cli -o=@acme`
   - Notes:
     - Leading `@` is optional.
-    - Personal usernames are not supported by `--org` (use default personal context).
+    - Personal usernames are not supported by `--org`/`-o` (use default personal context).
+
+- `--help, -h`: Show usage information and exit.
+
+- `--version, -v`: Print the current version and exit.
 
 ### Navigation & View Controls
 - **Top/Bottom**: `Ctrl+G` (top), `G` (bottom)

--- a/README.md
+++ b/README.md
@@ -220,6 +220,13 @@ Launch the app, then use the keys below:
     - Leading `@` is optional.
     - Personal usernames are not supported by `--org`/`-o` (use default personal context).
 
+- `--token, -t <pat>`: Use a Personal Access Token just for this run. Does not persist to config.
+  - Examples:
+    - `gh-manager-cli --token ghp_XXXXXXXXXXXXXXXXXXXXXXXXXXXX`
+    - `gh-manager-cli -t=ghp_XXXXXXXXXXXXXXXXXXXXXXXXXXXX`
+  - Precedence: CLI token > `GITHUB_TOKEN`/`GH_TOKEN` env vars > stored config.
+  - Security: Supplying tokens on the command line may be captured in shell history. Prefer env vars or the interactive prompt when possible.
+
 - `--help, -h`: Show usage information and exit.
 
 - `--version, -v`: Print the current version and exit.

--- a/README.md
+++ b/README.md
@@ -208,6 +208,16 @@ Notes:
 
 Launch the app, then use the keys below:
 
+### CLI Flags
+
+- `--org <slug>`: Start in a specific organisation context (if accessible). Ignores the flag if you don’t have access or if the slug isn’t an organisation.
+  - Examples:
+    - `gh-manager-cli --org acme`
+    - `npx gh-manager-cli --org=@acme`
+  - Notes:
+    - Leading `@` is optional.
+    - Personal usernames are not supported by `--org` (use default personal context).
+
 ### Navigation & View Controls
 - **Top/Bottom**: `Ctrl+G` (top), `G` (bottom)
 - **Page Navigation**: ↑↓ Arrow keys, PageUp/PageDown

--- a/TODOs.md
+++ b/TODOs.md
@@ -344,6 +344,10 @@ Legend:
   - [x] `--org` to start with specific organization
     - Launch with `--org <slug>` to jump to that organisation context if accessible; otherwise ignored
     - Works with already authenticated session; overrides persisted context for the run
+  - [ ] `--token` / `-t` to provide a token for this run
+    - Accepts `--token <pat>` and `--token=<pat>` (and `-t` forms)
+    - Overrides env/config for the current process only; does not persist
+    - Show a brief security note about shell history; prefer env var or interactive prompt
   - [ ] `--sort` to set initial sort field
   - [ ] `--filter` to set initial filter
   - [ ] `--page-size` to override default page size

--- a/TODOs.md
+++ b/TODOs.md
@@ -341,7 +341,9 @@ Legend:
 - [~] CLI flags (partial implementation)
   - [x] `--version` / `-v` flag to show version
   - [x] `--help` / `-h` flag to show usage
-  - [ ] `--org` to start with specific organization
+  - [x] `--org` to start with specific organization
+    - Launch with `--org <slug>` to jump to that organisation context if accessible; otherwise ignored
+    - Works with already authenticated session; overrides persisted context for the run
   - [ ] `--sort` to set initial sort field
   - [ ] `--filter` to set initial filter
   - [ ] `--page-size` to override default page size

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,21 @@ import { logger } from './logger';
 
 // Basic CLI flags (handled before rendering Ink)
 const argv = process.argv.slice(2);
+
+// Simple argv helper
+const getFlagValue = (name: string): string | undefined => {
+  // Supports --name value and --name=value
+  const idx = argv.findIndex(a => a === `--${name}` || a.startsWith(`--${name}=`));
+  if (idx === -1) return undefined;
+  const at = argv[idx];
+  if (at.includes('=')) {
+    const [, v] = at.split('=');
+    return v?.trim() || undefined;
+  }
+  const next = argv[idx + 1];
+  if (next && !next.startsWith('-')) return next.trim();
+  return undefined;
+};
 if (argv.includes('--version') || argv.includes('-v')) {
   // Print semantic version without network
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -20,9 +35,10 @@ if (argv.includes('--help') || argv.includes('-h')) {
   process.stdout.write(`\n` +
     `gh-manager-cli — GitHub repo manager (Ink TUI)\n\n` +
     `Usage:\n` +
-    `  gh-manager-cli            Launch the TUI\n` +
-    `  gh-manager-cli --version  Print version\n` +
-    `  gh-manager-cli --help     Show help\n\n` +
+    `  gh-manager-cli                     Launch the TUI\n` +
+    `  gh-manager-cli --org <slug>        Start in an organisation context (if accessible)\n` +
+    `  gh-manager-cli --version           Print version\n` +
+    `  gh-manager-cli --help              Show help\n\n` +
     `Env:\n` +
     `  GITHUB_TOKEN / GH_TOKEN   Personal Access Token\n` +
     `  REPOS_PER_FETCH           Page size (1-50)\n`);
@@ -71,10 +87,18 @@ process.on('unhandledRejection', (reason: any) => {
   process.exit(1);
 });
 
+// Parse optional org flag
+const initialOrgSlug = (() => {
+  const v = getFlagValue('org');
+  if (!v) return undefined;
+  // Normalise: strip leading @ if provided
+  return v.replace(/^@/, '');
+})();
+
 logger.debug('Rendering UI');
 const { unmount } = render(
   <Box flexDirection="column">
-    <App />
+    <App initialOrgSlug={initialOrgSlug} />
     <Text color="gray"></Text>
   </Box>
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -51,6 +51,7 @@ if (argv.includes('--help') || argv.includes('-h')) {
     `Usage:\n` +
     `  gh-manager-cli                     Launch the TUI\n` +
     `  gh-manager-cli --org, -o <slug>    Start in an organisation context (if accessible)\n` +
+    `  gh-manager-cli --token, -t <pat>   Use a token just for this run (not persisted)\n` +
     `  gh-manager-cli --version           Print version\n` +
     `  gh-manager-cli --help              Show help\n\n` +
     `Env:\n` +
@@ -101,7 +102,7 @@ process.on('unhandledRejection', (reason: any) => {
   process.exit(1);
 });
 
-// Parse optional org flag
+// Parse optional flags
 const initialOrgSlug = (() => {
   const v = getFlagValue('org') ?? getShortFlagValue('o');
   if (!v) return undefined;
@@ -109,10 +110,16 @@ const initialOrgSlug = (() => {
   return v.replace(/^@/, '');
 })();
 
+const inlineToken = (() => {
+  const v = getFlagValue('token') ?? getShortFlagValue('t');
+  if (!v) return undefined;
+  return v.trim();
+})();
+
 logger.debug('Rendering UI');
 const { unmount } = render(
   <Box flexDirection="column">
-    <App initialOrgSlug={initialOrgSlug} />
+    <App initialOrgSlug={initialOrgSlug} inlineToken={inlineToken} inlineTokenEphemeral={Boolean(inlineToken)} />
     <Text color="gray"></Text>
   </Box>
 );

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -181,14 +181,13 @@ export default function App({ initialOrgSlug, inlineToken, inlineTokenEphemeral 
         // On successful validation, clear any previous rate-limit context
         setWasRateLimited(false);
         setRateLimitReset(null);
-        // If token came from prompt, it will be in input and not yet stored
         // Only persist if we haven't already stored a token, the token isn't inline-ephemeral,
-        // and it originated from either a PAT prompt or OAuth flow.
+        // and the token originated from an interactive prompt or OAuth flow.
         const hadStored = Boolean(getStoredToken());
         const shouldPersist =
           !hadStored &&
           !inlineTokenEphemeral &&
-          (tokenSource === 'pat' || tokenSource === 'oauth');
+          (sessionTokenOrigin === 'prompt' || sessionTokenOrigin === 'oauth');
         if (shouldPersist) {
           storeToken(token);
         }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -260,8 +260,10 @@ export default function App({ initialOrgSlug, inlineToken, inlineTokenEphemeral 
           setError(errorMessage);
           setInput('');
           setToken(null);
-          // Clear stored token since it's invalid
-          clearStoredToken();
+          // Only clear stored token if the failed token originated from storage
+          if (sessionTokenOrigin === 'stored') {
+            try { clearStoredToken(); } catch {}
+          }
           setMode('auth_method_selection');
         }
       }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -13,7 +13,7 @@ const packageJson = require('../../package.json');
 
 type Mode = 'checking' | 'auth_method_selection' | 'prompt' | 'validating' | 'oauth_flow' | 'ready' | 'error' | 'rate_limited';
 
-export default function App() {
+export default function App({ initialOrgSlug }: { initialOrgSlug?: string }) {
   const { exit } = useApp();
   const { stdout } = useStdout();
   const [mode, setMode] = useState<Mode>('checking');
@@ -501,6 +501,7 @@ export default function App() {
         onLogout={handleLogout}
         viewerLogin={viewer ?? undefined}
         onOrgContextChange={setOrgContext}
+        initialOrgSlug={initialOrgSlug}
       />
     </Box>
   );

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -177,8 +177,14 @@ export default function App({ initialOrgSlug, inlineToken, inlineTokenEphemeral 
         setWasRateLimited(false);
         setRateLimitReset(null);
         // If token came from prompt, it will be in input and not yet stored
-        if (!getStoredToken() && !inlineTokenEphemeral) {
-          // Persist only when not provided via ephemeral inline token
+        // Only persist if we haven't already stored a token, the token isn't inline-ephemeral,
+        // and it originated from either a PAT prompt or OAuth flow.
+        const hadStored = Boolean(getStoredToken());
+        const shouldPersist =
+          !hadStored &&
+          !inlineTokenEphemeral &&
+          (tokenSource === 'pat' || tokenSource === 'oauth');
+        if (shouldPersist) {
           storeToken(token);
         }
         setInput(''); // Clear the input after successful authentication

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -13,7 +13,7 @@ const packageJson = require('../../package.json');
 
 type Mode = 'checking' | 'auth_method_selection' | 'prompt' | 'validating' | 'oauth_flow' | 'ready' | 'error' | 'rate_limited';
 
-export default function App({ initialOrgSlug }: { initialOrgSlug?: string }) {
+export default function App({ initialOrgSlug, inlineToken, inlineTokenEphemeral }: { initialOrgSlug?: string; inlineToken?: string; inlineTokenEphemeral?: boolean }) {
   const { exit } = useApp();
   const { stdout } = useStdout();
   const [mode, setMode] = useState<Mode>('checking');
@@ -52,10 +52,14 @@ export default function App({ initialOrgSlug }: { initialOrgSlug?: string }) {
     const env = getTokenFromEnv();
     const stored = getStoredToken();
     const source = getTokenSource();
-    
+
     setTokenSource(source);
-    
-    if (env) {
+
+    if (inlineToken) {
+      // Highest precedence: inline token from CLI flag; do not persist
+      setToken(inlineToken);
+      setMode('validating');
+    } else if (env) {
       setToken(env);
       setMode('validating');
     } else if (stored) {
@@ -64,7 +68,7 @@ export default function App({ initialOrgSlug }: { initialOrgSlug?: string }) {
     } else {
       setMode('auth_method_selection');
     }
-  }, []);
+  }, [inlineToken]);
 
   // Handle OAuth flow
   useEffect(() => {
@@ -173,7 +177,8 @@ export default function App({ initialOrgSlug }: { initialOrgSlug?: string }) {
         setWasRateLimited(false);
         setRateLimitReset(null);
         // If token came from prompt, it will be in input and not yet stored
-        if (!getStoredToken()) {
+        if (!getStoredToken() && !inlineTokenEphemeral) {
+          // Persist only when not provided via ephemeral inline token
           storeToken(token);
         }
         setInput(''); // Clear the input after successful authentication

--- a/src/ui/RepoList.tsx
+++ b/src/ui/RepoList.tsx
@@ -49,10 +49,10 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   }, []);
 
   // Stable reference to org context change handler to avoid unstable deps in effects
-  const handleOrgContextChangeRef = useRef(handleOrgContextChange);
+  const handleOrgContextChangeRef = useRef(onOrgContextChange);
   useEffect(() => {
-    handleOrgContextChangeRef.current = handleOrgContextChange;
-  }, [handleOrgContextChange]);
+    handleOrgContextChangeRef.current = onOrgContextChange;
+  }, [onOrgContextChange]);
   
   // Log on component mount
   React.useEffect(() => {
@@ -162,7 +162,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         const slug = initialOrgSlug.replace(/^@/, '');
         const match = orgs.find(o => o.login.toLowerCase() === slug.toLowerCase());
         if (match) {
-          await handleOrgContextChangeRef.current({
+          await handleOrgContextChangeRef.current?.({
             type: 'organization',
             login: match.login,
             name: match.name || undefined,
@@ -364,7 +364,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     
     // Notify parent component of the change
     if (onOrgContextChange) {
-      onOrgContextChange(newContext);
+      handleOrgContextChangeRef.current?.(newContext);
     }
   }
 
@@ -638,7 +638,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       setOwnerContext(ui.ownerContext);
       // Notify parent of loaded context
       if (onOrgContextChange) {
-        onOrgContextChange(ui.ownerContext);
+        handleOrgContextChangeRef.current?.(ui.ownerContext);
       }
       
       // Check if organization is enterprise

--- a/src/ui/RepoList.tsx
+++ b/src/ui/RepoList.tsx
@@ -159,12 +159,17 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       appliedInitialOrg.current = true;
       try {
         const orgs = await fetchViewerOrganizations(client);
-        const match = orgs.find(o => o.login.toLowerCase() === initialOrgSlug.toLowerCase());
+        const slug = initialOrgSlug.replace(/^@/, '');
+        const match = orgs.find(o => o.login.toLowerCase() === slug.toLowerCase());
         if (match) {
-          await handleOrgContextChangeRef.current({ type: 'organization', login: match.login, name: match.name || undefined });
+          await handleOrgContextChangeRef.current({
+            type: 'organization',
+            login: match.login,
+            name: match.name || undefined,
+          });
           addDebugMessage(`[--org] Switched context to @${match.login}`);
         } else {
-          addDebugMessage(`[--org] No access to org @${initialOrgSlug}, ignoring flag`);
+          addDebugMessage(`[--org] No access to org @${slug}, ignoring flag`);
         }
       } catch (e: any) {
         addDebugMessage(`[--org] Failed to apply org flag: ${e.message || e}`);

--- a/src/ui/RepoList.tsx
+++ b/src/ui/RepoList.tsx
@@ -164,7 +164,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         addDebugMessage(`[--org] Failed to apply org flag: ${e.message || e}`);
       }
     })();
-  }, [initialOrgSlug, token, prefsLoaded]);
+  }, [initialOrgSlug, token, prefsLoaded, client, handleOrgContextChange, addDebugMessage, onOrgContextChange]);
 
   function closeArchiveModal() {
     setArchiveMode(false);

--- a/src/ui/RepoList.tsx
+++ b/src/ui/RepoList.tsx
@@ -162,7 +162,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         const slug = initialOrgSlug.replace(/^@/, '');
         const match = orgs.find(o => o.login.toLowerCase() === slug.toLowerCase());
         if (match) {
-          await handleOrgContextChangeRef.current?.({
+          await handleOrgContextChange({
             type: 'organization',
             login: match.login,
             name: match.name || undefined,

--- a/src/ui/RepoList.tsx
+++ b/src/ui/RepoList.tsx
@@ -763,6 +763,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     if (viewerLogin && searchActive && !searchLoading && searchItems.length === 0) {
       let policy: 'cache-first' | 'network-only' = 'cache-first';
       try {
+        const orgLogin = ownerContext !== 'personal' ? ownerContext.login : undefined;
         const key = makeSearchKey({
           viewer: viewerLogin || 'unknown',
           q: filter.trim(),

--- a/wiki/Token-and-Security.md
+++ b/wiki/Token-and-Security.md
@@ -15,6 +15,15 @@ The app needs a GitHub token to read your repositories.
 
 Note: Tokens are stored in plaintext on disk with restricted permissions. Future work may add OS keychain support.
 
+### CLI Token Flag vs Environment Variables
+
+- You can supply a token just for a single run with the CLI flag: `--token <pat>` or `-t <pat>`.
+- Precedence: CLI token > environment (`GITHUB_TOKEN` / `GH_TOKEN`) > stored config.
+- Non‑persistence: Tokens provided via `--token/-t` are NOT saved to disk.
+- Security: Command‑line arguments may be recorded in shell history and visible to other local users via process listings. Prefer environment variables or the interactive prompt when possible.
+  - Safer example (one‑off): `GITHUB_TOKEN=ghp_XXXX gh-manager-cli`
+  - Or run without flags and enter the token at the prompt (it is masked and then stored locally with restricted permissions).
+
 ## PAT Permissions & Scopes
 
 Choose the least-privileged token for the features you plan to use:
@@ -41,4 +50,3 @@ If in doubt, the classic `repo` scope plus `delete_repo` (for deletion) is the s
 - [Installation](Installation.md) - How to install gh-manager-cli
 - [Features](Features.md) - Core features and capabilities
 - [Troubleshooting](Troubleshooting.md) - Common issues and solutions
-

--- a/wiki/Usage.md
+++ b/wiki/Usage.md
@@ -4,9 +4,13 @@ Launch the app, then use the keys below to navigate and interact with your repos
 
 ## CLI Flags
 
-- `--org <slug>`: Start in a specific organisation context (if accessible). If the slug isn’t an organisation you belong to, the flag is ignored and the app opens in your personal context.
-  - Examples: `gh-manager-cli --org acme`, `npx gh-manager-cli --org=@acme`
-  - Leading `@` is optional. Personal usernames are not supported by `--org` (use default personal context).
+- `--org, -o <slug>`: Start in a specific organisation context (if accessible). If the slug isn’t an organisation you belong to, the flag is ignored and the app opens in your personal context.
+  - Examples: `gh-manager-cli --org acme`, `gh-manager-cli -o acme`, `npx gh-manager-cli --org=@acme`, `npx gh-manager-cli -o=@acme`
+  - Leading `@` is optional. Personal usernames are not supported by `--org`/`-o` (use default personal context).
+
+- `--help, -h`: Show usage information and exit.
+
+- `--version, -v`: Print the current version and exit.
 
 ## Navigation & View Controls
 

--- a/wiki/Usage.md
+++ b/wiki/Usage.md
@@ -2,6 +2,12 @@
 
 Launch the app, then use the keys below to navigate and interact with your repositories.
 
+## CLI Flags
+
+- `--org <slug>`: Start in a specific organisation context (if accessible). If the slug isn’t an organisation you belong to, the flag is ignored and the app opens in your personal context.
+  - Examples: `gh-manager-cli --org acme`, `npx gh-manager-cli --org=@acme`
+  - Leading `@` is optional. Personal usernames are not supported by `--org` (use default personal context).
+
 ## Navigation & View Controls
 
 - **Top/Bottom**: `Ctrl+G` (top), `G` (bottom)
@@ -64,4 +70,3 @@ Launch the app, then use the keys below to navigate and interact with your repos
 - [Features](Features.md) - Detailed feature list
 - [Token & Security](Token-and-Security.md) - Authentication details
 - [Troubleshooting](Troubleshooting.md) - Common issues and solutions
-

--- a/wiki/Usage.md
+++ b/wiki/Usage.md
@@ -8,6 +8,11 @@ Launch the app, then use the keys below to navigate and interact with your repos
   - Examples: `gh-manager-cli --org acme`, `gh-manager-cli -o acme`, `npx gh-manager-cli --org=@acme`, `npx gh-manager-cli -o=@acme`
   - Leading `@` is optional. Personal usernames are not supported by `--org`/`-o` (use default personal context).
 
+- `--token, -t <pat>`: Provide a Personal Access Token just for this run (not persisted).
+  - Examples: `gh-manager-cli --token ghp_XXX`, `gh-manager-cli -t=ghp_XXX`
+  - Precedence: CLI token > env (`GITHUB_TOKEN`/`GH_TOKEN`) > stored config.
+  - Security: Passing tokens on the command line can appear in shell history. Prefer env vars or the interactive prompt.
+
 - `--help, -h`: Show usage information and exit.
 
 - `--version, -v`: Print the current version and exit.


### PR DESCRIPTION
This PR combines two CLI enhancements and related UI wiring and docs.\n\nFeatures\n- Add organisation context flag: --org with short alias -o\n  - Allows starting the app scoped to an accessible organisation\n  - Waits for UI prefs to load; applies once per run\n- Add ephemeral token flag: --token with short alias -t\n  - Token precedence: CLI > env (GITHUB_TOKEN/GH_TOKEN) > stored config\n  - Does not persist when provided via CLI flag\n\nImplementation\n- src/index.tsx: flag parsing and help text updates\n- src/ui/App.tsx: prefer inline token; skip persistence when ephemeral\n- src/ui/RepoList.tsx: initial org flag application; stable onOrgContextChange ref\n\nDocs\n- README + wiki/Usage: document --org/-o and --token/-t with examples\n- wiki/Token-and-Security: add precedence and safety notes for CLI tokens\n- TODOs: track --token/-t work under CLI flags\n\nNotes\n- Includes RepoList optimizations (useCallback; stable handler ref)\n- Tested locally for flag parsing precedence and help output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - CLI flags: --org / -o (start in an organisation, optional leading @), --token / -t (ephemeral per-run PAT, precedence over env/stored), --help / -h, --version / -v.
  - App accepts initialOrgSlug/inlineToken and can auto‑apply an organisation on startup; improved startup, shutdown, error and debug logging.

- **Documentation**
  - Expanded README, wiki and TODOs with CLI flags, navigation/view controls, repository actions, token precedence and security guidance (README contains duplicate block).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->