### PR TITLE
feat: background fetch-all pagination with light bulk query (SWR-360)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 - ✅ GitHub GraphQL API integration with Apollo Client caching
 - ✅ Interactive terminal UI with Ink
 - ✅ OAuth and PAT authentication with secure storage
-- ✅ Infinite scroll with smart prefetching
+- ✅ Background fetch-all (whole account cached after first page)
 - ✅ Repository management (delete, archive, visibility change)
 - ✅ GitHub Enterprise support with Internal visibility
 - ✅ Organization switching and context management
@@ -67,7 +67,7 @@ gh-manager-cli/
 - OAuth and PAT authentication: prompt → validate → persist (0600 perms on POSIX)
 - List personal and organization repos with metadata (name, description, stars, forks, etc.)
 - Full keyboard navigation with extensive shortcuts
-- Smart infinite scroll with 80% prefetch trigger
+- Background fetch-all: whole account loaded into the persisted cache after the first page
 - Server-side search with Apollo Client caching
 - Repository actions: delete, archive/unarchive, change visibility, sync forks
 - Organization and Enterprise GitHub support
@@ -103,9 +103,12 @@ See the living roadmap in [TODOs.md](./TODOs.md) for the canonical, up-to-date l
 ## GitHub API Details
 
 - GraphQL query against `viewer.repositories` with `ownerAffiliations: OWNER` and `orderBy: UPDATED_AT DESC`.
-- Page size: 50 per request.
-- On each page fetch, also read `totalCount` to reflect newly created repos.
-- Selected fields: name/nameWithOwner/description/visibility/isPrivate/isFork/isArchived/stargazerCount/forkCount/primaryLanguage/updatedAt/pushedAt/diskUsage.
+- Page size: 100 per request (default; configurable 1-100 via `REPOS_PER_FETCH`).
+- **Single pagination model — background fetch-all:** the first page renders immediately, then a background loop fetches every remaining page until `hasNextPage` is false, appending into the persisted cache. There is no scroll-position prefetch trigger for the owned/starred lists; the load is continuous and driven by the effect re-running as the list grows. (Server-side search remains lazy/per-query.)
+- Because the full set is cached, **sorting is client-side** (`filteredAndSorted`) with no server refetch on sort change; archive/visibility (private) filtering is also client-side.
+- On each page fetch, also read `totalCount` to reflect newly created repos and to show background-load progress (`loaded/total`).
+- Selected fields: name/nameWithOwner/description/visibility/isPrivate/isFork/isArchived/stargazerCount/forkCount/primaryLanguage/updatedAt/pushedAt/diskUsage, plus `parent { nameWithOwner }` and `defaultBranchRef { name }`.
+- **Light bulk query (SWR-360):** the list/search queries intentionally do NOT fetch per-repo commit history (`history.totalCount`). Computing that for each repo and its parent across 100 repos/page exceeds GitHub's per-query budget and returns HTTP 502. Consequently fork **"commits behind"** counts are not available from the bulk fetch — `parent { nameWithOwner }` still drives the "Fork of X" label, but the "(N behind)" indicator is populated by a separate on-demand enrichment pass (follow-up). `fetchRepositoryById` (single repo) still fetches the full history fields.
 
 ## Controls
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Interactive terminal app to browse and manage your personal GitHub repositories.
 `gh-manager-cli` replaces tedious web clicking with powerful terminal commands:
 
 ### ❌ GitHub Website Pain Points → ✅ Our Solution
-- **Slow pagination** (20 repos/page) → View all repos instantly with smooth scrolling
+- **Slow pagination** (page-by-page) → Whole account loaded in the background, browse and search everything instantly
 - **Multiple clicks per action** → Single keypress for any operation  
 - **No bulk operations** → Archive, delete, or modify multiple repos at once
 - **Buried settings menus** → Direct keyboard shortcuts for everything
@@ -73,7 +73,7 @@ On first run, you'll be prompted to authenticate with GitHub (OAuth recommended)
 ### Core Repository Management
 - **Authentication**: GitHub OAuth (recommended) or Personal Access Token with secure storage
 - **Repository Listing**: Browse all your personal repositories with metadata (stars, forks, language, etc.)
