### PR TITLE
feat: replace archive filter cycle with popup modal (A Archive Filter) [semantic pr title]

### DIFF
--- a/src/ui/components/modals/ArchiveFilterModal.tsx
+++ b/src/ui/components/modals/ArchiveFilterModal.tsx
@@ -1,0 +1,128 @@
+import React, { useState, useEffect } from 'react';
+import { Box, Text, useInput } from 'ink';
+import chalk from 'chalk';
+
+type ArchiveFilter = 'all' | 'unarchived' | 'archived';
+
+interface ArchiveFilterModalProps {
+  currentFilter: ArchiveFilter;
+  onSelect: (filter: ArchiveFilter) => void;
+  onCancel: () => void;
+}
+
+export default function ArchiveFilterModal({
+  currentFilter,
+  onSelect,
+  onCancel,
+}: ArchiveFilterModalProps) {
+  const options: ArchiveFilter[] = ['all', 'unarchived', 'archived'];
+
+  const [focusedOption, setFocusedOption] = useState<ArchiveFilter | 'cancel'>(currentFilter);
+
+  useEffect(() => {
+    setFocusedOption(currentFilter);
+  }, [currentFilter]);
+
+  useInput((input, key) => {
+    if (key.escape || (input && input.toUpperCase() === 'C')) {
+      onCancel();
+      return;
+    }
+
+    if (key.leftArrow || key.upArrow) {
+      if (focusedOption === 'cancel') {
+        const lastIndex = options.length - 1;
+        setFocusedOption(options[lastIndex]);
+      } else {
+        const idx = options.indexOf(focusedOption as ArchiveFilter);
+        if (idx > 0) setFocusedOption(options[idx - 1]);
+      }
+    }
+
+    if (key.rightArrow || key.downArrow) {
+      if (focusedOption !== 'cancel') {
+        const idx = options.indexOf(focusedOption as ArchiveFilter);
+        if (idx < options.length - 1) {
+          setFocusedOption(options[idx + 1]);
+        } else {
+          setFocusedOption('cancel');
+        }
+      }
+    }
+
+    if (key.tab) {
+      if (focusedOption === 'cancel') {
+        setFocusedOption(options[0]);
+      } else {
+        const idx = options.indexOf(focusedOption as ArchiveFilter);
+        if (idx < options.length - 1) {
+          setFocusedOption(options[idx + 1]);
+        } else {
+          setFocusedOption('cancel');
+        }
+      }
+    }
+
+    if (key.return) {
+      if (focusedOption === 'cancel') {
+        onCancel();
+      } else {
+        onSelect(focusedOption as ArchiveFilter);
+      }
+    }
+
+    // Quick select shortcuts
+    if (input) {
+      const u = input.toUpperCase();
+      if (u === 'L') onSelect('all');
+      else if (u === 'U') onSelect('unarchived');
+      else if (u === 'R') onSelect('archived');
+    }
+  });
+
+  const getLabel = (filter: ArchiveFilter): string => {
+    switch (filter) {
+      case 'all': return 'All Repositories';
+      case 'unarchived': return 'Unarchived Only';
+      case 'archived': return 'Archived Only';
+    }
+  };
+
+  const getColor = (filter: ArchiveFilter): string => {
+    if (filter === currentFilter) return 'green';
+    return focusedOption === filter ? 'cyan' : 'gray';
+  };
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={2} paddingY={1} width={45}>
+      <Text bold>Archive Filter</Text>
+
+      <Box flexDirection="column" marginTop={1}>
+        {options.map((option) => (
+          <Box key={option} paddingX={1}>
+            <Text>
+              {focusedOption === option ? chalk.bgCyan.black(' → ') : '   '}
+              {focusedOption === option
+                ? chalk[getColor(option)].bold(getLabel(option))
+                : chalk[getColor(option)](getLabel(option))}
+              {option === currentFilter && chalk.green(' ✓')}
+            </Text>
+          </Box>
+        ))}
+
+        <Box paddingX={1}>
+          <Text>
+            {focusedOption === 'cancel' ? chalk.bgWhite.black(' → ') : '   '}
+            {focusedOption === 'cancel' ? chalk.white.bold('Cancel') : chalk.gray('Cancel')}
+          </Text>
+        </Box>
+      </Box>
+
+      <Box marginTop={1}>
+        <Text color="gray" dimColor>
+          ↑↓/Enter • L All • U Unarchived • R Archived • Esc
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/components/modals/index.ts
+++ b/src/ui/components/modals/index.ts
@@ -1,3 +1,4 @@
+export { default as ArchiveFilterModal } from './ArchiveFilterModal';
 export { default as DeleteModal } from './DeleteModal';
 export { default as ArchiveModal } from './ArchiveModal';
 export { default as SyncModal } from './SyncModal';

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -9,7 +9,7 @@ import type { RepoNode, RateLimitInfo, RestRateLimitInfo } from '../../types';
 import { exec } from 'child_process';
 import OrgSwitcher from '../OrgSwitcher';
 import { logger } from '../../lib/logger';
-import { DeleteModal, ArchiveModal, SyncModal, InfoModal, LogoutModal, VisibilityModal, SortModal, SortDirectionModal, ChangeVisibilityModal, CopyUrlModal, RenameModal, StarModal } from '../components/modals';
+import { ArchiveFilterModal, DeleteModal, ArchiveModal, SyncModal, InfoModal, LogoutModal, VisibilityModal, SortModal, SortDirectionModal, ChangeVisibilityModal, CopyUrlModal, RenameModal, StarModal } from '../components/modals';
 import { UnstarModal } from '../components/modals/UnstarModal';
 import { RepoRow, FilterInput, RepoListHeader } from '../components/repo';
 import { SlowSpinner } from '../components/common';
@@ -146,6 +146,9 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   const [logoutMode, setLogoutMode] = useState(false);
   const [logoutFocus, setLogoutFocus] = useState<'confirm' | 'cancel'>('confirm');
   const [logoutError, setLogoutError] = useState<string | null>(null);
+
+  // Archive filter modal state
+  const [archiveFilterMode, setArchiveFilterMode] = useState(false);
 
   // Visibility modal state
   const [visibilityMode, setVisibilityMode] = useState(false);
@@ -1280,6 +1283,11 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return; // CopyUrlModal component handles its own keyboard input
     }
     
