### PR TITLE
feat: add stars mode and star/unstar functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ On first run, you'll be prompted to authenticate with GitHub (OAuth recommended)
 - **Interactive Sorting**: Modal-based sort selection (updated, pushed, name, stars) with modal-based direction selection
 - **Smart Search**: Server-side search through repository names and descriptions (3+ characters)
 - **Visibility Filtering**: Modal-based visibility filter (All, Public, Private/Internal for enterprise) with smart filtering
-- **Fork Status Tracking**: Toggle display of commits behind upstream for forked repositories
+- **Fork Status Tracking**: Always shows commits behind upstream for forked repositories
+- **Stars Mode**: View and manage starred repositories (personal account only)
 - **Repository Actions**:
   - View detailed info (`I`) - Shows repository metadata, language, size, and timestamps
   - Open in browser (Enter/`O`)
@@ -85,7 +86,8 @@ On first run, you'll be prompted to authenticate with GitHub (OAuth recommended)
   - Delete repository (`Del` or `Backspace`) with secure two-step confirmation
   - Archive/unarchive repositories (`Ctrl+A`) with confirmation prompts
   - Change repository visibility (`Ctrl+V`) - Switch between Public, Private, and Internal (enterprise only)
-  - Sync forks with upstream (`Ctrl+S`) with automatic conflict detection
+  - Star/unstar repositories (`Ctrl+S`) - Toggle star status for any repository
+  - Sync forks with upstream (`Ctrl+F`) with automatic conflict detection
 
 ### User Interface & Experience
 - **Keyboard Navigation**: Full keyboard control (arrow keys, PageUp/Down, `Ctrl+G`/`G`)
@@ -266,8 +268,9 @@ Launch the app, then use the keys below:
   - Stars: Number of stars
 - **Sort Direction**: `D` to open sort direction modal (ascending/descending)
 - **Display Density**: `T` to toggle compact/cozy/comfy
-- **Fork Status**: `F` to toggle showing commits behind upstream
+- **Fork Status**: Always enabled - shows commits behind upstream for all forks
 - **Visibility Filter**: `V` opens modal (All, Public, Private/Internal for enterprise)
+- **Stars Mode**: `Shift+S` (personal account only) to view starred repositories
 
 ### Navigation & Account
 - **Open in browser**: Enter or `O`
@@ -284,7 +287,10 @@ Launch the app, then use the keys below:
 - **Delete repository**: `Del` or `Backspace` (with two-step confirmation modal)
   - Type confirmation code → confirm (Y/Enter)
   - Cancel: press `C` or Esc
-- **Sync fork**: `Ctrl+S` (for forks only, shows commit status and handles conflicts)
+- **Star/Unstar**: `Ctrl+S` to toggle star status for any repository
+- **Sync fork**: `Ctrl+F` (for forks only, shows commit status and handles conflicts)
+- **Rename repository**: `Ctrl+R` with inline validation
+- **Copy URL**: `C` to copy repository URL to clipboard (SSH/HTTPS options)
 
 ### General
 - **Esc**: Cancels modals, clears search, or returns to normal listing (does not quit)

--- a/TODOs.md
+++ b/TODOs.md
@@ -53,13 +53,15 @@ Legend:
 
 ## Near‑Term
 
