### PR TITLE
fix: add archive filter toggle for repositories [semantic pr title]

### DIFF
--- a/.github/scripts/normalize-pr-title.cjs
+++ b/.github/scripts/normalize-pr-title.cjs
@@ -1,0 +1,349 @@
+#!/usr/bin/env node
+
+/**
+ * Shared script for normalizing PR titles to conventional commit format
+ * Adapted for ra2mp3 bash project - removed project-specific Linear issue references
+ */
+
+// Valid conventional commit types
+const VALID_TYPES = ['feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test', 'build', 'ci', 'chore', 'revert'];
+
+// Regex patterns
+const patterns = {
+  // Strict validation - lowercase types only
+  validFormat: /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+$/,
+  
+  // Case-insensitive validation
+  validFormatInsensitive: /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+$/i,
+  
+  // Extract type, scope, and breaking change (case-insensitive)
+  typeExtraction: /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\((.+?)\))?(!?):\s*(.+)$/i,
+  
+  // Remove existing type prefix (case-insensitive)
+  removePrefix: /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+?\))?!?:\s*/i
+};
+
+/**
+ * Check if a title is valid according to conventional commits
+ */
+function isValidTitle(title) {
+  return patterns.validFormat.test(title) || title.includes('[semantic pr title]');
+}
+
+/**
+ * Check if a title has correct structure but wrong case
+ */
+function needsCaseCorrection(title) {
+  return !patterns.validFormat.test(title) && patterns.validFormatInsensitive.test(title);
+}
+
+/**
+ * Normalize a title that has correct structure but wrong case
+ */
+function normalizeCaseOnly(title) {
+  const match = title.match(patterns.typeExtraction);
+  if (!match) return null;
+  
+  const [, type, , scope, breaking, description] = match;
+  const normalizedType = type.toLowerCase();
+  const normalizedScope = scope ? scope.toLowerCase() : '';
+  const normalizedBreaking = breaking || '';
+  // Preserve proper case in description, only ensure sentence case (first letter lowercase)
+  const normalizedDescription = description.charAt(0).toLowerCase() + description.slice(1);
+  
+  if (scope) {
+    return `${normalizedType}(${normalizedScope})${normalizedBreaking}: ${normalizedDescription}`;
+  } else {
+    return `${normalizedType}${normalizedBreaking}: ${normalizedDescription}`;
+  }
+}
+
+/**
+ * Extract and analyze commit messages
+ */
+function analyzeCommits(commitMessages) {
+  const typeRegex = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\((.+?)\))?(!?):/i;
+  
+  const results = commitMessages
+    .map(msg => {
+      const match = msg.match(typeRegex);
+      if (match) {
+        const [, type, , scope, breaking] = match;
+        const hasBreaking = breaking === '!' || msg.includes('BREAKING CHANGE');
+        return { 
+          type: type.toLowerCase(), 
+          scope: scope ? scope.toLowerCase() : null, 
+          breaking: hasBreaking, 
+          message: msg 
+        };
+      }
+      return null;
+    })
+    .filter(Boolean);
+  
+  const hasBreakingChanges = results.some(result => result.breaking);
+  const types = results.map(result => result.type);
+  const scopes = results.map(result => result.scope).filter(Boolean);
+  
+  return {
+    results,
+    hasBreakingChanges,
+    types,
+    scopes
+  };
+}
+
+/**
+ * Determine primary type based on priority
+ */
+function determinePrimaryType(types, hasBreakingChanges, analysisResults) {
+  if (hasBreakingChanges) {
+    const breakingResult = analysisResults.find(result => result.breaking);
+    return breakingResult ? breakingResult.type : 'feat';
+  }
+  
+  const priorityOrder = ['feat', 'fix', 'refactor', 'docs', 'style', 'test', 'build', 'ci', 'chore'];
+  for (const type of priorityOrder) {
+    if (types.includes(type)) {
+      return type;
+    }
+  }
+  
+  return 'chore';
+}
+
+/**
+ * Determine most common scope
+ */
+function determinePrimaryScope(scopes) {
+  if (scopes.length === 0) return '';
+  
+  const scopeCounts = {};
+  scopes.forEach(scope => {
+    scopeCounts[scope] = (scopeCounts[scope] || 0) + 1;
+  });
+  
+  const totalCommitsWithScope = scopes.length;
+  const mostCommonScope = Object.keys(scopeCounts).reduce((a, b) => 
+    scopeCounts[a] > scopeCounts[b] ? a : b
+  );
+  const mostCommonCount = scopeCounts[mostCommonScope];
+  
+  // Use scope if it appears in more than half of the scoped commits
+  if (mostCommonCount > totalCommitsWithScope / 2) {
+    return mostCommonScope;
+  }
+  
+  return '';
+}
+
+/**
+ * Generate a normalized PR title
+ */
+function generateTitle(currentTitle, commits, branchName) {
+  // First check if we just need case correction
+  if (needsCaseCorrection(currentTitle)) {
+    const normalized = normalizeCaseOnly(currentTitle);
+    if (normalized) return normalized;
+  }
+  
+  // Extract commit information
+  const commitMessages = commits.map(commit => 
+    typeof commit === 'string' ? commit : commit.commit.message.split('\n')[0]
+  );
+  
+  const analysis = analyzeCommits(commitMessages);
+  
+  // No commits - use branch name to determine type
+  if (commits.length === 0) {
+    // Preserve case but ensure sentence case (first letter lowercase)
+    const titleToUse = currentTitle.charAt(0).toLowerCase() + currentTitle.slice(1);
+    if (branchName && branchName.includes('feat')) {
+      return `feat: ${titleToUse}`;
+    } else if (branchName && branchName.includes('fix')) {
+      return `fix: ${titleToUse}`;
+    } else {
+      return `chore: ${titleToUse}`;
+    }
+  }
+  
+  // Single commit with valid format - normalize it
+  if (commits.length === 1 && analysis.results.length === 1) {
+    const result = analysis.results[0];
+    const msgMatch = result.message.match(/^([^:]+):\s*(.+)$/i);
+    if (msgMatch) {
+      const [, prefix, description] = msgMatch;
+      // Preserve case but ensure sentence case (first letter lowercase)
+      const normalizedDescription = description.charAt(0).toLowerCase() + description.slice(1);
+      let newTitle = `${prefix.toLowerCase()}: ${normalizedDescription}`;
+      
+      // Add breaking change indicator if needed
+      if (result.breaking && !newTitle.includes('!')) {
+        newTitle = newTitle.replace(/^(\w+)(\(.+?\))?:/, '$1$2!:');
+      }
+      return newTitle;
+    }
+  }
+  
+  // Multiple commits or complex case
+  const primaryType = determinePrimaryType(analysis.types, analysis.hasBreakingChanges, analysis.results);
+  const primaryScope = determinePrimaryScope(analysis.scopes);
+  
+  // Extract base title and normalize
+  let baseTitle = currentTitle
+    .replace(' [semantic pr title]', '')
+    .replace(patterns.removePrefix, '');
+  // Preserve case but ensure sentence case (first letter lowercase)
+  baseTitle = baseTitle.charAt(0).toLowerCase() + baseTitle.slice(1);
+  
+  // Build the type prefix
+  let typePrefix = primaryType;
+  if (analysis.hasBreakingChanges) {
+    typePrefix += '!';
+  }
+  
+  // Generate descriptive additions for multiple commit types
+  if (analysis.results.length > 1) {
+    const typeGroups = {};
+    analysis.results.forEach(result => {
+      if (!typeGroups[result.type]) typeGroups[result.type] = 0;
+      typeGroups[result.type]++;
+    });
+    
+    const typeDescriptions = [];
+    Object.entries(typeGroups).forEach(([type, count]) => {
+      if (type !== primaryType) {
+        typeDescriptions.push(count > 1 ? `${type} changes` : `${type} change`);
+      }
+    });
+    
+    if (typeDescriptions.length > 0) {
+      const additionalText = typeDescriptions.join(' and ');
+      if (!baseTitle.includes(additionalText)) {
+        baseTitle += ` with ${additionalText}`;
+      }
+    }
+  }
+  
+  // Construct the final title
+  if (primaryScope) {
+    return `${typePrefix}(${primaryScope.toLowerCase()}): ${baseTitle}`;
+  } else {
+    return `${typePrefix}: ${baseTitle}`;
+  }
+}
+
+/**
+ * Ensure title follows conventional format and normalize
+ */
+function ensureValidFormat(title) {
+  // Check if already valid
+  if (patterns.validFormat.test(title)) {
+    return title;
+  }
+  
+  // Try to normalize case if structure is correct
+  if (patterns.validFormatInsensitive.test(title)) {
+    return normalizeCaseOnly(title) || title;
+  }
+  
+  // Try to extract a valid type from the title
+  const typeMatch = title.match(/^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)/i);
+  if (typeMatch) {
+    // Normalize the existing type
+    return title.replace(/^[^:]+/, typeMatch[0].toLowerCase());
+  }
+  
+  // Add chore prefix if no valid type found
+  const desc = title.charAt(0).toLowerCase() + title.slice(1);
+  return `chore: ${desc}`;
+}
+
+/**
+ * Final normalization step
+ */
+function finalNormalize(title) {
+  // Normalize the title: lowercase type/scope but preserve case in description (sentence case)
+  return title.replace(/^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\((.+?)\))?(!?): (.+)$/i, 
+    (match, type, scopeGroup, scope, breaking, description) => {
+      const normalizedType = type.toLowerCase();
+      const normalizedScope = scope ? scope.toLowerCase() : '';
+      const normalizedBreaking = breaking || '';
+      // Preserve case but ensure sentence case (first letter lowercase)
+      const normalizedDescription = description.charAt(0).toLowerCase() + description.slice(1);
+      
+      if (scopeGroup) {
+        return `${normalizedType}(${normalizedScope})${normalizedBreaking}: ${normalizedDescription}`;
+      } else {
+        return `${normalizedType}${normalizedBreaking}: ${normalizedDescription}`;
+      }
+    });
+}
+
+/**
+ * Main function to process PR title
+ */
+function processPRTitle(currentTitle, commits = [], branchName = '') {
+  // Check if already valid AND properly cased
+  if (isValidTitle(currentTitle)) {
+    // Even if valid format, ensure description is lowercased
+    const normalized = finalNormalize(currentTitle);
+    if (normalized === currentTitle) {
+      return { 
+        newTitle: currentTitle, 
+        changed: false,
+        reason: 'already_valid'
+      };
+    } else {
+      // Valid format but needs case normalization
+      return {
+        newTitle: normalized,
+        changed: true,
+        reason: 'case_correction'
+      };
+    }
+  }
+  
+  // Generate new title
+  let newTitle = generateTitle(currentTitle, commits, branchName);
+  
+  // Ensure valid format
+  newTitle = ensureValidFormat(newTitle);
+  
+  // Final normalization
+  newTitle = finalNormalize(newTitle);
+  
+  // Remove trailing periods
+  newTitle = newTitle.replace(/\.$/, '');
+  
+  return {
+    newTitle,
+    changed: newTitle !== currentTitle,
+    reason: needsCaseCorrection(currentTitle) ? 'case_correction' : 'format_correction'
+  };
+}
+
+module.exports = {
+  processPRTitle,
+  isValidTitle,
+  needsCaseCorrection,
+  analyzeCommits,
+  patterns,
+  VALID_TYPES
+};
+
+// CLI interface for testing
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    console.log('Usage: node normalize-pr-title.cjs "<title>" [commits-json] [branch-name]');
+    process.exit(1);
+  }
+
+  const title = args[0];
+  const commits = args[1] ? JSON.parse(args[1]) : [];
+  const branch = args[2] || '';
+
+  const result = processPRTitle(title, commits, branch);
+  console.log(JSON.stringify(result, null, 2));
+}

