### PR TITLE
feat: Add sort direction modal for improved UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ On first run, you'll be prompted to authenticate with GitHub (OAuth recommended)
 - **Authentication**: GitHub OAuth (recommended) or Personal Access Token with secure storage
 - **Repository Listing**: Browse all your personal repositories with metadata (stars, forks, language, etc.)
 - **Live Pagination**: Infinite scroll with automatic page prefetching
-- **Interactive Sorting**: Modal-based sort selection (updated, pushed, name, stars) with direction toggle
+- **Interactive Sorting**: Modal-based sort selection (updated, pushed, name, stars) with modal-based direction selection
 - **Smart Search**: Server-side search through repository names and descriptions (3+ characters)
 - **Visibility Filtering**: Modal-based visibility filter (All, Public, Private/Internal for enterprise) with smart filtering
 - **Fork Status Tracking**: Toggle display of commits behind upstream for forked repositories
@@ -264,7 +264,7 @@ Launch the app, then use the keys below:
   - Pushed: When code was last pushed
   - Name: Alphabetical by repository name
   - Stars: Number of stars
-- **Sort Direction**: `D` to toggle ascending/descending
+- **Sort Direction**: `D` to open sort direction modal (ascending/descending)
 - **Display Density**: `T` to toggle compact/cozy/comfy
 - **Fork Status**: `F` to toggle showing commits behind upstream
 - **Visibility Filter**: `V` opens modal (All, Public, Private/Internal for enterprise)