-- [ ] Stars mode (Personal Account only)
-  - Special mode to list repositories that the user has starred
-  - Available only when viewing Personal Account (not organizations)
-  - Key binding to trigger unstar action for selected repository
-  - GraphQL query to fetch starred repositories
-  - Display similar to regular repo list but with unstar action instead of delete
-  - Consider showing when/why starred if metadata available
+- [x] Stars mode (Personal Account only)
+  - Special mode to list repositories that the user has starred ✓
+  - Available only when viewing Personal Account (not organizations) ✓
+  - Key binding: Shift+S to toggle stars mode ✓
+  - Key binding: U to trigger unstar action for selected repository ✓
+  - GraphQL query to fetch starred repositories ✓
+  - Display similar to regular repo list but with unstar action instead of delete ✓
+  - Visual indicator "⭐ Stars Mode" in header when active ✓
+  - UnstarModal component for confirmation before unstarring ✓
 
 - [x] Repo actions with confirmations
   - [x] Archive / Unarchive repositories

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -246,6 +246,7 @@ export async function fetchViewerReposPage(
               isArchived
               stargazerCount
               forkCount
+              viewerHasStarred
               primaryLanguage {
                 name
                 color
@@ -253,6 +254,10 @@ export async function fetchViewerReposPage(
               updatedAt
               pushedAt
               diskUsage
+              owner {
+                __typename
+                login
+              }
               ${includeForkTracking ? `
               parent {
                 nameWithOwner
@@ -768,6 +773,11 @@ export async function getStarredRepositories(
             isArchived
             stargazerCount
             forkCount
+            viewerHasStarred
+            owner {
+              __typename
+              login
+            }
             primaryLanguage {
               name
               color
@@ -807,6 +817,38 @@ export async function getStarredRepositories(
     };
   } catch (error: any) {
     logger.error('Failed to fetch starred repositories', {
+      error: error.message,
+      stack: error.stack
+    });
+    throw error;
+  }
+}
+
+// Star a repository
+export async function starRepository(
+  client: ReturnType<typeof makeClient>,
+  starrableId: string
+): Promise<void> {
+  logger.info('Starring repository', {
+    starrableId
+  });
+
+  const mutation = /* GraphQL */ `
+    mutation StarRepo($starrableId: ID!) {
+      addStar(input: { starrableId: $starrableId }) {
+        clientMutationId
+      }
+    }
+  `;
+
+  try {
+    await client(mutation, { starrableId });
+    logger.info('Successfully starred repository', {
+      starrableId
+    });
+  } catch (error: any) {
+    logger.error('Failed to star repository', {
+      starrableId,
       error: error.message,
       stack: error.stack
     });

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -722,6 +722,130 @@ export async function deleteRepositoryRest(
   throw new Error(msg);
 }
 
+// Fetch starred repositories
+export async function getStarredRepositories(
+  client: ReturnType<typeof makeClient>,
+  first: number,
+  after?: string
+): Promise<{
+  nodes: RepoNode[];
+  endCursor?: string;
+  hasNextPage: boolean;
+  totalCount: number;
+  rateLimit: RateLimitInfo;
+}> {
+  logger.info('Fetching starred repositories', {
+    first,
+    after
+  });
+
+  const query = /* GraphQL */ `
+    query StarredRepos($first: Int!, $after: String) {
+      rateLimit {
+        limit
+        remaining
+        resetAt
+      }
+      viewer {
+        starredRepositories(
+          first: $first
+          after: $after
+          orderBy: { field: STARRED_AT, direction: DESC }
+        ) {
+          totalCount
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
+          nodes {
+            id
+            name
+            nameWithOwner
+            description
+            visibility
+            isPrivate
+            isFork
+            isArchived
+            stargazerCount
+            forkCount
+            primaryLanguage {
+              name
+              color
+            }
+            updatedAt
+            pushedAt
+            diskUsage
+            parent {
+              nameWithOwner
+            }
+            defaultBranchRef { name }
+          }
+        }
+      }
+    }
+  `;
+
+  try {
+    const res: any = await client(query, {
+      first,
+      after: after ?? null,
+    });
+
+    const data = res.viewer.starredRepositories;
+    
+    logger.info('Successfully fetched starred repositories', {
+      count: data.nodes?.length || 0,
+      totalCount: data.totalCount
+    });
+
+    return {
+      nodes: data.nodes as RepoNode[],
+      endCursor: data.pageInfo.endCursor,
+      hasNextPage: data.pageInfo.hasNextPage,
+      totalCount: data.totalCount,
+      rateLimit: res.rateLimit as RateLimitInfo,
+    };
+  } catch (error: any) {
+    logger.error('Failed to fetch starred repositories', {
+      error: error.message,
+      stack: error.stack
+    });
+    throw error;
+  }
+}
+
+// Unstar a repository
+export async function unstarRepository(
+  client: ReturnType<typeof makeClient>,
+  starrableId: string
+): Promise<void> {
+  logger.info('Unstarring repository', {
+    starrableId
+  });
+
+  const mutation = /* GraphQL */ `
+    mutation UnstarRepo($starrableId: ID!) {
+      removeStar(input: { starrableId: $starrableId }) {
+        clientMutationId
+      }
+    }
+  `;
+
+  try {
+    await client(mutation, { starrableId });
+    logger.info('Successfully unstarred repository', {
+      starrableId
+    });
+  } catch (error: any) {
+    logger.error('Failed to unstar repository', {
+      starrableId,
+      error: error.message,
+      stack: error.stack
+    });
+    throw error;
+  }
+}
+
 export async function archiveRepositoryById(
   client: ReturnType<typeof makeClient>,
   repositoryId: string

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -486,6 +486,8 @@ export async function fetchViewerReposPageUnified(
                   isArchived
                   stargazerCount
                   forkCount
+                  viewerHasStarred
+                  owner { __typename login }
                   primaryLanguage { name color }
                   updatedAt
                   pushedAt
@@ -521,6 +523,8 @@ export async function fetchViewerReposPageUnified(
                   isArchived
                   stargazerCount
                   forkCount
+                  viewerHasStarred
+                  owner { __typename login }
                   primaryLanguage { name color }
                   updatedAt
                   pushedAt
@@ -633,6 +637,8 @@ export async function searchRepositoriesUnified(
               isArchived
               stargazerCount
               forkCount
+              viewerHasStarred
+              owner { __typename login }
               primaryLanguage { name color }
               updatedAt
               pushedAt

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export interface RepoNode {
   isArchived: boolean;
   stargazerCount: number;
   forkCount: number;
+  viewerHasStarred?: boolean;
   primaryLanguage: Maybe<Language>;
   updatedAt: string; // ISO
   pushedAt: string; // ISO
@@ -39,6 +40,10 @@ export interface RepoNode {
       }
     }
   }>;
+  owner?: {
+    __typename: 'Organization' | 'User';
+    login: string;
+  };
 }
 
 export interface PageInfo {

--- a/src/ui/components/modals/StarModal.tsx
+++ b/src/ui/components/modals/StarModal.tsx
@@ -1,0 +1,152 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Text } from 'ink';
+import { useInput } from 'ink';
+import type { RepoNode } from '../../../types';
+
+interface StarModalProps {
+  visible: boolean;
+  repo: RepoNode | null;
+  isStarred: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isStarring?: boolean;
+  error?: string | null;
+}
+
+export function StarModal({
+  visible,
+  repo,
+  isStarred,
+  onConfirm,
+  onCancel,
+  isStarring = false,
+  error = null,
+}: StarModalProps) {
+  const [focusedButton, setFocusedButton] = useState<'cancel' | 'star'>('cancel');
+
+  useInput((input, key) => {
+    if (!visible) return;
+
+    if (key.escape || input === 'c' || input === 'C') {
+      onCancel();
+      return;
+    }
+
+    if (key.leftArrow) {
+      setFocusedButton('cancel');
+    } else if (key.rightArrow) {
+      setFocusedButton('star');
+    }
+
+    if (key.return || input === 'y' || input === 'Y') {
+      if (focusedButton === 'star') {
+        onConfirm();
+      } else {
+        onCancel();
+      }
+    }
+
+    if (input === 'n' || input === 'N') {
+      onCancel();
+    }
+
+    if (input === 's' || input === 'S') {
+      onConfirm();
+    }
+  });
+
+  useEffect(() => {
+    if (visible) {
+      setFocusedButton('cancel');
+    }
+  }, [visible]);
+
+  if (!visible || !repo) return null;
+
+  const action = isStarred ? 'Unstar' : 'Star';
+  const actionLower = isStarred ? 'unstar' : 'star';
+  const actionGerund = isStarred ? 'Unstarring' : 'Starring';
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="yellow"
+      paddingX={2}
+      paddingY={1}
+      marginTop={1}
+    >
+      <Box marginBottom={1}>
+        <Text bold color="yellow">
+          ⭐ {action} Repository
+        </Text>
+      </Box>
+
+      <Box marginBottom={1}>
+        <Text>
+          Are you sure you want to {actionLower}{' '}
+          <Text bold color="cyan">
+            {repo.nameWithOwner}
+          </Text>
+          ?
+        </Text>
+      </Box>
+
+      {repo.description && (
+        <Box marginBottom={1}>
+          <Text dimColor wrap="wrap">
+            {repo.description}
+          </Text>
+        </Box>
+      )}
+
+      <Box marginBottom={1}>
+        <Text dimColor>
+          Current Stars: {repo.stargazerCount} • Forks: {repo.forkCount}
+        </Text>
+      </Box>
+
+      {error && (
+        <Box marginBottom={1} flexDirection="column">
+          <Text color="red" wrap="wrap">
+            {error.includes('OAuth access restrictions') ? '⚠️ ' : 'Error: '}{error}
+          </Text>
+        </Box>
+      )}
+
+      {isStarring ? (
+        <Box>
+          <Text color="yellow">{actionGerund}...</Text>
+        </Box>
+      ) : (
+        <>
+          <Box gap={2}>
+            <Box>
+              <Text
+                backgroundColor={focusedButton === 'cancel' ? 'white' : undefined}
+                color={focusedButton === 'cancel' ? 'black' : 'white'}
+                bold={focusedButton === 'cancel'}
+              >
+                {' '}
+                Cancel (C/Esc){' '}
+              </Text>
+            </Box>
+            <Box>
+              <Text
+                backgroundColor={focusedButton === 'star' ? 'yellow' : undefined}
+                color={focusedButton === 'star' ? 'black' : 'yellow'}
+                bold={focusedButton === 'star'}
+              >
+                {' '}
+                {action} (S/Y){' '}
+              </Text>
+            </Box>
+          </Box>
+          <Box marginTop={1}>
+            <Text dimColor>Use ← → to navigate, Enter to select</Text>
+          </Box>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/src/ui/components/modals/UnstarModal.tsx
+++ b/src/ui/components/modals/UnstarModal.tsx
@@ -101,8 +101,10 @@ export function UnstarModal({
       </Box>
 
       {error && (
-        <Box marginBottom={1}>
-          <Text color="red">Error: {error}</Text>
+        <Box marginBottom={1} flexDirection="column">
+          <Text color="red" wrap="wrap">
+            {error.includes('OAuth access restrictions') ? '⚠️ ' : 'Error: '}{error}
+          </Text>
         </Box>
       )}
 

--- a/src/ui/components/modals/UnstarModal.tsx
+++ b/src/ui/components/modals/UnstarModal.tsx
@@ -1,0 +1,144 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Text } from 'ink';
+import { useInput } from 'ink';
+import type { RepoNode } from '../../../types';
+
+interface UnstarModalProps {
+  visible: boolean;
+  repo: RepoNode | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isUnstarring?: boolean;
+  error?: string | null;
+}
+
+export function UnstarModal({
+  visible,
+  repo,
+  onConfirm,
+  onCancel,
+  isUnstarring = false,
+  error = null,
+}: UnstarModalProps) {
+  const [focusedButton, setFocusedButton] = useState<'cancel' | 'unstar'>('cancel');
+
+  useInput((input, key) => {
+    if (!visible) return;
+
+    if (key.escape || input === 'c' || input === 'C') {
+      onCancel();
+      return;
+    }
+
+    if (key.leftArrow) {
+      setFocusedButton('cancel');
+    } else if (key.rightArrow) {
+      setFocusedButton('unstar');
+    }
+
+    if (key.return || input === 'y' || input === 'Y') {
+      if (focusedButton === 'unstar') {
+        onConfirm();
+      } else {
+        onCancel();
+      }
+    }
+
+    if (input === 'n' || input === 'N') {
+      onCancel();
+    }
+
+    if (input === 'u' || input === 'U') {
+      onConfirm();
+    }
+  });
+
+  useEffect(() => {
+    if (visible) {
+      setFocusedButton('cancel');
+    }
+  }, [visible]);
+
+  if (!visible || !repo) return null;
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="yellow"
+      paddingX={2}
+      paddingY={1}
+      marginTop={1}
+    >
+      <Box marginBottom={1}>
+        <Text bold color="yellow">
+          ⭐ Unstar Repository
+        </Text>
+      </Box>
+
+      <Box marginBottom={1}>
+        <Text>
+          Are you sure you want to unstar{' '}
+          <Text bold color="cyan">
+            {repo.nameWithOwner}
+          </Text>
+          ?
+        </Text>
+      </Box>
+
+      {repo.description && (
+        <Box marginBottom={1}>
+          <Text dimColor wrap="wrap">
+            {repo.description}
+          </Text>
+        </Box>
+      )}
+
+      <Box marginBottom={1}>
+        <Text dimColor>
+          Stars: {repo.stargazerCount} • Forks: {repo.forkCount}
+        </Text>
+      </Box>
+
+      {error && (
+        <Box marginBottom={1}>
+          <Text color="red">Error: {error}</Text>
+        </Box>
+      )}
+
+      {isUnstarring ? (
+        <Box>
+          <Text color="yellow">Unstarring...</Text>
+        </Box>
+      ) : (
+        <>
+          <Box gap={2}>
+            <Box>
+              <Text
+                backgroundColor={focusedButton === 'cancel' ? 'white' : undefined}
+                color={focusedButton === 'cancel' ? 'black' : 'white'}
+                bold={focusedButton === 'cancel'}
+              >
+                {' '}
+                Cancel (C/Esc){' '}
+              </Text>
+            </Box>
+            <Box>
+              <Text
+                backgroundColor={focusedButton === 'unstar' ? 'yellow' : undefined}
+                color={focusedButton === 'unstar' ? 'black' : 'yellow'}
+                bold={focusedButton === 'unstar'}
+              >
+                {' '}
+                Unstar (U/Y){' '}
+              </Text>
+            </Box>
+          </Box>
+          <Box marginTop={1}>
+            <Text dimColor>Use ← → to navigate, Enter to select</Text>
+          </Box>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/src/ui/components/modals/index.ts
+++ b/src/ui/components/modals/index.ts
@@ -9,4 +9,5 @@ export { default as SortDirectionModal } from './SortDirectionModal';
 export { ChangeVisibilityModal } from './ChangeVisibilityModal';
 export { default as CopyUrlModal } from './CopyUrlModal';
 export { default as RenameModal } from './RenameModal';
+export { StarModal } from './StarModal';
 

--- a/src/ui/components/repo/RepoListHeader.tsx
+++ b/src/ui/components/repo/RepoListHeader.tsx
@@ -58,7 +58,7 @@ export default function RepoListHeader({
       <Text color="gray" dimColor>
         Fork Status - Commits Behind: {forkTracking ? 'ON' : 'OFF'}
       </Text>
-      {!!visibilityLabel && (
+      {!!visibilityLabel && !starsMode && (
         <Text color="yellow">
           Visibility: {visibilityLabel}
         </Text>

--- a/src/ui/components/repo/RepoListHeader.tsx
+++ b/src/ui/components/repo/RepoListHeader.tsx
@@ -13,6 +13,7 @@ interface RepoListHeaderProps {
   searchLoading: boolean;
   visibilityFilter?: 'all' | 'public' | 'private' | 'internal';
   isEnterprise?: boolean;
+  starsMode?: boolean;
 }
 
 export default function RepoListHeader({
@@ -24,7 +25,8 @@ export default function RepoListHeader({
   searchActive,
   searchLoading,
   visibilityFilter = 'all',
-  isEnterprise = false
+  isEnterprise = false,
+  starsMode = false
 }: RepoListHeaderProps) {
   const contextLabel = ownerContext === 'personal'
     ? 'Personal Account'
@@ -44,6 +46,11 @@ export default function RepoListHeader({
     <Box flexDirection="row" gap={2} marginBottom={1}>
       {contextLabel && (
         <Text>{contextLabel}</Text>
+      )}
+      {starsMode && (
+        <Text color="yellow" bold>
+          ⭐ Stars Mode
+        </Text>
       )}
       <Text color="gray" dimColor>
         Sort: {sortKey} {sortDir === 'asc' ? '↑' : '↓'}

--- a/src/ui/components/repo/RepoRow.tsx
+++ b/src/ui/components/repo/RepoRow.tsx
@@ -12,6 +12,7 @@ interface RepoRowProps {
   spacingLines: number;
   dim?: boolean;
   forkTracking: boolean;
+  starsMode?: boolean;
 }
 
 export default function RepoRow({ 
@@ -21,7 +22,8 @@ export default function RepoRow({
   maxWidth, 
   spacingLines, 
   dim, 
-  forkTracking 
+  forkTracking,
+  starsMode = false
 }: RepoRowProps) {
   const langName = repo.primaryLanguage?.name || '';
   const langColor = repo.primaryLanguage?.color || '#666666';
@@ -47,6 +49,11 @@ export default function RepoRow({
     line1 += chalk.magenta(' Internal');
   } else if (repo.visibility === 'PRIVATE' || (repo.isPrivate && !repo.visibility)) {
     line1 += chalk.yellow(' Private');
+  }
+  
+  // In stars mode, show indicator for org repos that might have OAuth restrictions
+  if (starsMode && repo.owner && repo.owner.__typename === 'Organization') {
+    line1 += chalk.gray(' [org]');
   }
   if (repo.isArchived) line1 += ' ' + chalk.bgGray.whiteBright(' Archived ') + ' ';
   if (repo.isFork && repo.parent) {

--- a/src/ui/components/repo/RepoRow.tsx
+++ b/src/ui/components/repo/RepoRow.tsx
@@ -43,6 +43,10 @@ export default function RepoRow({
   const numColor = selected ? chalk.cyan : chalk.gray;
   const nameColor = selected ? chalk.cyan.bold : chalk.white;
   line1 += numColor(`${String(index).padStart(3, ' ')}.`);
+  // Show star icon if the repo is starred
+  if (repo.viewerHasStarred) {
+    line1 += chalk.yellow(' ⭐');
+  }
   line1 += nameColor(` ${repo.nameWithOwner}`);
   // Use visibility field to properly distinguish between PRIVATE and INTERNAL
   if (repo.visibility === 'INTERNAL') {

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -1234,15 +1234,18 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return;
     }
 
-    // ESC key while viewing search results - clear search and return to normal listing
-    if (key.escape && searchActive) {
+    // ESC key while viewing search results or filtered stars - clear filter and return to normal listing
+    if (key.escape && (searchActive || (starsMode && filter.trim().length > 0))) {
       setFilter('');
-      setSearchItems([]);
-      setSearchEndCursor(null);
-      setSearchHasNextPage(false);
-      setSearchTotalCount(0);
+      if (!starsMode) {
+        // Only clear search-related state in non-stars mode
+        setSearchItems([]);
+        setSearchEndCursor(null);
+        setSearchHasNextPage(false);
+        setSearchTotalCount(0);
+      }
       setCursor(0); // Reset cursor to top
-      addDebugMessage('[ESC] Cleared search and returned to normal listing');
+      addDebugMessage('[ESC] Cleared filter and returned to normal listing');
       return;
     }
 

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -628,6 +628,14 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     // Reset visibility filter to 'all' when switching organizations
     setVisibilityFilter('all');
     
+    // Disable star mode when switching to non-personal context
+    if (newContext !== 'personal' && starsMode) {
+      setStarsMode(false);
+      setStarredItems([]);
+      setStarredPageInfo({ hasNextPage: false, endCursor: null });
+      setStarredTotalCount(0);
+    }
+    
     // Update affiliations based on context
     const newAffiliations = newContext === 'personal' 
       ? ['OWNER'] as OwnerAffiliation[]
@@ -1411,8 +1419,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return;
     }
 
-    // Sync fork with upstream modal (Ctrl+S)
-    if (key.ctrl && (input === 's' || input === 'S')) {
+    // Sync fork with upstream modal (Ctrl+Y)
+    if (key.ctrl && (input === 'y' || input === 'Y')) {
       const repo = visibleItems[cursor];
       if (repo && repo.isFork && repo.parent) {
         // Only show sync option for forks that are behind
@@ -1552,8 +1560,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return;
     }
     
-    // Star/unstar toggle (Ctrl+U) - only in normal mode
-    if (key.ctrl && (input === 'u' || input === 'U') && !starsMode) {
+    // Star/unstar toggle (Ctrl+S) - only in normal mode
+    if (key.ctrl && (input === 's' || input === 'S') && !starsMode) {
       const repo = visibleItems[cursor];
       if (repo) {
         setStarTarget(repo);
@@ -1581,8 +1589,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return;
     }
 
-    // Toggle fork tracking
-    if (input && input.toUpperCase() === 'F') {
+    // Toggle fork tracking (Ctrl+F)
+    if (key.ctrl && (input === 'f' || input === 'F')) {
       setForkTracking((prev) => {
         const next = !prev;
         storeUIPrefs({ forkTracking: next });
@@ -2492,7 +2500,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         {/* Line 2: Search and filtering */}
         <Box width={terminalWidth} justifyContent="center">
           <Text color="gray" dimColor={modalOpen ? true : undefined}>
-            / Search • S Sort • D Direction • T Density • F Fork Status{!starsMode && ' • V Visibility'}{ownerContext === 'personal' && ' • Shift+S Stars'}
+            / Search • S Sort • D Direction • T Density • Ctrl+F Fork Status{!starsMode && ' • V Visibility'}{ownerContext === 'personal' && ' • Shift+S Stars'}
           </Text>
         </Box>
         {/* Line 3: Repository actions */}
@@ -2500,7 +2508,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
           <Text color="gray" dimColor={modalOpen ? true : undefined}>
             {starsMode ? 
               'I Info • C Copy URL • U Unstar Repository' :
-              'I Info • C Copy URL • Ctrl+U Un/Star • Ctrl+R Rename • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+S Sync Fork'
+              'I Info • C Copy URL • Ctrl+S Un/Star • Ctrl+R Rename • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+Y Sync Fork'
             }
           </Text>
         </Box>

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState, useRef, useCallback } from 'react'
 import { Box, Text, useApp, useInput, useStdout, Spacer, Newline } from 'ink';
 import TextInput from 'ink-text-input';
 import chalk from 'chalk';
-import { makeClient, fetchViewerReposPageUnified, searchRepositoriesUnified, deleteRepositoryRest, archiveRepositoryById, unarchiveRepositoryById, changeRepositoryVisibility, syncForkWithUpstream, getRepositoryFromCache, purgeApolloCacheFiles, inspectCacheStatus, updateCacheAfterDelete, updateCacheAfterArchive, updateCacheAfterVisibilityChange, updateCacheWithRepository, checkOrganizationIsEnterprise, OwnerAffiliation, fetchViewerOrganizations, fetchRestRateLimits, renameRepositoryById, updateCacheAfterRename } from '../../services/github';
+import { makeClient, fetchViewerReposPageUnified, searchRepositoriesUnified, deleteRepositoryRest, archiveRepositoryById, unarchiveRepositoryById, changeRepositoryVisibility, syncForkWithUpstream, getRepositoryFromCache, purgeApolloCacheFiles, inspectCacheStatus, updateCacheAfterDelete, updateCacheAfterArchive, updateCacheAfterVisibilityChange, updateCacheWithRepository, checkOrganizationIsEnterprise, OwnerAffiliation, fetchViewerOrganizations, fetchRestRateLimits, renameRepositoryById, updateCacheAfterRename, getStarredRepositories, unstarRepository } from '../../services/github';
 import { getUIPrefs, storeUIPrefs, OwnerContext } from '../../config/config';
 import { makeApolloKey, makeSearchKey, isFresh, markFetched } from '../../services/apolloMeta';
 import type { RepoNode, RateLimitInfo, RestRateLimitInfo } from '../../types';
@@ -10,6 +10,7 @@ import { exec } from 'child_process';
 import OrgSwitcher from '../OrgSwitcher';
 import { logger } from '../../lib/logger';
 import { DeleteModal, ArchiveModal, SyncModal, InfoModal, LogoutModal, VisibilityModal, SortModal, SortDirectionModal, ChangeVisibilityModal, CopyUrlModal, RenameModal } from '../components/modals';
+import { UnstarModal } from '../components/modals/UnstarModal';
 import { RepoRow, FilterInput, RepoListHeader } from '../components/repo';
 import { SlowSpinner } from '../components/common';
 import { truncate, formatDate, copyToClipboard } from '../../lib/utils';
@@ -160,6 +161,20 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   // Sort modal state
   const [sortMode, setSortMode] = useState(false);
   const [sortDirectionMode, setSortDirectionMode] = useState(false);
+  
+  // Stars mode state
+  const [starsMode, setStarsMode] = useState(false);
+  const [starredItems, setStarredItems] = useState<RepoNode[]>([]);
+  const [starredEndCursor, setStarredEndCursor] = useState<string | null>(null);
+  const [starredHasNextPage, setStarredHasNextPage] = useState(false);
+  const [starredTotalCount, setStarredTotalCount] = useState<number>(0);
+  const [starredLoading, setStarredLoading] = useState(false);
+  
+  // Unstar modal state
+  const [unstarMode, setUnstarMode] = useState(false);
+  const [unstarTarget, setUnstarTarget] = useState<RepoNode | null>(null);
+  const [unstarring, setUnstarring] = useState(false);
+  const [unstarError, setUnstarError] = useState<string | null>(null);
 
   // Apply initial --org flag once (if provided)
   const appliedInitialOrg = useRef(false);
@@ -246,6 +261,70 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   }
   
   // Single sync execution function to prevent duplicate operations
+  // Fetch starred repositories
+  async function fetchStarredRepositories(after?: string | null, reset = false) {
+    setStarredLoading(true);
+    try {
+      const page = await getStarredRepositories(client, PAGE_SIZE, after ?? undefined);
+      
+      setStarredItems(prev => (reset || !after ? page.nodes : [...prev, ...page.nodes]));
+      setStarredEndCursor(page.endCursor ?? null);
+      setStarredHasNextPage(page.hasNextPage);
+      setStarredTotalCount(page.totalCount);
+      
+      if (page.rateLimit) {
+        setRateLimit(page.rateLimit);
+        if (prevRateLimit !== undefined) {
+          setPrevRateLimit(prevRateLimit);
+        }
+        setPrevRateLimit(page.rateLimit.remaining);
+      }
+      
+      setStarredLoading(false);
+    } catch (e: any) {
+      setStarredLoading(false);
+      setError(e.message || 'Failed to fetch starred repositories');
+    }
+  }
+  
+  // Handle unstar action
+  async function handleUnstar() {
+    if (!unstarTarget || unstarring) return;
+    
+    try {
+      setUnstarring(true);
+      const targetId = (unstarTarget as any).id;
+      
+      await unstarRepository(client, targetId);
+      
+      // Remove from starred items list
+      setStarredItems(prev => prev.filter((r: any) => r.id !== targetId));
+      setStarredTotalCount(c => Math.max(0, c - 1));
+      
+      // Adjust cursor if needed
+      setCursor(c => Math.max(0, Math.min(c, starredItems.length - 2)));
+      
+      trackSuccessfulOperation();
+      
+      // Close modal
+      setUnstarMode(false);
+      setUnstarTarget(null);
+      setUnstarError(null);
+      setUnstarring(false);
+    } catch (e: any) {
+      setUnstarring(false);
+      setUnstarError(e.message || 'Failed to unstar repository');
+    }
+  }
+  
+  // Close unstar modal
+  function closeUnstarModal() {
+    setUnstarMode(false);
+    setUnstarTarget(null);
+    setUnstarError(null);
+    setUnstarring(false);
+  }
+
   async function executeSync() {
     if (!syncTarget || syncing) return;
     
@@ -1020,6 +1099,16 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return;
     }
 
+    // When in unstar mode, trap inputs for modal
+    if (unstarMode) {
+      if (key.escape || (input && input.toUpperCase() === 'C')) {
+        closeUnstarModal();
+        return;
+      }
+      // Let the UnstarModal component handle other inputs
+      return;
+    }
+
     // When in sync mode, trap inputs for modal
     if (syncMode) {
       if (key.escape || (input && input.toUpperCase() === 'C')) {
@@ -1316,13 +1405,38 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return;
     }
 
-    // Sort modal: show sort options
-    if (input && input.toUpperCase() === 'S') {
+    // Sort modal: show sort options (S key when not in stars mode)
+    if (input && input.toUpperCase() === 'S' && !key.shift) {
       setSortMode(true);
       return;
     }
     if (input && input.toUpperCase() === 'D') {
       setSortDirectionMode(true);
+      return;
+    }
+    
+    // Stars mode toggle (Shift+S) - only available in personal context
+    if (key.shift && input === 'S' && ownerContext === 'personal') {
+      const newStarsMode = !starsMode;
+      setStarsMode(newStarsMode);
+      setCursor(0);
+      
+      if (newStarsMode) {
+        // Entering stars mode - fetch starred repositories
+        fetchStarredRepositories(null, true);
+      }
+      return;
+    }
+    
+    // Unstar action (U key) - only in stars mode
+    if (input && input.toUpperCase() === 'U' && starsMode) {
+      const repo = visibleItems[cursor];
+      if (repo) {
+        setUnstarTarget(repo);
+        setUnstarMode(true);
+        setUnstarError(null);
+        setUnstarring(false);
+      }
       return;
     }
 
@@ -1437,7 +1551,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     return result;
   }, [searchItems, visibilityFilter]);
   
-  const visibleItems = searchActive ? filteredSearchItems : filteredAndSorted;
+  const visibleItems = starsMode ? starredItems : (searchActive ? filteredSearchItems : filteredAndSorted);
   
   // Debug log
   useEffect(() => {
@@ -2091,6 +2205,17 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               onCopy={handleCopyUrl}
             />
           </Box>
+        ) : unstarMode && unstarTarget ? (
+          <Box height={contentHeight} alignItems="center" justifyContent="center">
+            <UnstarModal
+              visible={unstarMode}
+              repo={unstarTarget}
+              onConfirm={handleUnstar}
+              onCancel={closeUnstarModal}
+              isUnstarring={unstarring}
+              error={unstarError}
+            />
+          </Box>
         ) : (
           <>
             {/* Context/Filter/sort status */}
@@ -2104,6 +2229,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               searchLoading={searchLoading}
               visibilityFilter={visibilityFilter}
               isEnterprise={isEnterpriseOrg}
+              starsMode={starsMode}
             />
 
             {/* Filter input */}
@@ -2210,13 +2336,16 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         {/* Line 2: Search and filtering */}
         <Box width={terminalWidth} justifyContent="center">
           <Text color="gray" dimColor={modalOpen ? true : undefined}>
-            / Search • S Sort • D Direction • T Density • F Fork Status • V Visibility
+            / Search • S Sort • D Direction • T Density • F Fork Status • V Visibility{ownerContext === 'personal' && ' • Shift+S Stars'}
           </Text>
         </Box>
         {/* Line 3: Repository actions */}
         <Box width={terminalWidth} justifyContent="center">
           <Text color="gray" dimColor={modalOpen ? true : undefined}>
-            I Info • C Copy URL • Ctrl+R Rename • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+S Sync Fork
+            {starsMode ? 
+              'I Info • C Copy URL • U Unstar Repository' :
+              'I Info • C Copy URL • Ctrl+R Rename • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+S Sync Fork'
+            }
           </Text>
         </Box>
         {/* Line 4: System controls */}

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -1552,8 +1552,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return;
     }
     
-    // Star/unstar toggle (Shift+U) - only in normal mode
-    if (key.shift && input === 'U' && !starsMode) {
+    // Star/unstar toggle (Ctrl+U) - only in normal mode
+    if (key.ctrl && (input === 'u' || input === 'U') && !starsMode) {
       const repo = visibleItems[cursor];
       if (repo) {
         setStarTarget(repo);
@@ -2500,7 +2500,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
           <Text color="gray" dimColor={modalOpen ? true : undefined}>
             {starsMode ? 
               'I Info • C Copy URL • U Unstar Repository' :
-              'I Info • C Copy URL • Shift+U Un/Star • Ctrl+R Rename • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+S Sync Fork'
+              'I Info • C Copy URL • Ctrl+U Un/Star • Ctrl+R Rename • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+S Sync Fork'
             }
           </Text>
         </Box>

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -1222,11 +1222,12 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         addDebugMessage('[ESC] Cleared search and returned to normal listing');
         return;
       }
-      // Down arrow in filter mode with search results - exit filter mode and select first item
-      if (key.downArrow && searchActive && visibleItems.length > 0) {
+      // Down arrow in filter mode with results - exit filter mode and select first item
+      // Works for both search mode and stars mode filtering
+      if (key.downArrow && (searchActive || (starsMode && filter.trim().length > 0)) && visibleItems.length > 0) {
         setFilterMode(false);
         setCursor(0); // Select first item
-        addDebugMessage('[DOWN] Exited filter mode and selected first search result');
+        addDebugMessage('[DOWN] Exited filter mode and selected first result');
         return;
       }
       // Let TextInput handle characters; Enter will exit via onSubmit

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -1439,11 +1439,26 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       setStarsMode(newStarsMode);
       setCursor(0);
       
+      // Clear filter when toggling modes
+      setFilter('');
+      setFilterMode(false);
+      
       if (newStarsMode) {
         // Entering stars mode - fetch starred repositories
         // Reset visibility filter since it doesn't apply to starred repos
         setVisibilityFilter('all');
+        // Clear search items since we're switching to starred repos
+        setSearchItems([]);
+        setSearchEndCursor(null);
+        setSearchHasNextPage(false);
+        setSearchTotalCount(0);
         fetchStarredRepositories(null, true);
+      } else {
+        // Exiting stars mode - clear search state
+        setSearchItems([]);
+        setSearchEndCursor(null);
+        setSearchHasNextPage(false);
+        setSearchTotalCount(0);
       }
       return;
     }

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -1423,6 +1423,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       
       if (newStarsMode) {
         // Entering stars mode - fetch starred repositories
+        // Reset visibility filter since it doesn't apply to starred repos
+        setVisibilityFilter('all');
         fetchStarredRepositories(null, true);
       }
       return;
@@ -1480,9 +1482,11 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return;
     }
     
-    // Open visibility filter modal (V)
+    // Open visibility filter modal (V) - disabled in stars mode
     if (input && input.toUpperCase() === 'V') {
-      setVisibilityMode(true);
+      if (!starsMode) {
+        setVisibilityMode(true);
+      }
       return;
     }
   });
@@ -1599,7 +1603,12 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     const prefetchThreshold = Math.floor(visibleItems.length * 0.8);
     const nearEnd = visibleItems.length > 0 && cursor >= prefetchThreshold;
     
-    if (searchActive) {
+    if (starsMode) {
+      if (!starredLoading && starredHasNextPage && nearEnd) {
+        addDebugMessage(`[Infinite Scroll] Prefetching starred repos at ${cursor}/${visibleItems.length} (80% threshold: ${prefetchThreshold})`);
+        fetchStarredRepositories(starredEndCursor);
+      }
+    } else if (searchActive) {
       if (!searchLoading && searchHasNextPage && nearEnd) {
         addDebugMessage(`[Infinite Scroll] Prefetching search results at ${cursor}/${visibleItems.length} (80% threshold: ${prefetchThreshold})`);
         fetchSearchPage(searchEndCursor);
@@ -1611,7 +1620,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cursor, visibleItems.length, searchActive, searchLoading, searchHasNextPage, searchEndCursor, loading, loadingMore, hasNextPage, endCursor]);
+  }, [cursor, visibleItems.length, starsMode, starredLoading, starredHasNextPage, starredEndCursor, searchActive, searchLoading, searchHasNextPage, searchEndCursor, loading, loadingMore, hasNextPage, endCursor]);
 
   // Helper: open URL in default browser (cross-platform best-effort)
   function openInBrowser(url: string) {
@@ -2336,7 +2345,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         {/* Line 2: Search and filtering */}
         <Box width={terminalWidth} justifyContent="center">
           <Text color="gray" dimColor={modalOpen ? true : undefined}>
-            / Search • S Sort • D Direction • T Density • F Fork Status • V Visibility{ownerContext === 'personal' && ' • Shift+S Stars'}
+            / Search • S Sort • D Direction • T Density • F Fork Status{!starsMode && ' • V Visibility'}{ownerContext === 'personal' && ' • Shift+S Stars'}
           </Text>
         </Box>
         {/* Line 3: Repository actions */}

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -280,9 +280,6 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       
       if (page.rateLimit) {
         setRateLimit(page.rateLimit);
-        if (prevRateLimit !== undefined) {
-          setPrevRateLimit(prevRateLimit);
-        }
         setPrevRateLimit(page.rateLimit.remaining);
       }
       
@@ -632,7 +629,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     if (newContext !== 'personal' && starsMode) {
       setStarsMode(false);
       setStarredItems([]);
-      setStarredPageInfo({ hasNextPage: false, endCursor: null });
+      setStarredHasNextPage(false);
+      setStarredEndCursor(null);
       setStarredTotalCount(0);
     }
     

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -933,8 +933,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     if (ui.sortDir && (ui.sortDir === 'asc' || ui.sortDir === 'desc')) {
       setSortDir(ui.sortDir);
     }
-    if (ui.forkTracking !== undefined) setForkTracking(ui.forkTracking);
-    else setForkTracking(true); // Default to ON if not set in config
+    // Fork tracking is now always ON
+    setForkTracking(true);
     
     // Load visibility filter
     if (ui.visibilityFilter && ['all', 'public', 'private', 'internal'].includes(ui.visibilityFilter)) {
@@ -1419,8 +1419,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return;
     }
 
-    // Sync fork with upstream modal (Ctrl+Y)
-    if (key.ctrl && (input === 'y' || input === 'Y')) {
+    // Sync fork with upstream modal (Ctrl+F)
+    if (key.ctrl && (input === 'f' || input === 'F')) {
       const repo = visibleItems[cursor];
       if (repo && repo.isFork && repo.parent) {
         // Only show sync option for forks that are behind
@@ -1589,28 +1589,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return;
     }
 
-    // Toggle fork tracking (Ctrl+F)
-    if (key.ctrl && (input === 'f' || input === 'F')) {
-      setForkTracking((prev) => {
-        const next = !prev;
-        storeUIPrefs({ forkTracking: next });
-        
-        // Check if we need to refresh data
-        const needsRefresh = next && items.some(repo => 
-          repo.isFork && repo.parent && (!repo.defaultBranchRef?.target?.history || !repo.parent.defaultBranchRef?.target?.history)
-        );
-        
-        if (needsRefresh) {
-          // Current data lacks commit history, need full refresh with new fork tracking value
-          setSortingLoading(true);
-          fetchPage(null, true, true, next);
-        }
-        // If toggling OFF or data is already complete, just update display immediately
-        
-        return next;
-      });
-      return;
-    }
+    // Fork tracking is now always on - removed toggle
     
     // Open visibility filter modal (V) - disabled in stars mode
     if (input && input.toUpperCase() === 'V') {
@@ -2500,7 +2479,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         {/* Line 2: Search and filtering */}
         <Box width={terminalWidth} justifyContent="center">
           <Text color="gray" dimColor={modalOpen ? true : undefined}>
-            / Search • S Sort • D Direction • T Density • Ctrl+F Fork Status{!starsMode && ' • V Visibility'}{ownerContext === 'personal' && ' • Shift+S Stars'}
+            / Search • S Sort • D Direction • T Density{!starsMode && ' • V Visibility'}{ownerContext === 'personal' && ' • Shift+S Stars'}
           </Text>
         </Box>
         {/* Line 3: Repository actions */}
@@ -2508,7 +2487,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
           <Text color="gray" dimColor={modalOpen ? true : undefined}>
             {starsMode ? 
               'I Info • C Copy URL • U Unstar Repository' :
-              'I Info • C Copy URL • Ctrl+S Un/Star • Ctrl+R Rename • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+Y Sync Fork'
+              'I Info • C Copy URL • Ctrl+S Un/Star • Ctrl+R Rename • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+F Sync Fork'
             }
           </Text>
         </Box>

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -313,7 +313,21 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       setUnstarring(false);
     } catch (e: any) {
       setUnstarring(false);
-      setUnstarError(e.message || 'Failed to unstar repository');
+      
+      // Check for OAuth access restriction error
+      const errorMsg = e.message || 'Failed to unstar repository';
+      if (errorMsg.includes('OAuth App access restrictions')) {
+        // Extract org name from the error or use the repo owner
+        const orgMatch = errorMsg.match(/`([^`]+)` organization/);
+        const orgName = orgMatch ? orgMatch[1] : unstarTarget?.nameWithOwner.split('/')[0];
+        
+        setUnstarError(
+          `Cannot unstar: The ${orgName} organization has OAuth access restrictions. ` +
+          `You'll need to unstar this repository directly on GitHub.`
+        );
+      } else {
+        setUnstarError(errorMsg);
+      }
     }
   }
   
@@ -2303,6 +2317,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                       maxWidth={terminalWidth - 6}
                       spacingLines={spacingLines}
                       forkTracking={forkTracking}
+                      starsMode={starsMode}
                     />
                   );
                 })

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -1509,7 +1509,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     }
 
     // Sort modal: show sort options (S key when not in stars mode)
