### PR TITLE
feat(cli): add --token/-t flag for ephemeral token override

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -13,7 +13,7 @@ const packageJson = require('../../package.json');
 
 type Mode = 'checking' | 'auth_method_selection' | 'prompt' | 'validating' | 'oauth_flow' | 'ready' | 'error' | 'rate_limited';
 
-export default function App() {
+export default function App({ inlineToken, inlineTokenEphemeral }: { inlineToken?: string; inlineTokenEphemeral?: boolean }) {
   const { exit } = useApp();
   const { stdout } = useStdout();
   const [mode, setMode] = useState<Mode>('checking');
@@ -52,10 +52,13 @@ export default function App() {
     const env = getTokenFromEnv();
     const stored = getStoredToken();
     const source = getTokenSource();
-    
+
     setTokenSource(source);
-    
-    if (env) {
+
+    if (inlineToken) {
+      setToken(inlineToken);
+      setMode('validating');
+    } else if (env) {
       setToken(env);
       setMode('validating');
     } else if (stored) {
@@ -64,7 +67,7 @@ export default function App() {
     } else {
       setMode('auth_method_selection');
     }
-  }, []);
+  }, [inlineToken]);
 
   // Handle OAuth flow
   useEffect(() => {
@@ -173,7 +176,7 @@ export default function App() {
         setWasRateLimited(false);
         setRateLimitReset(null);
         // If token came from prompt, it will be in input and not yet stored
-        if (!getStoredToken()) {
+        if (!getStoredToken() && !inlineTokenEphemeral) {
           storeToken(token);
         }
         setInput(''); // Clear the input after successful authentication

--- a/wiki/Token-and-Security.md
+++ b/wiki/Token-and-Security.md
@@ -15,6 +15,15 @@ The app needs a GitHub token to read your repositories.
 
 Note: Tokens are stored in plaintext on disk with restricted permissions. Future work may add OS keychain support.
 
+### CLI Token Flag vs Environment Variables
+
+- You can supply a token just for a single run with the CLI flag: `--token <pat>` or `-t <pat>`.
+- Precedence: CLI token > environment (`GITHUB_TOKEN` / `GH_TOKEN`) > stored config.
+- Non‑persistence: Tokens provided via `--token/-t` are NOT saved to disk.
+- Security: Command‑line arguments may be recorded in shell history and visible to other local users via process listings. Prefer environment variables or the interactive prompt when possible.
+  - Safer example (one‑off): `GITHUB_TOKEN=ghp_XXXX gh-manager-cli`
+  - Or run without flags and enter the token at the prompt (it is masked and then stored locally with restricted permissions).
+
 ## PAT Permissions & Scopes
 
 Choose the least-privileged token for the features you plan to use:
@@ -41,4 +50,3 @@ If in doubt, the classic `repo` scope plus `delete_repo` (for deletion) is the s
 - [Installation](Installation.md) - How to install gh-manager-cli
 - [Features](Features.md) - Core features and capabilities
 - [Troubleshooting](Troubleshooting.md) - Common issues and solutions
-

--- a/wiki/Usage.md
+++ b/wiki/Usage.md
@@ -2,6 +2,17 @@
 
 Launch the app, then use the keys below to navigate and interact with your repositories.
 
+## CLI Flags
+
+- `--token, -t <pat>`: Provide a Personal Access Token just for this run (not persisted).
+  - Examples: `gh-manager-cli --token ghp_XXX`, `gh-manager-cli -t=ghp_XXX`
+  - Precedence: CLI token > env (`GITHUB_TOKEN`/`GH_TOKEN`) > stored config.
+  - Security: Passing tokens on the command line can appear in shell history. Prefer env vars or the interactive prompt.
+
+- `--help, -h`: Show usage information and exit.
+
+- `--version, -v`: Print the current version and exit.
+
 ## Navigation & View Controls
 
 - **Top/Bottom**: `Ctrl+G` (top), `G` (bottom)
@@ -64,4 +75,3 @@ Launch the app, then use the keys below to navigate and interact with your repos
 - [Features](Features.md) - Detailed feature list
 - [Token & Security](Token-and-Security.md) - Authentication details
 - [Troubleshooting](Troubleshooting.md) - Common issues and solutions
-


### PR DESCRIPTION
Adds a short and long flag to provide a one-off token without persisting it.\n\nChanges:\n- CLI: parse `--token` and `-t` (both value and =value forms)\n- App: prefer inline token over env/config for current run only; skip persistence\n- Help/Docs: usage text and wiki updated; security note on CLI tokens vs env vars\n\nNotes:\n- Precedence: CLI token > env (GITHUB_TOKEN/GH_TOKEN) > stored config\n- Security: CLI args may appear in shell history; env or prompt is safer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added per-run token support via --token/-t flags; token is used for the current session and not saved.
  - Prioritises inline tokens over environment variables and stored tokens during startup.
  - Expanded CLI help/usage to document the new token flags.
- Documentation
  - Updated guides with token precedence (CLI > env vars > stored), examples for one-off usage, and security notes about shell history visibility.
  - Documented available CLI flags: --token/-t, --help/-h, and --version/-v.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->