### PR TITLE
chore: symlink CLAUDE.md to AGENTS.md (SWR-363) [semantic pr title]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,13 @@ First run prompts for a PAT if not provided via env vars. The token is validated
 - **main:** Production-ready code only
 - **Feature branches:** For new features and major changes
 
+### Linear Issue Linking (REQUIRED)
+Every change should trace back to a Linear issue. To guarantee GitHub ↔ Linear auto-linking:
+- **Branch name MUST include the Linear issue ID**, e.g. `feature/swr-360-background-fetch-all` (`<type>/swr-<id>-<slug>`).
+- **PR title MUST include the Linear issue ID**, e.g. `feat: background fetch-all pagination with light bulk query (SWR-360)`.
+- If no Linear issue exists for the work yet, **create one first**, then name the branch and PR with its ID.
+- This is what links the PR back to the Linear issue and surfaces progress there — do not open a PR without the ID in both places.
+
 ### Commit Message Format
 **REQUIRED:** All commits MUST follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,1 @@
-# CLAUDE.md - gh-manager-cli Project
-
-## Project Overview
-This is the `gh-manager-cli` project - a Node.js + TypeScript terminal UI for managing GitHub repositories.
-
-## Agent Documentation
-For detailed project architecture, setup instructions, features, and development guide, see `@AGENTS.md`.
-
-## Quick Reference
-- **Project Type:** Node.js CLI application with React-based TUI
-- **Primary File:** `AGENTS.md` contains all project documentation
-- **Build Command:** `pnpm build`
-- **Run Command:** `node dist/index.js` or `gh-manager-cli` (after `pnpm link`)
-
-Always refer to `@AGENTS.md` for complete project details, architecture, and development instructions.
+AGENTS.md


### PR DESCRIPTION
Implements **SWR-363**.

Converts `CLAUDE.md` from a standalone file into a **symlink to `AGENTS.md`**, giving a single source of truth for agent/project documentation and preventing the two from drifting.

- Git records it as a symlink (mode `120000` → `AGENTS.md`).
- `AGENTS.md` remains the canonical doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and symlink-only changes with no runtime, auth, or application code impact.
> 
> **Overview**
> **Single source of truth for agent docs:** `CLAUDE.md` is no longer a duplicate overview; it now points at `AGENTS.md` (symlink), so Claude and other agents read the same canonical project memory without drift.
> 
> **Process docs in `AGENTS.md`:** Adds a required **Linear issue linking** section—branch names and PR titles must include the Linear issue ID (e.g. `SWR-360`) so GitHub and Linear stay linked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab2fd0675b43bc247960da82fe868950c7e2f068. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal development documentation file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->