-    if (input && input.toUpperCase() === 'S' && !key.shift) {
+    if (input && input.toUpperCase() === 'S' && !key.shift && !key.ctrl) {
       setSortMode(true);
       return;
     }

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -2,14 +2,14 @@ import React, { useEffect, useMemo, useState, useRef, useCallback } from 'react'
 import { Box, Text, useApp, useInput, useStdout, Spacer, Newline } from 'ink';
 import TextInput from 'ink-text-input';
 import chalk from 'chalk';
-import { makeClient, fetchViewerReposPageUnified, searchRepositoriesUnified, deleteRepositoryRest, archiveRepositoryById, unarchiveRepositoryById, changeRepositoryVisibility, syncForkWithUpstream, getRepositoryFromCache, purgeApolloCacheFiles, inspectCacheStatus, updateCacheAfterDelete, updateCacheAfterArchive, updateCacheAfterVisibilityChange, updateCacheWithRepository, checkOrganizationIsEnterprise, OwnerAffiliation, fetchViewerOrganizations, fetchRestRateLimits, renameRepositoryById, updateCacheAfterRename, getStarredRepositories, unstarRepository } from '../../services/github';
+import { makeClient, fetchViewerReposPageUnified, searchRepositoriesUnified, deleteRepositoryRest, archiveRepositoryById, unarchiveRepositoryById, changeRepositoryVisibility, syncForkWithUpstream, getRepositoryFromCache, purgeApolloCacheFiles, inspectCacheStatus, updateCacheAfterDelete, updateCacheAfterArchive, updateCacheAfterVisibilityChange, updateCacheWithRepository, checkOrganizationIsEnterprise, OwnerAffiliation, fetchViewerOrganizations, fetchRestRateLimits, renameRepositoryById, updateCacheAfterRename, getStarredRepositories, starRepository, unstarRepository } from '../../services/github';
 import { getUIPrefs, storeUIPrefs, OwnerContext } from '../../config/config';
 import { makeApolloKey, makeSearchKey, isFresh, markFetched } from '../../services/apolloMeta';
 import type { RepoNode, RateLimitInfo, RestRateLimitInfo } from '../../types';
 import { exec } from 'child_process';
 import OrgSwitcher from '../OrgSwitcher';
 import { logger } from '../../lib/logger';
-import { DeleteModal, ArchiveModal, SyncModal, InfoModal, LogoutModal, VisibilityModal, SortModal, SortDirectionModal, ChangeVisibilityModal, CopyUrlModal, RenameModal } from '../components/modals';
+import { DeleteModal, ArchiveModal, SyncModal, InfoModal, LogoutModal, VisibilityModal, SortModal, SortDirectionModal, ChangeVisibilityModal, CopyUrlModal, RenameModal, StarModal } from '../components/modals';
 import { UnstarModal } from '../components/modals/UnstarModal';
 import { RepoRow, FilterInput, RepoListHeader } from '../components/repo';
 import { SlowSpinner } from '../components/common';
@@ -175,6 +175,12 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   const [unstarTarget, setUnstarTarget] = useState<RepoNode | null>(null);
   const [unstarring, setUnstarring] = useState(false);
   const [unstarError, setUnstarError] = useState<string | null>(null);
+  
+  // Star modal state (for normal mode)
+  const [starMode, setStarMode] = useState(false);
+  const [starTarget, setStarTarget] = useState<RepoNode | null>(null);
+  const [starring, setStarring] = useState(false);
+  const [starError, setStarError] = useState<string | null>(null);
 
   // Apply initial --org flag once (if provided)
   const appliedInitialOrg = useRef(false);
@@ -337,6 +343,67 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     setUnstarTarget(null);
     setUnstarError(null);
     setUnstarring(false);
+  }
+  
+  // Handle star/unstar action (for normal mode)
+  async function handleStar() {
+    if (!starTarget || starring) return;
+    
+    const isStarred = starTarget.viewerHasStarred;
+    
+    try {
+      setStarring(true);
+      const targetId = (starTarget as any).id;
+      
+      if (isStarred) {
+        await unstarRepository(client, targetId);
+      } else {
+        await starRepository(client, targetId);
+      }
+      
+      // Update the repo in the list
+      const updateRepo = (r: any) => {
+        if (r.id === targetId) {
+          return { ...r, viewerHasStarred: !isStarred, stargazerCount: r.stargazerCount + (isStarred ? -1 : 1) };
+        }
+        return r;
+      };
+      
+      setItems(prev => prev.map(updateRepo));
+      setSearchItems(prev => prev.map(updateRepo));
+      
+      trackSuccessfulOperation();
+      
+      // Close modal
+      setStarMode(false);
+      setStarTarget(null);
+      setStarError(null);
+      setStarring(false);
+    } catch (e: any) {
+      setStarring(false);
+      
+      // Check for OAuth access restriction error
+      const errorMsg = e.message || `Failed to ${isStarred ? 'unstar' : 'star'} repository`;
+      if (errorMsg.includes('OAuth access restrictions')) {
+        const orgMatch = errorMsg.match(/`([^`]+)` organization/);
+        const orgName = orgMatch ? orgMatch[1] : starTarget?.nameWithOwner.split('/')[0];
+        
+        setStarError(
+          `Cannot ${isStarred ? 'unstar' : 'star'}: The ${orgName} organization has OAuth access restrictions. ` +
+          `You'll need to ${isStarred ? 'unstar' : 'star'} this repository directly on GitHub.`
+        );
+      } else {
+        setStarError(errorMsg);
+      }
+    }
+  }
+  
+  // Close star modal
+  function closeStarModal() {
+    setStarMode(false);
+    setStarTarget(null);
+    setStarError(null);
+    setStarring(false);
   }
 
   async function executeSync() {
@@ -1123,6 +1190,16 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return;
     }
 
