### PR TITLE
fix: restore changelog body in GitHub release notes [semantic pr title]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,6 +184,7 @@ jobs:
           # testing for the next version heading.
           if [ -f "CHANGELOG.md" ]; then
             CHANGELOG=$(awk -v ver="$VERSION" '
+              BEGIN { gsub(/\./, "\\.", ver) }   # match version dots literally, not as regex wildcards
               !started && $0 ~ ("^#+ \\[?" ver "\\]?") { started=1; print; next }
               started && /^#+ \[?[0-9]+\.[0-9]+\.[0-9]+\]?/ { exit }
               started { print }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,13 +177,19 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "Version: ${VERSION}"
           
-          # Extract changelog for this version
+          # Extract changelog for this version.
+          # NOTE: a naive awk range "/start/,/end/" collapses to a single line here,
+          # because the version's own heading also matches the generic version-number
+          # end pattern. Use a flag-based scan that consumes the start heading before
+          # testing for the next version heading.
           if [ -f "CHANGELOG.md" ]; then
-            # Extract content between this version and the previous version
-            CHANGELOG=$(awk "/^#+ \[?${VERSION}\]?/,/^#+ \[?[0-9]+\.[0-9]+\.[0-9]+\]?/" CHANGELOG.md | head -n -1)
+            CHANGELOG=$(awk -v ver="$VERSION" '
+              !started && $0 ~ ("^#+ \\[?" ver "\\]?") { started=1; print; next }
+              started && /^#+ \[?[0-9]+\.[0-9]+\.[0-9]+\]?/ { exit }
+              started { print }
+            ' CHANGELOG.md)
             if [ -z "$CHANGELOG" ]; then
-              # Fallback: try to get content after version heading
-              CHANGELOG=$(awk "/^#+ \[?${VERSION}\]?/,/^$/{print}" CHANGELOG.md)
+              CHANGELOG="# Release v${VERSION}"
             fi
             # Save to file for GitHub release
             echo "$CHANGELOG" > release_notes.md


### PR DESCRIPTION
## Problem

GitHub releases have shown only the version heading (no changelog body) since **v1.36.0** — e.g. [v1.38.1](https://github.com/wiiiimm/gh-manager-cli/releases).

## Root cause

The `create-release` job (added in v1.36.0) builds release notes from `CHANGELOG.md`:

```bash
CHANGELOG=$(awk "/^#+ \[?${VERSION}\]?/,/^#+ \[?[0-9]+\.[0-9]+\.[0-9]+\]?/" CHANGELOG.md | head -n -1)
```

This is a classic `awk` range bug. In `awk '/start/,/end/'`, the `end` pattern is tested **on the same line** that matched `start`. The version's own heading — e.g. `# [1.36.0](…compare/v1.35.1...v1.36.0)` — matches the generic `[0-9]+\.[0-9]+\.[0-9]+` end pattern via the `…v1.36.0)` part. So the range collapses to **just the heading line**, `head -n -1` strips it → empty, and the fallback (which stops at the first blank line under the heading) keeps **only the heading**.

Timeline matches exactly: ≤ v1.35.0 full changelogs (older mechanism), v1.35.1 empty (transition), v1.36.0+ heading-only (this broken job).

A secondary latent bug: `head -n -1` is GNU-only and errors on BSD/macOS `head`.

## Fix

Replace the range with a flag-based scan that consumes the start heading before testing for the next version heading, and drop the GNU-only `head -n -1`. Verified locally that it produces the correct body for v1.36.0–v1.38.1.

## Notes

- Only affects **future** releases. Existing v1.36.0–v1.38.1 bodies can be backfilled separately with `gh release edit vX.Y.Z --notes-file …` if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-pipeline-only change to how `release_notes.md` is built; no runtime app or auth behavior changes.
> 
> **Overview**
> Fixes **GitHub release notes** in the `create-release` job so future releases include the full changelog section from `CHANGELOG.md`, not just the version heading.
> 
> The old `awk '/start/,/end/'` range plus `head -n -1` collapsed because the current version heading also matches the generic “next version” pattern (e.g. via `…v1.36.0)` in compare links). The workflow now uses a **flag-based `awk` scan**: match the exact version heading (with dots escaped), print through the body, then stop at the next semver heading. **GNU-only `head -n -1` and the blank-line fallback** are removed; if extraction is empty, notes fall back to `# Release v${VERSION}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dea7e89a325df4aee12883529cc7a44131a6799f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced the stability of changelog extraction in the release workflow for improved reliability during version releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->