-- **Live Pagination**: Infinite scroll with automatic page prefetching
+- **Background Fetch-All**: Loads your entire account in the background after the first page, so filtering/sorting/search are instant and complete
 - **Interactive Sorting**: Modal-based sort selection (updated, pushed, name, stars) with modal-based direction selection
 - **Smart Search**: Server-side search through repository names and descriptions (3+ characters)
 - **Visibility Filter**: Modal-based visibility filter (All, Public, Private/Internal for enterprise) with smart filtering
@@ -305,8 +305,9 @@ Status bar shows loaded count vs total. A rate-limit line displays `remaining/li
 ## Pagination Details
 
 - Uses GitHub GraphQL `viewer.repositories` with `ownerAffiliations: OWNER`, ordered by `UPDATED_AT DESC`.
-- Fetches 15 repos per page by default (configurable via `REPOS_PER_FETCH` environment variable, 1-50).
-- Updates `totalCount` each time and prefetches the next page when selection nears the end of loaded list.
+- **Background fetch-all:** the first page renders immediately, then the remaining repositories load in the background until the whole account is cached locally. Filtering, sorting, and search then operate over the complete set, client-side and instant.
+- Fetches 100 repos per page by default (configurable via `REPOS_PER_FETCH` environment variable, 1-100).
+- Reads `totalCount` from the first page and shows background-load progress (`loaded/total`) while filling. The list stays usable from the first page throughout; very large accounts simply take longer to finish loading.
 
 ## Development
 

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -492,11 +492,8 @@ export async function fetchViewerReposPageUnified(
                   updatedAt
                   pushedAt
                   diskUsage
-                  ${includeForkTracking ? `
-                  parent { nameWithOwner defaultBranchRef { name target { ... on Commit { history(first: 0) { totalCount } } } } }
-                  defaultBranchRef { name target { ... on Commit { history(first: 0) { totalCount } } } }` : `
                   parent { nameWithOwner }
-                  defaultBranchRef { name }`}
+                  defaultBranchRef { name }
                 }
               }
             }
@@ -529,11 +526,8 @@ export async function fetchViewerReposPageUnified(
                   updatedAt
                   pushedAt
                   diskUsage
-                  ${includeForkTracking ? `
-                  parent { nameWithOwner defaultBranchRef { name target { ... on Commit { history(first: 0) { totalCount } } } } }
-                  defaultBranchRef { name target { ... on Commit { history(first: 0) { totalCount } } } }` : `
                   parent { nameWithOwner }
-                  defaultBranchRef { name }`}
+                  defaultBranchRef { name }
                 }
               }
             }
@@ -643,11 +637,8 @@ export async function searchRepositoriesUnified(
               updatedAt
               pushedAt
               diskUsage
-              ${includeForkTracking ? `
-              parent { nameWithOwner defaultBranchRef { name target { ... on Commit { history(first: 0) { totalCount } } } } }
-              defaultBranchRef { name target { ... on Commit { history(first: 0) { totalCount } } } }` : `
               parent { nameWithOwner }