+    // When in star mode, trap inputs for modal
+    if (starMode) {
+      if (key.escape || (input && input.toUpperCase() === 'C')) {
+        closeStarModal();
+        return;
+      }
+      // Let the StarModal component handle other inputs
+      return;
+    }
+
     // When in sync mode, trap inputs for modal
     if (syncMode) {
       if (key.escape || (input && input.toUpperCase() === 'C')) {
@@ -1471,6 +1548,18 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         setUnstarMode(true);
         setUnstarError(null);
         setUnstarring(false);
+      }
+      return;
+    }
+    
+    // Star/unstar toggle (Shift+U) - only in normal mode
+    if (key.shift && input === 'U' && !starsMode) {
+      const repo = visibleItems[cursor];
+      if (repo) {
+        setStarTarget(repo);
+        setStarMode(true);
+        setStarError(null);
+        setStarring(false);
       }
       return;
     }
@@ -2270,6 +2359,18 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               error={unstarError}
             />
           </Box>
+        ) : starMode && starTarget ? (
+          <Box height={contentHeight} alignItems="center" justifyContent="center">
+            <StarModal
+              visible={starMode}
+              repo={starTarget}
+              isStarred={starTarget.viewerHasStarred || false}
+              onConfirm={handleStar}
+              onCancel={closeStarModal}
+              isStarring={starring}
+              error={starError}
+            />
+          </Box>
         ) : (
           <>
             {/* Context/Filter/sort status */}
@@ -2399,7 +2500,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
           <Text color="gray" dimColor={modalOpen ? true : undefined}>
             {starsMode ? 
               'I Info • C Copy URL • U Unstar Repository' :
-              'I Info • C Copy URL • Ctrl+R Rename • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+S Sync Fork'
+              'I Info • C Copy URL • Shift+U Un/Star • Ctrl+R Rename • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+S Sync Fork'
             }
           </Text>
         </Box>

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -1552,7 +1552,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     return arr;
   }, [filtered, sortKey, sortDir]);
 
