### PR TITLE
fix: stars toggle footer hint truncation and contextual labels (SWR-359)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,8 @@ See the living roadmap in [TODOs.md](./TODOs.md) for the canonical, up-to-date l
 - `Ctrl+V`: change repository visibility
 - `Ctrl+S`: sync fork with upstream
 - `Ctrl+L`: logout (returns to Authentication Required)
+- `Shift+S`: toggle between own repos and starred repos (personal context only)
+  - Footer hint shows `Shift+S Starred` in normal mode and `Shift+S My Repos` in starred mode; hidden in org context
 - `R`: refresh list (purges cache)
 - `Q`: quit (Esc cancels an open modal or exits search mode; does not quit)
 

--- a/README.md
+++ b/README.md
@@ -273,7 +273,8 @@ Launch the app, then use the keys below:
 - **Fork Status**: Always enabled - shows commits behind upstream for all forks
 - **Visibility Filter**: `V` opens modal (All, Public, Private/Internal for enterprise)
 - **Archive Filter**: `A` toggles archive filter (All → Unarchived → Archived)
-- **Stars Mode**: `Shift+S` (personal account only) to view starred repositories
+- **Stars Mode**: `Shift+S` (personal account only) to toggle between your own repos and your starred repos
+  - Footer hint shows `Shift+S Starred` in normal mode and `Shift+S My Repos` in starred mode
 
 ### Navigation & Account
 - **Open in browser**: Enter or `O`

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -2535,15 +2535,15 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         {/* Line 2: Search and filtering */}
         <Box width={terminalWidth} justifyContent="center">
           <Text color="gray" dimColor={modalOpen ? true : undefined}>
-            / Search • S Sort • D Direction • T Density • A Archive Filter{!starsMode && ' • V Visibility Filter'}{ownerContext === 'personal' && ' • Shift+S Stars'}
+            / Search • S Sort • D Direction • T Density • A Archive Filter{!starsMode && ' • V Visibility Filter'}
           </Text>
         </Box>
-        {/* Line 3: Repository actions */}
+        {/* Line 3: Repository actions (stars toggle at start so it is never truncated) */}
         <Box width={terminalWidth} justifyContent="center">
           <Text color="gray" dimColor={modalOpen ? true : undefined}>
             {starsMode ? 
-              'I Info • C Copy URL • U Unstar Repository' :
-              'I Info • C Copy URL • Ctrl+S Un/Star • Ctrl+R Rename • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+F Sync Fork'
+              'Shift+S My Repos • I Info • C Copy URL • U Unstar Repository' :
+              `${ownerContext === 'personal' ? 'Shift+S Starred • ' : ''}I Info • C Copy URL • Ctrl+S Un/Star • Ctrl+R Rename • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+F Sync Fork`
             }
           </Text>
         </Box>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the `Shift+S` stars toggle footer hint being silently truncated on narrow terminals, and introduces contextual destination labels.

## Problem

The hint was appended at the **end** of the search/filter footer line (Line 2):

```
/ Search • S Sort • D Direction • T Density • A Archive Filter • V Visibility Filter • Shift+S Stars
```

On narrow terminals this line wraps or gets cut, and since `Shift+S Stars` is last it's the first thing dropped. Additionally, there was **no toggle-back hint at all** when already in stars mode.

## Changes

### `src/ui/views/RepoList.tsx`

- **Line 2** (search/filter): Removed the `Shift+S Stars` hint entirely — the line is now:
  ```
  / Search • S Sort • D Direction • T Density • A Archive Filter • V Visibility Filter
  ```
- **Line 3** (actions): Stars toggle hint moved to the **start** of the actions line, so it is always the first item and never truncated:
  - Stars mode → `Shift+S My Repos • I Info • C Copy URL • U Unstar Repository`
  - Normal/personal mode → `Shift+S Starred • I Info • C Copy URL • Ctrl+S Un/Star • …`
  - Org context → no toggle hint (unchanged gating)

### `README.md` / `AGENTS.md`

- Updated keybinding documentation to reflect the contextual `Shift+S Starred` / `Shift+S My Repos` labels.

## Acceptance criteria

- [x] Stars toggle hint is visible in personal context across narrow/medium/wide terminal widths (not truncated away)
- [x] Normal mode shows `Shift+S Starred`
- [x] Stars mode shows `Shift+S My Repos` (toggle-back hint now exists)
- [x] Hint still hidden in non-personal (org) context, consistent with the gated toggle
- [x] README.md and AGENTS.md updated

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SWR-359](https://linear.app/stealths/issue/SWR-359/stars-toggle-footer-hint-gets-truncated-unclear-label)

<div><a href="https://cursor.com/agents/bc-a356fac7-7468-4dc0-80c4-6166012e12eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a356fac7-7468-4dc0-80c4-6166012e12eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