-              defaultBranchRef { name }`}
+              defaultBranchRef { name }
             }
           }
         }

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -20,11 +20,11 @@ const getPageSize = () => {
   const envValue = process.env.REPOS_PER_FETCH;
   if (envValue) {
     const parsed = parseInt(envValue, 10);
-    if (!isNaN(parsed) && parsed >= 1 && parsed <= 50) {
+    if (!isNaN(parsed) && parsed >= 1 && parsed <= 100) {
       return parsed;
     }
   }
-  return 15; // Default
+  return 100; // Default — large pages for background fetch-all (GitHub max is 100)
 };
 
 const PAGE_SIZE = getPageSize();
@@ -1004,31 +1004,12 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client, prefsLoaded, ownerContext, ownerAffiliations]);
 
-  // Refresh from server when sorting changes
+  // Sorting changes.
+  // Owned repos sort entirely client-side (filteredAndSorted) over the full
+  // background-loaded set, so no server refetch is needed (SWR-360). Search still
+  // re-runs server-side because its result set is server-ordered and paginated.
   useEffect(() => {
-    // Skip initial mount
-    if (!searchActive) {
-      if (items.length > 0) {
-        let policy: 'cache-first' | 'network-only' = 'cache-first';
-        
-        // Determine organization login if in org context
-        const orgLogin = ownerContext !== 'personal' ? ownerContext.login : undefined;
-        
-        try {
-          const key = makeApolloKey({
-            viewer: viewerLogin || 'unknown',
-            sortKey,
-            sortDir,
-            pageSize: PAGE_SIZE,
-            forkTracking,
-            ownerContext: orgLogin ? `org:${orgLogin}` : 'personal',
-            affiliations: ownerAffiliations.join(',')
-          });
-          policy = isFresh(key) ? 'cache-first' : 'network-only';
-        } catch {}
-        fetchPage(null, true, true, undefined, policy);
-      }
-    } else {
+    if (searchActive) {
       // Re-run search with new sort
       if (!searchLoading && filter.trim().length >= 3) {
         let policy: 'cache-first' | 'network-only' = 'cache-first';
@@ -1761,7 +1742,12 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     return { start, end };
   }, [visibleItems.length, cursor, listHeight, spacingLines]);
 
-  // Infinite scroll: prefetch when at 80% of loaded items, or immediately when filter hides all loaded items
+  // Single pagination model (SWR-360): background fetch-all.
+  // Owned repos and starred repos eagerly load the entire set in the background —
+  // each page completing re-runs this effect (items length changes) which fetches the
+  // next page until hasNextPage is false. No scroll-position gating. This makes
+  // filtering, sorting, and (future) fuzzy search complete and client-side.
+  // Search stays lazy/server-side (per-query, paginated near the end of the list).
   useEffect(() => {
     const prefetchThreshold = Math.floor(visibleItems.length * 0.8);
     const nearEnd = visibleItems.length > 0 && cursor >= prefetchThreshold;
@@ -1771,21 +1757,20 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     // When an archive filter is active and all loaded items are filtered out, keep fetching.
     // Require rawItemsLength > 0 to avoid a spurious fetch on stale hasNextPage/endCursor.
     const filterDrainedPage = visibleItems.length === 0 && archiveFilter !== 'all' && rawItemsLength > 0;
-    const shouldFetch = nearEnd || filterDrainedPage;
 
     if (starsMode) {
-      if (!starredLoading && starredHasNextPage && shouldFetch) {
-        addDebugMessage(`[Infinite Scroll] Prefetching starred repos at ${cursor}/${visibleItems.length} (80% threshold: ${prefetchThreshold})`);
+      // Background-fill the entire starred set.
+      if (!starredLoading && starredHasNextPage) {
         fetchStarredRepositories(starredEndCursor);
       }
     } else if (searchActive) {
-      if (!searchLoading && searchHasNextPage && shouldFetch) {
-        addDebugMessage(`[Infinite Scroll] Prefetching search results at ${cursor}/${visibleItems.length} (80% threshold: ${prefetchThreshold})`);
+      // Search remains lazy: prefetch near the end or when a filter drains the page.
+      if (!searchLoading && searchHasNextPage && (nearEnd || filterDrainedPage)) {
         fetchSearchPage(searchEndCursor);
       }
     } else {
-      if (!loading && !loadingMore && hasNextPage && shouldFetch) {
-        addDebugMessage(`[Infinite Scroll] Prefetching repos at ${cursor}/${visibleItems.length} (80% threshold: ${prefetchThreshold})`);
+      // Background-fill the entire owned set.
+      if (!loading && !loadingMore && hasNextPage) {
         fetchPage(endCursor);
       }
     }
@@ -1815,7 +1800,10 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         </Text>
         <Text bold color={modalOpen ? 'gray' : undefined} dimColor={modalOpen ? true : undefined}>Repositories</Text>
         <Text color="gray">({visibleItems.length}/{searchActive ? searchTotalCount : totalCount})</Text>
-        {(loading || searchLoading) && (
+        {loadingMore && hasNextPage && !starsMode && !searchActive && totalCount > 0 && (
+          <Text color="cyan">{` · loading ${items.length}/${totalCount}`}</Text>
+        )}
+        {(loading || searchLoading || loadingMore) && (
           <Box width={2} flexShrink={0} flexGrow={0} marginLeft={1}>
             <Text color="yellow">
               <SlowSpinner />
@@ -2505,8 +2493,22 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                 })
               )}
               
-              {/* Infinite scroll loading indicator */}
-              {loadingMore && hasNextPage && (
+              {/* Background fetch-all progress indicator */}
+              {loadingMore && hasNextPage && !starsMode && !searchActive && (
+                <Box justifyContent="center" alignItems="center" marginTop={1}>
+                  <Box flexDirection="row">
+                    <Box width={2} flexShrink={0} flexGrow={0} marginRight={1}>
+                      <Text color="cyan">
+                        <SlowSpinner />
+                      </Text>
+                    </Box>
+                    <Text color="cyan">
+                      Loading repositories… {totalCount > 0 ? `(${items.length}/${totalCount})` : `(${items.length})`}
+                    </Text>
+                  </Box>
+                </Box>
+              )}
+              {loadingMore && hasNextPage && (starsMode || searchActive) && (
                 <Box justifyContent="center" alignItems="center" marginTop={1}>
                   <Box flexDirection="row">
                     <Box width={2} flexShrink={0} flexGrow={0} marginRight={1}>


### PR DESCRIPTION
Implements **SWR-360** — single background fetch-all pagination model.

## What changed
- **Single pagination model:** render page 1 immediately, then background-fetch all remaining repos into the persisted cache until complete. Removes the scroll-position prefetch trigger.
- **Page size → 100** (env `REPOS_PER_FETCH`, 1-100).
- **Client-side sorting** over the full set — no server refetch on sort change.
- **Live `loaded/total` counter** in the header and the list footer during the background fill.
- **Light bulk query (fixes HTTP 502):** the list/search GraphQL queries no longer fetch per-repo commit history. Computing `history.totalCount` for each repo + its parent across 100 repos/page exceeded GitHub's per-query budget and returned 502. `fetchRepositoryById` (single repo) keeps the full fields.

## Interim behavior (by design)
- ✅ Forks still show **"Fork of X"**.
- ⏳ Fork **"(N behind)"** is temporarily hidden — that count is the expensive data removed above. It returns via the follow-up enrichment pass (**SWR-362**).

## Testing
- Build passes (`tsup`).
- ⚠️ Test suite could not run locally: `vitest@4.1.0` requires vite 6+, but vite `5.4.19` is installed (pre-existing fallout from the vitest 2→4 bump, unrelated to this change).
- Manual: `REPOS_PER_FETCH=5 node dist/index.js` — list loads cleanly (no 502), counter climbs to total, sorting is instant.

## Docs
- README.md and AGENTS.md updated (background fetch-all, page size, light query, deferred commits-behind).

Refs SWR-360. Follow-up: SWR-362 (fork commits-behind enrichment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core list loading, caching, and GraphQL shape; large accounts will issue more API traffic until fully loaded, and fork “commits behind” is temporarily missing in the list.
> 
> **Overview**
> Replaces scroll-triggered infinite scroll with **background fetch-all** for owned and starred repos: the first page shows immediately, then pages load continuously until the account is fully cached. **Default page size rises to 100** (`REPOS_PER_FETCH`, max 100). **Sorting on the main list is client-side** over that cached set—changing sort no longer refetches from GitHub (search still refetches when sort changes).
> 
> List/search GraphQL queries are **slimmed down** by dropping per-repo commit `history` fields that caused **HTTP 502** at 100 repos/page; bulk rows keep `parent { nameWithOwner }` and `defaultBranchRef { name }` only. **“(N behind)” on fork rows disappears** until a planned enrichment pass; single-repo fetch still has full history.
> 
> The UI adds **loaded/total** progress in the header and list footer during background fill. **README** and **AGENTS.md** document the new pagination model and light query.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b93a7ad1417293eb737444d85f3681dfa244c8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->