-  const searchActive = filter.trim().length >= 3;
+  // In stars mode, we never do GitHub search - just local filtering
+  const searchActive = !starsMode && filter.trim().length >= 3;
   
   // Apply visibility filter to search results too
   const filteredSearchItems = useMemo(() => {
@@ -1569,7 +1570,18 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     return result;
   }, [searchItems, visibilityFilter]);
   
-  const visibleItems = starsMode ? starredItems : (searchActive ? filteredSearchItems : filteredAndSorted);
+  // Apply filter to starred items if in stars mode
+  const filteredStarredItems = useMemo(() => {
+    if (!filter || filter.trim().length === 0) return starredItems;
+    
+    const lowerFilter = filter.toLowerCase();
+    return starredItems.filter(repo => 
+      repo.nameWithOwner.toLowerCase().includes(lowerFilter) ||
+      (repo.description && repo.description.toLowerCase().includes(lowerFilter))
+    );
+  }, [starredItems, filter]);
+  
+  const visibleItems = starsMode ? filteredStarredItems : (searchActive ? filteredSearchItems : filteredAndSorted);
   
   // Debug log
   useEffect(() => {
@@ -2294,7 +2306,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               onSubmit={() => {
                 setFilterMode(false);
               }}
-              placeholder="Type to search (3+ chars for server search)..."
+              placeholder={starsMode ? "Type to filter starred repositories..." : "Type to search (3+ chars for server search)..."}
             />
           </Box>
         )}

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -10,14 +10,18 @@ gh-manager-cli provides a comprehensive set of features for managing your GitHub
 - **Interactive Sorting**: Modal-based sort selection (updated, pushed, name, stars) with direction toggle
 - **Smart Search**: Server-side search through repository names and descriptions (3+ characters)
 - **Visibility Filtering**: Modal-based visibility filter (All, Public, Private/Internal for enterprise) with smart filtering