+    // When archive filter modal is open, trap inputs for modal
+    if (archiveFilterMode) {
+      return; // ArchiveFilterModal component handles its own keyboard input
+    }
+
     // When visibility modal is open, trap inputs for modal
     if (visibilityMode) {
       return; // VisibilityModal component handles its own keyboard input
@@ -1598,14 +1606,9 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
 
     // Fork tracking is now always on - removed toggle
 
-    // Archive filter toggle (A) - cycle All → Unarchived → Archived
+    // Open archive filter modal (A)
     if (input && input.toUpperCase() === 'A' && !key.ctrl) {
-      setArchiveFilter(f => {
-        const next: ArchiveFilter = f === 'all' ? 'unarchived' : f === 'unarchived' ? 'archived' : 'all';
-        storeUIPrefs({ archiveFilter: next });
-        return next;
-      });
-      setCursor(0);
+      setArchiveFilterMode(true);
       return;
     }
 
@@ -1798,7 +1801,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
 
   const lowRate = (rateLimit && rateLimit.remaining <= Math.ceil(rateLimit.limit * 0.1)) || 
                    (restRateLimit && restRateLimit.core.remaining <= Math.ceil(restRateLimit.core.limit * 0.1));
-  const modalOpen = deleteMode || archiveMode || syncMode || logoutMode || infoMode || visibilityMode || sortMode || sortDirectionMode || changeVisibilityMode || copyUrlMode || renameMode;
+  const modalOpen = deleteMode || archiveMode || syncMode || logoutMode || infoMode || visibilityMode || archiveFilterMode || sortMode || sortDirectionMode || changeVisibilityMode || copyUrlMode || renameMode;
 
   // Memoize header to prevent re-renders - must be before any returns
   const headerBar = useMemo(() => (
@@ -2307,6 +2310,19 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               );
             })()}
           </Box>