--- a/src/ui/components/modals/SortDirectionModal.tsx
+++ b/src/ui/components/modals/SortDirectionModal.tsx
@@ -1,0 +1,179 @@
+import React, { useState, useEffect } from 'react';
+import { Box, Text, useInput } from 'ink';
+import chalk from 'chalk';
+
+export type SortDirection = 'asc' | 'desc';
+
+interface SortDirectionModalProps {
+  currentDirection: SortDirection;
+  currentSortKey: string;
+  onSelect: (direction: SortDirection) => void;
+  onCancel: () => void;
+}
+
+export default function SortDirectionModal({ 
+  currentDirection, 
+  currentSortKey,
+  onSelect, 
+  onCancel 
+}: SortDirectionModalProps) {
+  const options: SortDirection[] = ['desc', 'asc'];
+  
+  const [focusedOption, setFocusedOption] = useState<SortDirection | 'cancel'>(currentDirection);
+  
+  // Set initial focus to current direction
+  useEffect(() => {
+    setFocusedOption(currentDirection);
+  }, [currentDirection]);
+  
+  useInput((input, key) => {
+    if (key.escape || (input && input.toUpperCase() === 'C')) {
+      onCancel();
+      return;
+    }
+    
+    if (key.leftArrow || key.upArrow) {
+      // Move selection up
+      if (focusedOption === 'cancel') {
+        // Move from cancel to last option
+        setFocusedOption(options[options.length - 1]);
+      } else if (focusedOption === 'asc') {
+        setFocusedOption('desc');
+      } else if (focusedOption === 'desc') {
+        // Stay at top
+      }
+    }
+    
+    if (key.rightArrow || key.downArrow) {
+      // Move selection down
+      if (focusedOption === 'desc') {
+        setFocusedOption('asc');
+      } else if (focusedOption === 'asc') {
+        setFocusedOption('cancel');
+      } else if (focusedOption === 'cancel') {
+        // Stay at bottom
+      }
+    }
+    
+    if (key.tab) {
+      // Tab through all options including cancel
+      if (focusedOption === 'desc') {
+        setFocusedOption('asc');
+      } else if (focusedOption === 'asc') {
+        setFocusedOption('cancel');
+      } else if (focusedOption === 'cancel') {
+        setFocusedOption('desc');
+      }
+    }
+    
+    if (key.return) {
+      if (focusedOption === 'cancel') {
+        onCancel();
+      } else {
+        onSelect(focusedOption as SortDirection);
+      }
+    }
+    
+    // Quick select shortcuts
+    if (input) {
+      const upperInput = input.toUpperCase();
+      if (upperInput === 'A') {
+        onSelect('asc');
+      } else if (upperInput === 'D') {
+        onSelect('desc');
+      }
+    }
+  });
+  
+  const getButtonLabel = (direction: SortDirection): string => {
+    switch (direction) {
+      case 'desc': return 'Descending ↓';
+      case 'asc': return 'Ascending ↑';
+    }
+  };
+  
+  const getButtonDescription = (direction: SortDirection): string => {
+    switch (direction) {
+      case 'desc': 
+        switch (currentSortKey) {
+          case 'updated': return 'Most recently updated first';
+          case 'pushed': return 'Most recently pushed first';
+          case 'name': return 'Z to A';
+          case 'stars': return 'Most stars first';
+          default: return 'Highest to lowest';
+        }
+      case 'asc':
+        switch (currentSortKey) {
+          case 'updated': return 'Oldest updated first';
+          case 'pushed': return 'Oldest pushed first';
+          case 'name': return 'A to Z';
+          case 'stars': return 'Fewest stars first';
+          default: return 'Lowest to highest';
+        }
+    }
+  };
+  
+  const getButtonColor = (direction: SortDirection): string => {
+    if (direction === currentDirection) {
+      return 'green'; // Current selection
+    }
+    return focusedOption === direction ? 'cyan' : 'gray';
+  };
+  
+  const formatSortKey = (): string => {
+    switch (currentSortKey) {
+      case 'updated': return 'Last Updated';
+      case 'pushed': return 'Last Pushed';
+      case 'name': return 'Name';
+      case 'stars': return 'Stars';
+      default: return currentSortKey;
+    }
+  };
+  
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={2} paddingY={1} width={45}>
+      <Text bold>Sort Direction</Text>
+      <Text color="gray" dimColor>Sorting by: {formatSortKey()}</Text>
+      
+      {/* Option buttons with descriptions */}
+      <Box flexDirection="column" marginTop={1}>
+        {options.map((option) => (
+          <Box key={option} paddingX={1} marginBottom={0}>
+            <Box flexDirection="column">
+              <Text>
+                {focusedOption === option ? 
+                  chalk.bgCyan.black(' → ') : '   '}
+                {focusedOption === option ? 
+                  chalk[getButtonColor(option)].bold(getButtonLabel(option)) : 
+                  chalk[getButtonColor(option)](getButtonLabel(option))
+                }
+                {option === currentDirection && chalk.green(' ✓')}
+              </Text>
+              <Text color="gray" dimColor>
+                {'      '}{getButtonDescription(option)}
+              </Text>
+            </Box>
+          </Box>
+        ))}
+        
+        {/* Cancel option */}
+        <Box paddingX={1} marginTop={1}>
+          <Text>
+            {focusedOption === 'cancel' ? 
+              chalk.bgWhite.black(' → ') : '   '}
+            {focusedOption === 'cancel' ? 
+              chalk.white.bold('Cancel') : 
+              chalk.gray('Cancel')
+            }
+          </Text>
+        </Box>
+      </Box>
+      
+      <Box marginTop={1}>
+        <Text color="gray" dimColor>
+          ↑↓/Enter • A/D • Esc
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/components/modals/SortDirectionModal.tsx
+++ b/src/ui/components/modals/SortDirectionModal.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import chalk from 'chalk';
+import { SortKey } from './SortModal';
 
 export type SortDirection = 'asc' | 'desc';
 
 interface SortDirectionModalProps {
   currentDirection: SortDirection;
-  currentSortKey: string;
+  currentSortKey: SortKey;
   onSelect: (direction: SortDirection) => void;
   onCancel: () => void;
 }
@@ -126,7 +127,6 @@ export default function SortDirectionModal({
       case 'pushed': return 'Last Pushed';
       case 'name': return 'Name';
       case 'stars': return 'Stars';
-      default: return currentSortKey;
     }
   };
   

--- a/src/ui/components/modals/index.ts
+++ b/src/ui/components/modals/index.ts
@@ -5,6 +5,7 @@ export { default as InfoModal } from './InfoModal';
 export { default as LogoutModal } from './LogoutModal';
 export { default as VisibilityModal } from './VisibilityModal';
 export { default as SortModal } from './SortModal';
+export { default as SortDirectionModal } from './SortDirectionModal';
 export { ChangeVisibilityModal } from './ChangeVisibilityModal';
 export { default as CopyUrlModal } from './CopyUrlModal';
 export { default as RenameModal } from './RenameModal';


### PR DESCRIPTION
## Summary
This PR improves the user experience by replacing the direct sort direction toggle with an interactive modal, providing better visual feedback and consistency with the existing sort key modal.

## Changes
- ✨ Created new `SortDirectionModal` component with visual feedback
- 🎨 Shows current sorting key context and describes what each direction means
- 🔄 Replaces direct toggle (D key) with modal-based interaction
- ⌨️ Provides keyboard shortcuts (A/D) and arrow key navigation
- 📝 Updated README to reflect the new modal-based interaction

## Before
- Pressing 'D' would immediately toggle between ascending/descending without feedback
- Users had no visual indication of what the sort direction meant for each sort key

## After
- Pressing 'D' opens a modal showing:
  - Current sort key (e.g., "Sorting by: Last Updated")
  - Clear options with descriptions:
    - Descending ↓ (e.g., "Most recently updated first")
    - Ascending ↑ (e.g., "Oldest updated first")
  - Visual indicator for current selection (✓)
  - Keyboard shortcuts for quick selection

## Screenshots
The modal provides context-aware descriptions based on the current sort key:
- **Last Updated**: "Most recently updated first" / "Oldest updated first"
- **Last Pushed**: "Most recently pushed first" / "Oldest pushed first"
- **Name**: "Z to A" / "A to Z"
- **Stars**: "Most stars first" / "Fewest stars first"

## Testing
- [x] Build successful
- [x] Modal opens with 'D' key
- [x] Arrow keys navigate options
- [x] Enter selects option
- [x] Escape/C cancels
- [x] Quick shortcuts (A/D) work
- [x] Visual feedback for current selection
- [x] Consistent with existing modal patterns

## Related
This follows the same UX pattern as the sort key modal (S key), providing a consistent and intuitive interface throughout the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Introduced a Sort Direction modal to choose Ascending/Descending instead of an instant toggle. Press D to open, use Arrow keys/Tab to navigate, Enter to confirm, A/D for quick select, Esc/Cancel to close. Visual cues mark current and focused options; other inputs are paused while the modal is open and header reflects active modals.

* Documentation
  * README updated to describe modal-based sort direction selection and revised D key behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->