-- **Fork Status Tracking**: Toggle display of commits behind upstream for forked repositories
+- **Fork Status Tracking**: Always shows commits behind upstream for forked repositories
+- **Stars Mode**: View and manage starred repositories (personal account only)
 - **Repository Actions**:
   - View detailed info (`I`) - Shows repository metadata, language, size, and timestamps
   - Open in browser (Enter/`O`)
   - Delete repository (`Del` or `Backspace`) with secure two-step confirmation
   - Archive/unarchive repositories (`Ctrl+A`) with confirmation prompts
   - Change repository visibility (`Ctrl+V`) - Switch between Public, Private, and Internal (enterprise only)
-  - Sync forks with upstream (`Ctrl+S`) with automatic conflict detection
+  - Star/unstar repositories (`Ctrl+S`) - Toggle star status for any repository
+  - Sync forks with upstream (`Ctrl+F`) with automatic conflict detection
+  - Rename repository (`Ctrl+R`) with inline validation
+  - Copy repository URL to clipboard (`C`) with SSH/HTTPS options
 
 ## User Interface & Experience
 

--- a/wiki/Usage.md
+++ b/wiki/Usage.md
@@ -31,8 +31,9 @@ Launch the app, then use the keys below to navigate and interact with your repos
   - Stars: Number of stars
 - **Sort Direction**: `D` to toggle ascending/descending
 - **Display Density**: `T` to toggle compact/cozy/comfy