+        ) : archiveFilterMode ? (
+          <Box height={contentHeight} alignItems="center" justifyContent="center">
+            <ArchiveFilterModal
+              currentFilter={archiveFilter}
+              onSelect={(filter) => {
+                setArchiveFilter(filter);
+                setArchiveFilterMode(false);
+                setCursor(0);
+                storeUIPrefs({ archiveFilter: filter });
+              }}
+              onCancel={() => setArchiveFilterMode(false)}
+            />
+          </Box>
         ) : visibilityMode ? (
           <Box height={contentHeight} alignItems="center" justifyContent="center">
             <VisibilityModal
@@ -2526,7 +2542,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         {/* Line 2: Search and filtering */}
         <Box width={terminalWidth} justifyContent="center">
           <Text color="gray" dimColor={modalOpen ? true : undefined}>
-            / Search • S Sort • D Direction • T Density • A Archive{!starsMode && ' • V Visibility Filter'}{ownerContext === 'personal' && ' • Shift+S Stars'}
+            / Search • S Sort • D Direction • T Density • A Archive Filter{!starsMode && ' • V Visibility Filter'}{ownerContext === 'personal' && ' • Shift+S Stars'}
           </Text>
         </Box>
         {/* Line 3: Repository actions */}


### PR DESCRIPTION
## Summary
Replaces the cycling archive filter behavior (A key) with an interactive modal dialog that allows users to select between "All Repositories", "Unarchived Only", and "Archived Only" options.

## Key Changes
- **New Component:** Added `ArchiveFilterModal.tsx` - a dedicated modal component for selecting archive filters with keyboard navigation support
  - Supports arrow keys (↑↓) and tab navigation between options
  - Quick-select shortcuts: L (All), U (Unarchived), R (Archived)
  - Displays current filter selection with a checkmark
  - Escape key or 'C' to cancel
  
- **Updated RepoList.tsx:**
  - Added `archiveFilterMode` state to manage modal visibility
  - Changed 'A' key behavior from cycling filters to opening the modal
  - Integrated modal rendering in the main UI layout
  - Added input trapping when modal is open to prevent background interactions
  - Updated help text from "A Archive" to "A Archive Filter"
  - Added modal to the `modalOpen` state check

- **Updated exports:** Added `ArchiveFilterModal` to the modals index for easy importing

## Implementation Details
The modal provides a more discoverable and user-friendly interface for archive filtering compared to the previous cycling behavior. Users can now see all available options at once and understand what each filter does. The modal maintains the current filter selection and provides visual feedback during navigation.

https://claude.ai/code/session_01TBo1H9kh42DFcrQ7bfUVjv

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to how archive filtering is selected; filtering logic and prefs persistence stay the same pattern as visibility.
> 
> **Overview**
> Replaces **A** key **cycling** through archive filters with an **interactive modal** aligned with the existing visibility filter UX.
> 
> Adds **`ArchiveFilterModal`**: choose **All**, **Unarchived only**, or **Archived only** via arrows/tab/Enter, shortcuts **L** / **U** / **R**, and Esc/**C** to dismiss; shows the active filter with a checkmark.
> 
> **`RepoList`** opens the modal on **A** (without Ctrl), traps keyboard input while open, persists the choice via **`storeUIPrefs`**, resets the list cursor on change, and updates help text to **A Archive Filter**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9069b036aca8c31e6103bbe9aeee39c7d93b5c0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->