### PR TITLE
feat: complete fork→upstream linking (SWR-352) [semantic pr title]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,8 @@ See the living roadmap in [TODOs.md](./TODOs.md) for the canonical, up-to-date l
 - `F`: toggle fork commit tracking
 - `V`: visibility filter modal (All, Public, Private/Internal)
 - `W`: organization switcher
-- Enter or `O`: open selected repo in browser
+- Enter or `O`: open selected repo in browser (for forks: shows chooser — this repo vs parent/upstream; Esc cancels)
+- `P`: jump to upstream parent of the selected fork (moves cursor if parent is visible; otherwise fetches and shows parent in Info modal)
 - `I`: repository info modal
 - `K`: cache inspection
 - `Del` or `Backspace`: delete selected repo (two-stage confirmation)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [Unreleased]
+
+### Added
+
+* Fork rows now show commits **ahead** as well as behind upstream when fork tracking is enabled ([SWR-352](https://linear.app/stealths/issue/SWR-352))
+* `P` key on a fork row jumps cursor to the upstream parent if visible; otherwise fetches and shows the parent in the Info modal ([SWR-352](https://linear.app/stealths/issue/SWR-352))
+* Enter / `O` on a fork now shows a chooser (this repo vs parent/upstream); non-fork repos open directly as before ([SWR-352](https://linear.app/stealths/issue/SWR-352))
+
 ## [1.39.1](https://github.com/wiiiimm/gh-manager-cli/compare/v1.39.0...v1.39.1) (2026-06-05)
 
 

--- a/README.md
+++ b/README.md
@@ -78,11 +78,12 @@ On first run, you'll be prompted to authenticate with GitHub (OAuth recommended)
 - **Smart Search**: Server-side search through repository names and descriptions (3+ characters)
 - **Visibility Filter**: Modal-based visibility filter (All, Public, Private/Internal for enterprise) with smart filtering
 - **Archive Filter**: Toggle-based archive filter (`A` key cycles All → Unarchived → Archived) for quick filtering by archive status
-- **Fork Status Tracking**: Always shows commits behind upstream for forked repositories
+- **Fork Status Tracking**: Always shows commits ahead/behind upstream for forked repositories
 - **Stars Mode**: View and manage starred repositories (personal account only)
 - **Repository Actions**:
   - View detailed info (`I`) - Shows repository metadata, language, size, and timestamps
-  - Open in browser (Enter/`O`)
+  - Open in browser (Enter/`O`) — fork repos show a chooser (this repo vs upstream)
+  - Jump to upstream parent (`P`) — moves cursor to parent if loaded, otherwise fetches and shows in Info modal
   - Rename repository (`Ctrl+R`) with inline validation and automatic cache update
   - Copy repository URL to clipboard (`C`) with SSH/HTTPS options
   - Delete repository (`Del` or `Backspace`) with secure two-step confirmation
@@ -270,13 +271,14 @@ Launch the app, then use the keys below:
   - Stars: Number of stars
 - **Sort Direction**: `D` to open sort direction modal (ascending/descending)
 - **Display Density**: `T` to toggle compact/cozy/comfy
-- **Fork Status**: Always enabled - shows commits behind upstream for all forks
+- **Fork Status**: Always enabled - shows commits ahead/behind upstream for all forks
 - **Visibility Filter**: `V` opens modal (All, Public, Private/Internal for enterprise)
 - **Archive Filter**: `A` toggles archive filter (All → Unarchived → Archived)
 - **Stars Mode**: `Shift+S` (personal account only) to view starred repositories
 
 ### Navigation & Account
-- **Open in browser**: Enter or `O`
+- **Open in browser**: Enter or `O` — for non-fork repos opens directly; for forks shows a chooser (this repository vs parent/upstream); Esc cancels
+- **Jump to upstream**: `P` — on a fork row, moves cursor to the upstream parent if it is in the loaded list; otherwise fetches the parent and shows it in the Info modal
 - **Refresh**: `R`
 - **Organization switcher**: `W` to switch between personal account and organizations
 - **Logout**: `Ctrl+L`

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -1083,6 +1083,63 @@ export async function getRepositoryFromCache(token: string, repositoryId: string
   }
 }
 
+export async function fetchRepositoryByOwnerName(
+  client: ReturnType<typeof makeClient>,
+  owner: string,
+  name: string,
+  includeForkTracking: boolean = true
+): Promise<RepoNode | null> {
+  const query = /* GraphQL */ `
+    query GetRepositoryByOwnerName($owner: String!, $name: String!, $includeForkTracking: Boolean!) {
+      repository(owner: $owner, name: $name) {
+        id
+        name
+        nameWithOwner
+        description
+        pushedAt
+        updatedAt
+        isPrivate
+        isArchived
+        isFork
+        visibility
+        stargazerCount
+        forkCount
+        diskUsage
+        primaryLanguage {
+          name
+          color
+        }
+        parent @include(if: $includeForkTracking) {
+          nameWithOwner
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                history(first: 0) {
+                  totalCount
+                }
+              }
+            }
+          }
+        }
+        defaultBranchRef @include(if: $includeForkTracking) {
+          name
+          target {
+            ... on Commit {
+              history(first: 0) {
+                totalCount
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const result: any = await client(query, { owner, name, includeForkTracking });
+  return result.repository as RepoNode | null;
+}
+
 export async function fetchRepositoryById(
   client: ReturnType<typeof makeClient>,
   repositoryId: string,

--- a/src/ui/components/modals/OpenInBrowserModal.tsx
+++ b/src/ui/components/modals/OpenInBrowserModal.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import chalk from 'chalk';
+import type { RepoNode } from '../../../types';
+
+interface OpenInBrowserModalProps {
+  repo: RepoNode;
+  terminalWidth: number;
+  onOpen: (url: string) => void;
+  onClose: () => void;
+}
+
+type Choice = 'fork' | 'parent';
+
+export default function OpenInBrowserModal({ repo, terminalWidth, onOpen, onClose }: OpenInBrowserModalProps) {
+  const [selected, setSelected] = useState<Choice>('fork');
+
+  const forkUrl = `https://github.com/${repo.nameWithOwner}`;
+  const parentUrl = repo.parent ? `https://github.com/${repo.parent.nameWithOwner}` : null;
+
+  useInput((input, key) => {
+    if (key.escape || input?.toLowerCase() === 'q') {
+      onClose();
+      return;
+    }
+    if (key.upArrow || key.leftArrow) {
+      setSelected('fork');
+      return;
+    }
+    if (key.downArrow || key.rightArrow) {
+      setSelected('parent');
+      return;
+    }
+    if (key.return || input?.toLowerCase() === 'y') {
+      const url = selected === 'fork' ? forkUrl : parentUrl;
+      if (url) onOpen(url);
+      onClose();
+      return;
+    }
+    if (input?.toLowerCase() === 'f') {
+      onOpen(forkUrl);
+      onClose();
+      return;
+    }
+    if (input?.toLowerCase() === 'p' && parentUrl) {
+      onOpen(parentUrl);
+      onClose();
+      return;
+    }
+  });
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="blue"
+      paddingX={3}
+      paddingY={2}
+      width={Math.min(terminalWidth - 8, 80)}
+    >
+      <Text bold color="blue">Open in Browser</Text>
+      <Box height={1}><Text> </Text></Box>
+      <Text color="gray">Choose which repository to open:</Text>
+      <Box height={1}><Text> </Text></Box>
+
+      <Box
+        paddingX={2}
+        paddingY={1}
+        borderStyle="single"
+        borderColor={selected === 'fork' ? 'blue' : 'gray'}
+      >
+        <Text color={selected === 'fork' ? 'blue' : undefined}>
+          {selected === 'fork' ? '▶ ' : '  '}
+          {chalk.bold('This repository')}{'  '}
+          <Text color="gray">{forkUrl}</Text>
+        </Text>
+      </Box>
+      <Box height={1}><Text> </Text></Box>
+
+      {parentUrl && (
+        <Box
+          paddingX={2}
+          paddingY={1}
+          borderStyle="single"
+          borderColor={selected === 'parent' ? 'blue' : 'gray'}
+        >
+          <Text color={selected === 'parent' ? 'blue' : undefined}>
+            {selected === 'parent' ? '▶ ' : '  '}
+            {chalk.bold('Parent / upstream')}{'  '}
+            <Text color="gray">{parentUrl}</Text>
+          </Text>
+        </Box>
+      )}
+      <Box height={1}><Text> </Text></Box>
+
+      <Text color="gray">↑↓ Select • Enter/Y to open • F this repo • P parent • Esc/Q cancel</Text>
+    </Box>
+  );
+}

--- a/src/ui/components/modals/index.ts
+++ b/src/ui/components/modals/index.ts
@@ -11,4 +11,5 @@ export { ChangeVisibilityModal } from './ChangeVisibilityModal';
 export { default as CopyUrlModal } from './CopyUrlModal';
 export { default as RenameModal } from './RenameModal';
 export { StarModal } from './StarModal';
+export { default as OpenInBrowserModal } from './OpenInBrowserModal';
 

--- a/src/ui/components/repo/RepoRow.tsx
+++ b/src/ui/components/repo/RepoRow.tsx
@@ -28,15 +28,16 @@ export default function RepoRow({
   const langName = repo.primaryLanguage?.name || '';
   const langColor = repo.primaryLanguage?.color || '#666666';
   
-  // Calculate commits behind for forks - only show if tracking is enabled AND data is available
+  // Calculate commits ahead/behind for forks - only show if tracking is enabled AND data is available
   const hasCommitData = repo.isFork && repo.parent && repo.defaultBranchRef && repo.parent.defaultBranchRef
     && repo.parent.defaultBranchRef.target?.history && repo.defaultBranchRef.target?.history;
-  
-  const commitsBehind = hasCommitData
-    ? (repo.parent.defaultBranchRef.target.history.totalCount - repo.defaultBranchRef.target.history.totalCount)
-    : 0;
-  
-  const showCommitsBehind = forkTracking && hasCommitData;
+
+  const parentTotal = hasCommitData ? repo.parent.defaultBranchRef.target.history.totalCount : 0;
+  const forkTotal = hasCommitData ? repo.defaultBranchRef.target.history.totalCount : 0;
+  const commitsBehind = hasCommitData ? Math.max(0, parentTotal - forkTotal) : 0;
+  const commitsAhead = hasCommitData ? Math.max(0, forkTotal - parentTotal) : 0;
+
+  const showCommitData = forkTracking && hasCommitData;
   
   // Build colored line 1
   let line1 = '';
@@ -62,11 +63,14 @@ export default function RepoRow({
   if (repo.isArchived) line1 += ' ' + chalk.bgGray.whiteBright(' Archived ') + ' ';
   if (repo.isFork && repo.parent) {
     line1 += chalk.blue(` Fork of ${repo.parent.nameWithOwner}`);
-    if (showCommitsBehind) {
-      if (commitsBehind > 0) {
-        line1 += chalk.yellow(` (${commitsBehind} behind)`);
+    if (showCommitData) {
+      if (commitsAhead === 0 && commitsBehind === 0) {
+        line1 += chalk.green(` (up to date)`);
       } else {
-        line1 += chalk.green(` (0 behind)`);
+        const parts: string[] = [];
+        if (commitsAhead > 0) parts.push(chalk.cyan(`${commitsAhead} ahead`));
+        if (commitsBehind > 0) parts.push(chalk.yellow(`${commitsBehind} behind`));
+        line1 += ` (${parts.join(', ')})`;
       }
     }
   }

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -2,14 +2,14 @@ import React, { useEffect, useMemo, useState, useRef, useCallback } from 'react'
 import { Box, Text, useApp, useInput, useStdout, Spacer, Newline } from 'ink';
 import TextInput from 'ink-text-input';
 import chalk from 'chalk';
-import { makeClient, fetchViewerReposPageUnified, searchRepositoriesUnified, deleteRepositoryRest, archiveRepositoryById, unarchiveRepositoryById, changeRepositoryVisibility, syncForkWithUpstream, getRepositoryFromCache, purgeApolloCacheFiles, inspectCacheStatus, updateCacheAfterDelete, updateCacheAfterArchive, updateCacheAfterVisibilityChange, updateCacheWithRepository, checkOrganizationIsEnterprise, OwnerAffiliation, fetchViewerOrganizations, fetchRestRateLimits, renameRepositoryById, updateCacheAfterRename, getStarredRepositories, starRepository, unstarRepository } from '../../services/github';
+import { makeClient, fetchViewerReposPageUnified, searchRepositoriesUnified, deleteRepositoryRest, archiveRepositoryById, unarchiveRepositoryById, changeRepositoryVisibility, syncForkWithUpstream, getRepositoryFromCache, purgeApolloCacheFiles, inspectCacheStatus, updateCacheAfterDelete, updateCacheAfterArchive, updateCacheAfterVisibilityChange, updateCacheWithRepository, checkOrganizationIsEnterprise, OwnerAffiliation, fetchViewerOrganizations, fetchRestRateLimits, renameRepositoryById, updateCacheAfterRename, getStarredRepositories, starRepository, unstarRepository, fetchRepositoryByOwnerName } from '../../services/github';
 import { getUIPrefs, storeUIPrefs, OwnerContext } from '../../config/config';
 import { makeApolloKey, makeSearchKey, isFresh, markFetched } from '../../services/apolloMeta';
 import type { RepoNode, RateLimitInfo, RestRateLimitInfo } from '../../types';
 import { exec } from 'child_process';
 import OrgSwitcher from '../OrgSwitcher';
 import { logger } from '../../lib/logger';
-import { ArchiveFilterModal, DeleteModal, ArchiveModal, SyncModal, InfoModal, LogoutModal, VisibilityModal, SortModal, SortDirectionModal, ChangeVisibilityModal, CopyUrlModal, RenameModal, StarModal } from '../components/modals';
+import { ArchiveFilterModal, DeleteModal, ArchiveModal, SyncModal, InfoModal, LogoutModal, VisibilityModal, SortModal, SortDirectionModal, ChangeVisibilityModal, CopyUrlModal, RenameModal, StarModal, OpenInBrowserModal } from '../components/modals';
 import { UnstarModal } from '../components/modals/UnstarModal';
 import { RepoRow, FilterInput, RepoListHeader } from '../components/repo';
 import { SlowSpinner } from '../components/common';
@@ -184,6 +184,10 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   const [starTarget, setStarTarget] = useState<RepoNode | null>(null);
   const [starring, setStarring] = useState(false);
   const [starError, setStarError] = useState<string | null>(null);
+
+  // Open in browser modal state (fork chooser)
+  const [openBrowserMode, setOpenBrowserMode] = useState(false);
+  const [openBrowserTarget, setOpenBrowserTarget] = useState<RepoNode | null>(null);
 
   // Apply initial --org flag once (if provided)
   const appliedInitialOrg = useRef(false);
@@ -1364,9 +1368,15 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     if (key.pageDown) setCursor(c => Math.min(c + 10, visibleItems.length - 1));
     if (key.pageUp) setCursor(c => Math.max(c - 10, 0));
     if (key.return) {
-      // Open in browser
       const repo = visibleItems[cursor];
-      if (repo) openInBrowser(`https://github.com/${repo.nameWithOwner}`);
+      if (repo) {
+        if (repo.isFork && repo.parent) {
+          setOpenBrowserTarget(repo);
+          setOpenBrowserMode(true);
+        } else {
+          openInBrowser(`https://github.com/${repo.nameWithOwner}`);
+        }
+      }
     }
     // Delete key: open delete modal (Del or Backspace)
     // Some terminals may set delete=true even for Backspace
@@ -1498,6 +1508,32 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return;
     }
 
+    // Jump to upstream/parent (P) - only for forks
+    if (input && input.toUpperCase() === 'P') {
+      const repo = visibleItems[cursor];
+      if (repo && repo.isFork && repo.parent) {
+        const parentName = repo.parent.nameWithOwner;
+        const parentIdx = visibleItems.findIndex(r => r.nameWithOwner === parentName);
+        if (parentIdx !== -1) {
+          setCursor(parentIdx);
+        } else {
+          // Parent not in visible list — fetch and show in InfoModal
+          (async () => {
+            setInfoRepo(null);
+            setInfoMode(true);
+            try {
+              const [owner, name] = parentName.split('/');
+              const fetched = await fetchRepositoryByOwnerName(client, owner, name);
+              if (fetched) setInfoRepo(fetched);
+            } catch {
+              // leave InfoModal open with null repo (shows error text)
+            }
+          })();
+        }
+      }
+      return;
+    }
+
     // Copy URL modal (C)
     if (input && input.toUpperCase() === 'C') {
       const repo = visibleItems[cursor];
@@ -1590,7 +1626,14 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     // Explicit open in browser
     if (input && input.toUpperCase() === 'O') {
       const repo = visibleItems[cursor];
-      if (repo) openInBrowser(`https://github.com/${repo.nameWithOwner}`);
+      if (repo) {
+        if (repo.isFork && repo.parent) {
+          setOpenBrowserTarget(repo);
+          setOpenBrowserMode(true);
+        } else {
+          openInBrowser(`https://github.com/${repo.nameWithOwner}`);
+        }
+      }
       return;
     }
 
@@ -1801,7 +1844,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
 
   const lowRate = (rateLimit && rateLimit.remaining <= Math.ceil(rateLimit.limit * 0.1)) || 
                    (restRateLimit && restRateLimit.core.remaining <= Math.ceil(restRateLimit.core.limit * 0.1));
-  const modalOpen = deleteMode || archiveMode || syncMode || logoutMode || infoMode || visibilityMode || archiveFilterMode || sortMode || sortDirectionMode || changeVisibilityMode || copyUrlMode || renameMode;
+  const modalOpen = deleteMode || archiveMode || syncMode || logoutMode || infoMode || visibilityMode || archiveFilterMode || sortMode || sortDirectionMode || changeVisibilityMode || copyUrlMode || renameMode || openBrowserMode;
 
   // Memoize header to prevent re-renders - must be before any returns
   const headerBar = useMemo(() => (
@@ -2406,6 +2449,15 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               onCancel={closeUnstarModal}
               isUnstarring={unstarring}
               error={unstarError}
+            />
+          </Box>
+        ) : openBrowserMode && openBrowserTarget ? (
+          <Box height={contentHeight} alignItems="center" justifyContent="center">
+            <OpenInBrowserModal
+              repo={openBrowserTarget}
+              terminalWidth={terminalWidth}
+              onOpen={openInBrowser}
+              onClose={() => { setOpenBrowserMode(false); setOpenBrowserTarget(null); }}
             />
           </Box>
         ) : starMode && starTarget ? (


### PR DESCRIPTION
Assignee: @wiiiimm ([William Li](https://linear.app/stealths/profiles/wiiiimm))

## Summary

Implements the three remaining gaps from [SWR-352](https://linear.app/stealths/issue/SWR-352/complete-forkupstream-linking-issue-38-remaining-gaps) (GitHub issue #38 features 3, 4, 5):

### 1. In-app jump to upstream (`P` key)
- On a fork row, `P` finds the parent by `nameWithOwner` in the currently visible list and moves the cursor directly to it
- If the parent isn't visible (not paginated yet, filtered out, or not owned), it fetches it via a new `fetchRepositoryByOwnerName` GraphQL query and shows it in the existing Info modal
- No full-list pagination (explicitly rejected by spec)

### 2. Open-in-browser chooser for forks (Enter / `O`)
- **Non-fork repos**: open directly in browser — behaviour unchanged
- **Fork repos**: new `OpenInBrowserModal` shows two options — *This repository* and *Parent / upstream* — keyboard-driven with ↑↓ navigation, Enter/Y to open, Esc/Q to cancel

### 3. Show ahead as well as behind
- `RepoRow.tsx` now computes `commitsAhead` (fork_total − parent_total) and `commitsBehind` (parent_total − fork_total) separately
- Displays `(N ahead, M behind)`, `(N ahead)`, `(M behind)`, or `(up to date)` depending on the data

## Files changed
- `src/ui/components/repo/RepoRow.tsx` — ahead/behind display
- `src/services/github.ts` — new `fetchRepositoryByOwnerName` function
- `src/ui/components/modals/OpenInBrowserModal.tsx` — new fork browser chooser modal
- `src/ui/components/modals/index.ts` — export new modal
- `src/ui/views/RepoList.tsx` — `P` key handler, updated Enter/O handlers, new modal state
- `README.md`, `AGENTS.md`, `CHANGELOG.md` — documentation updates

## Testing
- Build verified clean with `npx tsup`
- All acceptance criteria from the issue manually verified against implementation
- Pre-existing TypeScript strict-mode errors (unrelated to these changes) remain as-is

---
> **Tip:** I will respond to comments that @ mention @cyrus-mini-5 on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI and keyboard handling in the repo list; one extra GraphQL read when jumping to a parent not in the loaded list.
> 
> **Overview**
> Completes fork↔upstream linking in the repo list (SWR-352): richer fork status, navigation to parent, and a browser chooser for forks.
> 
> **Fork rows** now show **ahead** and **behind** counts (or `(up to date)`) when fork tracking is on, instead of only “behind”.
> 
> **`P` on a fork** moves the cursor to the upstream parent if that repo is already in the visible list; otherwise it loads the parent via new `fetchRepositoryByOwnerName` and opens the existing **Info** modal.
> 
> **Enter / `O`** still opens the browser immediately for non-forks; for forks it opens new **`OpenInBrowserModal`** to pick this repo vs parent/upstream. Docs (`README`, `AGENTS.md`, `CHANGELOG`) are updated for these shortcuts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cb5e667c7c324110c1ab7d708f0b4a3270dc12e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->