-- **Fork Status**: `F` to toggle showing commits behind upstream
+- **Fork Status**: Always enabled - shows commits behind upstream for all forks
 - **Visibility Filter**: `V` opens modal (All, Public, Private/Internal for enterprise)
+- **Stars Mode**: `Shift+S` (personal account only) to view starred repositories
 
 ## Navigation & Account
 
@@ -51,7 +52,10 @@ Launch the app, then use the keys below to navigate and interact with your repos
 - **Delete repository**: `Del` or `Backspace` (with two-step confirmation modal)
   - Type confirmation code → confirm (Y/Enter)
   - Cancel: press `C` or Esc
-- **Sync fork**: `Ctrl+S` (for forks only, shows commit status and handles conflicts)
+- **Star/Unstar**: `Ctrl+S` to toggle star status for any repository
+- **Sync fork**: `Ctrl+F` (for forks only, shows commit status and handles conflicts)
+- **Rename repository**: `Ctrl+R` with inline validation
+- **Copy URL**: `C` to copy repository URL to clipboard (SSH/HTTPS options)
 
 ## General
 


### PR DESCRIPTION
## Summary
This PR implements comprehensive starred repository management functionality, including:
- View starred repositories in a dedicated "Stars Mode" 
- Star/unstar repositories from the main listing
- Visual star indicators for starred repos