--- a/.github/workflows/pr-title-manager.yml
+++ b/.github/workflows/pr-title-manager.yml
@@ -119,7 +119,7 @@ jobs:
             // Load the shared normalization script
             const fs = require('fs');
             const path = require('path');
-            const scriptPath = path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/normalize-pr-title.js');
+            const scriptPath = path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/normalize-pr-title.cjs');
             
             // Debug: Check if file exists
             if (!fs.existsSync(scriptPath)) {

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ On first run, you'll be prompted to authenticate with GitHub (OAuth recommended)
 - **Live Pagination**: Infinite scroll with automatic page prefetching
 - **Interactive Sorting**: Modal-based sort selection (updated, pushed, name, stars) with modal-based direction selection
 - **Smart Search**: Server-side search through repository names and descriptions (3+ characters)
-- **Visibility Filtering**: Modal-based visibility filter (All, Public, Private/Internal for enterprise) with smart filtering
+- **Visibility Filter**: Modal-based visibility filter (All, Public, Private/Internal for enterprise) with smart filtering
+- **Archive Filter**: Toggle-based archive filter (`A` key cycles All → Unarchived → Archived) for quick filtering by archive status
 - **Fork Status Tracking**: Always shows commits behind upstream for forked repositories
 - **Stars Mode**: View and manage starred repositories (personal account only)
 - **Repository Actions**:
@@ -102,7 +103,7 @@ On first run, you'll be prompted to authenticate with GitHub (OAuth recommended)
 - **Rate Limit Monitoring**: Dual API rate limit display (GraphQL & REST) with real-time usage deltas and visual warnings
 
 ### Technical Features
-- **Preference Persistence**: UI settings (sort, density, visibility filter, fork tracking) saved between sessions
+- **Preference Persistence**: UI settings (sort, density, visibility filter, archive filter, fork tracking) saved between sessions
 - **Server-side Filtering**: Visibility filtering performed at GitHub API level for accurate pagination
 - **Cross-platform**: Works on macOS, Linux, and Windows
 - **Secure Storage**: Token stored with proper file permissions (0600)
@@ -271,6 +272,7 @@ Launch the app, then use the keys below:
 - **Display Density**: `T` to toggle compact/cozy/comfy
 - **Fork Status**: Always enabled - shows commits behind upstream for all forks
 - **Visibility Filter**: `V` opens modal (All, Public, Private/Internal for enterprise)
+- **Archive Filter**: `A` toggles archive filter (All → Unarchived → Archived)
 - **Stars Mode**: `Shift+S` (personal account only) to view starred repositories
 
 ### Navigation & Account

--- a/src/ui/components/repo/RepoListHeader.tsx
+++ b/src/ui/components/repo/RepoListHeader.tsx
@@ -65,7 +65,7 @@ export default function RepoListHeader({
           Visibility: {visibilityLabel}
         </Text>
       )}
-      {archiveFilter !== 'all' && !starsMode && (
+      {archiveFilter !== 'all' && (
         <Text color="cyan">
           Archive: {archiveFilter === 'archived' ? 'Archived' : 'Unarchived'}
         </Text>

--- a/src/ui/components/repo/RepoListHeader.tsx
+++ b/src/ui/components/repo/RepoListHeader.tsx
@@ -12,6 +12,7 @@ interface RepoListHeaderProps {
   searchActive: boolean;
   searchLoading: boolean;
   visibilityFilter?: 'all' | 'public' | 'private' | 'internal';
+  archiveFilter?: 'all' | 'unarchived' | 'archived';
   isEnterprise?: boolean;
   starsMode?: boolean;
 }
@@ -25,6 +26,7 @@ export default function RepoListHeader({
   searchActive,
   searchLoading,
   visibilityFilter = 'all',
+  archiveFilter = 'all',
   isEnterprise = false,
   starsMode = false
 }: RepoListHeaderProps) {
@@ -61,6 +63,11 @@ export default function RepoListHeader({
       {!!visibilityLabel && !starsMode && (
         <Text color="yellow">
           Visibility: {visibilityLabel}
+        </Text>
+      )}
+      {archiveFilter !== 'all' && !starsMode && (
+        <Text color="cyan">
+          Archive: {archiveFilter === 'archived' ? 'Archived' : 'Unarchived'}
         </Text>
       )}
       {filter && !searchActive && (

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -2477,7 +2477,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         {/* Line 2: Search and filtering */}
         <Box width={terminalWidth} justifyContent="center">
           <Text color="gray" dimColor={modalOpen ? true : undefined}>
-            / Search • S Sort • D Direction • T Density{!starsMode && ' • V Visibility'}{ownerContext === 'personal' && ' • Shift+S Stars'}
+            / Search • S Sort • D Direction • T Density{!starsMode && ' • V Visibility Filter'}{ownerContext === 'personal' && ' • Shift+S Stars'}
           </Text>
         </Box>
         {/* Line 3: Repository actions */}

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -1762,8 +1762,12 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   useEffect(() => {
     const prefetchThreshold = Math.floor(visibleItems.length * 0.8);
     const nearEnd = visibleItems.length > 0 && cursor >= prefetchThreshold;
-    // When an archive filter is active and all loaded items are filtered out, keep fetching
-    const filterDrainedPage = visibleItems.length === 0 && archiveFilter !== 'all';
+    // Raw (pre-filter) list length for the active mode — guards against firing during a context
+    // switch where items was cleared to [] before loading was set to true.
+    const rawItemsLength = starsMode ? starredItems.length : searchActive ? searchItems.length : items.length;
+    // When an archive filter is active and all loaded items are filtered out, keep fetching.
+    // Require rawItemsLength > 0 to avoid a spurious fetch on stale hasNextPage/endCursor.
+    const filterDrainedPage = visibleItems.length === 0 && archiveFilter !== 'all' && rawItemsLength > 0;
     const shouldFetch = nearEnd || filterDrainedPage;
 
     if (starsMode) {
@@ -1783,7 +1787,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cursor, visibleItems.length, archiveFilter, starsMode, starredLoading, starredHasNextPage, starredEndCursor, searchActive, searchLoading, searchHasNextPage, searchEndCursor, loading, loadingMore, hasNextPage, endCursor]);
+  }, [cursor, visibleItems.length, archiveFilter, items.length, starredItems.length, searchItems.length, starsMode, starredLoading, starredHasNextPage, starredEndCursor, searchActive, searchLoading, searchHasNextPage, searchEndCursor, loading, loadingMore, hasNextPage, endCursor]);
 
   // Helper: open URL in default browser (cross-platform best-effort)
   function openInBrowser(url: string) {

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -728,6 +728,10 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   const [visibilityFilter, setVisibilityFilter] = useState<VisibilityFilter>('all');
   const previousVisibilityFilter = useRef<VisibilityFilter>('all');
 
+  // Archive filter - 'all' | 'unarchived' | 'archived'
+  type ArchiveFilter = 'all' | 'unarchived' | 'archived';
+  const [archiveFilter, setArchiveFilter] = useState<ArchiveFilter>('all');
+
   // Map our sort keys to GitHub's GraphQL field names
   const sortFieldMap: Record<SortKey, string> = {
     'updated': 'UPDATED_AT',
@@ -937,6 +941,11 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     // Load visibility filter
     if (ui.visibilityFilter && ['all', 'public', 'private', 'internal'].includes(ui.visibilityFilter)) {
       setVisibilityFilter(ui.visibilityFilter as VisibilityFilter);
+    }
+
+    // Load archive filter
+    if (ui.archiveFilter && ['all', 'unarchived', 'archived'].includes(ui.archiveFilter)) {
+      setArchiveFilter(ui.archiveFilter as ArchiveFilter);
     }
     
     // Load organization context
@@ -1588,7 +1597,18 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     }
 
     // Fork tracking is now always on - removed toggle
-    
+
+    // Archive filter toggle (A) - cycle All → Unarchived → Archived
+    if (input && input.toUpperCase() === 'A' && !key.ctrl) {
+      setArchiveFilter(f => {
+        const next: ArchiveFilter = f === 'all' ? 'unarchived' : f === 'unarchived' ? 'archived' : 'all';
+        storeUIPrefs({ archiveFilter: next });
+        return next;
+      });
+      setCursor(0);
+      return;
+    }
+
     // Open visibility filter modal (V) - disabled in stars mode
     if (input && input.toUpperCase() === 'V') {
       if (!starsMode) {
@@ -1612,6 +1632,13 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     }
     // Note: Public filtering is done at the API level and works correctly
     
+    // Apply archive filter
+    if (archiveFilter === 'archived') {
+      result = result.filter(r => r.isArchived);
+    } else if (archiveFilter === 'unarchived') {
+      result = result.filter(r => !r.isArchived);
+    }
+
     // Apply text filter
     const q = filter.trim().toLowerCase();
     if (q) {
@@ -1620,9 +1647,9 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         (r.description ? r.description.toLowerCase().includes(q) : false)
       );
     }
-    
+
     return result;
-  }, [items, filter, visibilityFilter]);
+  }, [items, filter, visibilityFilter, archiveFilter]);
 
   const filteredAndSorted = useMemo(() => {
     const arr = [...filtered];
@@ -1651,28 +1678,43 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   // Apply visibility filter to search results too
   const filteredSearchItems = useMemo(() => {
     let result = searchItems;
-    
+
     // Match GitHub's behavior: Private filter includes both PRIVATE and INTERNAL
     if (visibilityFilter === 'private') {
-      // Show both PRIVATE and INTERNAL repos (matching GitHub's behavior)
       result = result.filter(r => r.visibility === 'PRIVATE' || r.visibility === 'INTERNAL');
     } else if (visibilityFilter === 'public') {
       result = result.filter(r => r.visibility === 'PUBLIC');
     }
-    
+
+    if (archiveFilter === 'archived') {
+      result = result.filter(r => r.isArchived);
+    } else if (archiveFilter === 'unarchived') {
+      result = result.filter(r => !r.isArchived);
+    }
+
     return result;
-  }, [searchItems, visibilityFilter]);
+  }, [searchItems, visibilityFilter, archiveFilter]);
   
   // Apply filter to starred items if in stars mode
   const filteredStarredItems = useMemo(() => {
-    if (!filter || filter.trim().length === 0) return starredItems;
-    
-    const lowerFilter = filter.toLowerCase();
-    return starredItems.filter(repo => 
-      repo.nameWithOwner.toLowerCase().includes(lowerFilter) ||
-      (repo.description && repo.description.toLowerCase().includes(lowerFilter))
-    );
-  }, [starredItems, filter]);
+    let result = starredItems;
+
+    if (filter && filter.trim().length > 0) {
+      const lowerFilter = filter.toLowerCase();
+      result = result.filter(repo =>
+        repo.nameWithOwner.toLowerCase().includes(lowerFilter) ||
+        (repo.description && repo.description.toLowerCase().includes(lowerFilter))
+      );
+    }
+
+    if (archiveFilter === 'archived') {
+      result = result.filter(r => r.isArchived);
+    } else if (archiveFilter === 'unarchived') {
+      result = result.filter(r => !r.isArchived);
+    }
+
+    return result;
+  }, [starredItems, filter, archiveFilter]);
   
   const visibleItems = starsMode ? filteredStarredItems : (searchActive ? filteredSearchItems : filteredAndSorted);
   
@@ -2368,6 +2410,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               searchActive={searchActive}
               searchLoading={searchLoading}
               visibilityFilter={visibilityFilter}
+              archiveFilter={archiveFilter}
               isEnterprise={isEnterpriseOrg}
               starsMode={starsMode}
             />
@@ -2477,7 +2520,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         {/* Line 2: Search and filtering */}
         <Box width={terminalWidth} justifyContent="center">
           <Text color="gray" dimColor={modalOpen ? true : undefined}>
-            / Search • S Sort • D Direction • T Density{!starsMode && ' • V Visibility Filter'}{ownerContext === 'personal' && ' • Shift+S Stars'}
+            / Search • S Sort • D Direction • T Density • A Archive{!starsMode && ' • V Visibility Filter'}{ownerContext === 'personal' && ' • Shift+S Stars'}
           </Text>
         </Box>
         {/* Line 3: Repository actions */}

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -1758,30 +1758,32 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     return { start, end };
   }, [visibleItems.length, cursor, listHeight, spacingLines]);
 
-  // Infinite scroll: prefetch when at 80% of loaded items
+  // Infinite scroll: prefetch when at 80% of loaded items, or immediately when filter hides all loaded items
   useEffect(() => {
-    // Trigger prefetch when cursor reaches 80% of the loaded items
     const prefetchThreshold = Math.floor(visibleItems.length * 0.8);
     const nearEnd = visibleItems.length > 0 && cursor >= prefetchThreshold;
-    
+    // When an archive filter is active and all loaded items are filtered out, keep fetching
+    const filterDrainedPage = visibleItems.length === 0 && archiveFilter !== 'all';
+    const shouldFetch = nearEnd || filterDrainedPage;
+
     if (starsMode) {
-      if (!starredLoading && starredHasNextPage && nearEnd) {
+      if (!starredLoading && starredHasNextPage && shouldFetch) {
         addDebugMessage(`[Infinite Scroll] Prefetching starred repos at ${cursor}/${visibleItems.length} (80% threshold: ${prefetchThreshold})`);
         fetchStarredRepositories(starredEndCursor);
       }
     } else if (searchActive) {
-      if (!searchLoading && searchHasNextPage && nearEnd) {
+      if (!searchLoading && searchHasNextPage && shouldFetch) {
         addDebugMessage(`[Infinite Scroll] Prefetching search results at ${cursor}/${visibleItems.length} (80% threshold: ${prefetchThreshold})`);
         fetchSearchPage(searchEndCursor);
       }
     } else {
-      if (!loading && !loadingMore && hasNextPage && nearEnd) {
+      if (!loading && !loadingMore && hasNextPage && shouldFetch) {
         addDebugMessage(`[Infinite Scroll] Prefetching repos at ${cursor}/${visibleItems.length} (80% threshold: ${prefetchThreshold})`);
         fetchPage(endCursor);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cursor, visibleItems.length, starsMode, starredLoading, starredHasNextPage, starredEndCursor, searchActive, searchLoading, searchHasNextPage, searchEndCursor, loading, loadingMore, hasNextPage, endCursor]);
+  }, [cursor, visibleItems.length, archiveFilter, starsMode, starredLoading, starredHasNextPage, starredEndCursor, searchActive, searchLoading, searchHasNextPage, searchEndCursor, loading, loadingMore, hasNextPage, endCursor]);
 
   // Helper: open URL in default browser (cross-platform best-effort)
   function openInBrowser(url: string) {


### PR DESCRIPTION
Closes #42

## Summary
Adds a new archive filter feature that allows users to quickly toggle between viewing all repositories, only unarchived repositories, or only archived repositories. The filter is accessible via the `A` key and cycles through the three states.

## Key Changes
- **Archive Filter State**: Added `archiveFilter` state with three modes: 'all', 'unarchived', 'archived'
- **Keyboard Shortcut**: Implemented `A` key binding to cycle through archive filter states (All → Unarchived → Archived)
- **Filter Application**: Applied archive filtering to all three repository lists:
  - Main filtered list (filtered items)
  - Search results (filteredSearchItems)
  - Starred repositories (filteredStarredItems)
- **Persistence**: Archive filter preference is saved and restored between sessions via `storeUIPrefs()`
- **UI Updates**: 
  - Added archive filter status display in RepoListHeader component
  - Updated help text to show `A` key for archive filter and clarified visibility filter as "Visibility Filter"
  - Updated README documentation to describe the new archive filter feature
- **Component Props**: Passed `archiveFilter` prop to RepoListHeader for display

## Implementation Details
- Archive filtering uses the `isArchived` property on repository objects
- The filter respects all existing filtering modes (visibility, search, text filter)
- Archive filter is applied consistently across all view modes (normal, search, stars)
- Cursor resets to top when filter changes for better UX
- Filter state is included in dependency arrays for all affected useMemo hooks

https://claude.ai/code/session_01TBo1H9kh42DFcrQ7bfUVjv

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing list filtering and pagination tweaks only; no auth or API contract changes beyond existing repo fetch paths.
> 
> **Overview**
> Adds an **archive filter** to the repository list so users can cycle **All → Unarchived → Archived** with **`A`**, with the choice **persisted** in UI prefs and shown in the header when not “all.”
> 
> Filtering uses **`isArchived`** on the main list, search results, and starred repos. **Infinite scroll** now also prefetches when an archive filter hides every loaded row but more pages exist (guarded so empty context switches don’t trigger bad fetches).
> 
> **README** and footer help text document the shortcut; visibility help is labeled **“Visibility Filter.”**
> 
> CI: introduces **`.github/scripts/normalize-pr-title.cjs`** and points **PR Title Manager** at that **`.cjs`** path instead of **`.js`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e24cb209a6a0b379118f71e47a5206a7177be41d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->