## Features Added

### 🌟 Stars Mode (Personal Account Only)
- Toggle with `Shift+S` to enter/exit stars mode
- View all starred repositories with pagination support
- Local filtering/search within starred repos
- Unstar repositories with `U` key and confirmation modal
- Automatically disabled when switching to organization context

### ⭐ Star/Unstar in Normal Mode
- `Ctrl+S` to toggle star status for any repository
- Modal confirmation with current star state
- Handles OAuth access restrictions gracefully
- Updates star icon immediately after action

### 🎯 Visual Indicators
- Star icon (⭐) shown next to starred repository names
- Works in both normal listing and stars mode
- [org] indicator for organization repos in stars mode

### ⌨️ Keyboard Shortcut Updates
- **Star/Unstar**: `Ctrl+S` (was conflicting with Sort, now fixed)
- **Sync Fork**: `Ctrl+F` (moved from Ctrl+S)
- **Fork Status**: Always enabled (removed toggle, was Ctrl+F)

## Technical Implementation
- Added GraphQL queries for fetching starred repositories
- Added star/unstar mutations with Apollo cache updates
- Added `viewerHasStarred` field to all repository queries
- Implemented `StarModal` and `UnstarModal` components
- Enhanced error handling for OAuth App access restrictions

## Bug Fixes
- Fixed pagination for starred repositories
- Fixed down arrow navigation in search filter for stars mode
- Fixed escape key handling with filter in stars mode
- Fixed Ctrl+S conflict with Sort modal trigger
- Added viewerHasStarred to Apollo queries to show star icons

## Documentation
- Updated README.md with all new keyboard shortcuts
- Updated wiki/Usage.md and wiki/Features.md
- Removed outdated fork status toggle documentation

## Testing
- Tested starring/unstarring repositories
- Tested stars mode with pagination
- Tested search/filter in stars mode
- Tested OAuth restriction error handling
- Verified all keyboard shortcuts work correctly

Closes #[issue-number-if-applicable]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Stars Mode to view/manage starred repositories (personal accounts only).
  - Star/Unstar repositories via Ctrl+S with confirmation dialog.
  - Fork sync moved to Ctrl+F.
  - Rename repository with inline validation (Ctrl+R).
  - Copy repository URL to clipboard (C), supporting SSH/HTTPS.
  - Always show commits behind upstream for forks (fork status tracking always on).
  - UI updates for Stars Mode (header label, starred markers, local filtering).

- Documentation
  - Updated onboarding, usage, and feature guides for Stars Mode, new/changed shortcuts, fork status behaviour, and repository actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->