### PR TITLE
feat: fork ahead/behind enrichment, jump-to-upstream (P), and open-in-browser chooser (SWR-362) [semantic pr title]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,8 @@ See the living roadmap in [TODOs.md](./TODOs.md) for the canonical, up-to-date l
 - Because the full set is cached, **sorting is client-side** (`filteredAndSorted`) with no server refetch on sort change; archive/visibility (private) filtering is also client-side.
 - On each page fetch, also read `totalCount` to reflect newly created repos and to show background-load progress (`loaded/total`).
 - Selected fields: name/nameWithOwner/description/visibility/isPrivate/isFork/isArchived/stargazerCount/forkCount/primaryLanguage/updatedAt/pushedAt/diskUsage, plus `parent { nameWithOwner }` and `defaultBranchRef { name }`.
-- **Light bulk query (SWR-360):** the list/search queries intentionally do NOT fetch per-repo commit history (`history.totalCount`). Computing that for each repo and its parent across 100 repos/page exceeds GitHub's per-query budget and returns HTTP 502. Consequently fork **"commits behind"** counts are not available from the bulk fetch — `parent { nameWithOwner }` still drives the "Fork of X" label, but the "(N behind)" indicator is populated by a separate on-demand enrichment pass (follow-up). `fetchRepositoryById` (single repo) still fetches the full history fields.
+- **Light bulk query (SWR-360):** the list/search queries intentionally do NOT fetch per-repo commit history (`history.totalCount`). Computing that for each repo and its parent across 100 repos/page exceeds GitHub's per-query budget and returns HTTP 502. Fork `parent { nameWithOwner }` is still fetched so the "Fork of X" label always shows.
+- **Fork ahead/behind enrichment (SWR-362):** after the background fetch-all completes, a separate effect (`useEffect` gated on `!loading && !loadingMore && !hasNextPage`) enriches forks-only with commit counts. It uses `enrichForksWithAheadBehind` which builds a batched aliased GraphQL query (`fork_N: node(id:)` + `parent_N: repository(owner,name)`) capped at 5 forks per request (10 history queries). Results are merged directly into `items` state. A 200ms delay between batches throttles rate-limit consumption. Already-enriched IDs are tracked in `enrichmentDoneRef` to avoid re-fetching. Both `(N ahead)` and `(N behind)` are displayed in `RepoRow` and the sync confirmation modal.
 
 ## Controls
 
@@ -120,16 +121,17 @@ See the living roadmap in [TODOs.md](./TODOs.md) for the canonical, up-to-date l
 - `S`: sort modal (updated, pushed, name, stars)
 - `D`: toggle sort direction
 - `T`: toggle display density (compact/cozy/comfy)
-- `F`: toggle fork commit tracking
 - `V`: visibility filter modal (All, Public, Private/Internal)
-- `W`: organization switcher
-- Enter or `O`: open selected repo in browser
+- `W`: organisation switcher
+- Enter or `O`: open selected repo in browser; for forks shows a chooser (This repository / Parent/upstream, Esc cancels)
+- `P`: on a fork — jump cursor to the parent repo if it is already loaded; otherwise fetches the parent repo and shows it in the Info modal
 - `I`: repository info modal
 - `K`: cache inspection
 - `Del` or `Backspace`: delete selected repo (two-stage confirmation)
 - `Ctrl+A`: archive/unarchive selected repo
 - `Ctrl+V`: change repository visibility
-- `Ctrl+S`: sync fork with upstream
+- `Ctrl+F`: sync fork with upstream (shows ahead/behind counts)
+- `Ctrl+S`: star/unstar selected repo
 - `Ctrl+L`: logout (returns to Authentication Required)
 - `R`: refresh list (purges cache)
 - `Q`: quit (Esc cancels an open modal or exits search mode; does not quit)

--- a/README.md
+++ b/README.md
@@ -78,18 +78,19 @@ On first run, you'll be prompted to authenticate with GitHub (OAuth recommended)
 - **Smart Search**: Server-side search through repository names and descriptions (3+ characters)
 - **Visibility Filter**: Modal-based visibility filter (All, Public, Private/Internal for enterprise) with smart filtering
 - **Archive Filter**: Toggle-based archive filter (`A` key cycles All → Unarchived → Archived) for quick filtering by archive status
-- **Fork Status Tracking**: Always shows commits behind upstream for forked repositories
+- **Fork Ahead/Behind Tracking**: After the background fetch-all completes, forks are enriched with both **ahead** and **behind** commit counts in a separate lightweight pass (batched 5 at a time to avoid rate-limit issues)
 - **Stars Mode**: View and manage starred repositories (personal account only)
 - **Repository Actions**:
   - View detailed info (`I`) - Shows repository metadata, language, size, and timestamps
-  - Open in browser (Enter/`O`)
+  - Open in browser (Enter/`O`) — for forks a chooser lets you open this repo or the upstream
+  - Jump to upstream (`P`) — moves cursor to the parent if loaded; otherwise fetches and shows it
   - Rename repository (`Ctrl+R`) with inline validation and automatic cache update
   - Copy repository URL to clipboard (`C`) with SSH/HTTPS options
   - Delete repository (`Del` or `Backspace`) with secure two-step confirmation
   - Archive/unarchive repositories (`Ctrl+A`) with confirmation prompts
   - Change repository visibility (`Ctrl+V`) - Switch between Public, Private, and Internal (enterprise only)
   - Star/unstar repositories (`Ctrl+S`) - Toggle star status for any repository
-  - Sync forks with upstream (`Ctrl+F`) with automatic conflict detection
+  - Sync forks with upstream (`Ctrl+F`) with ahead/behind counts and automatic conflict detection
 
 ### User Interface & Experience
 - **Keyboard Navigation**: Full keyboard control (arrow keys, PageUp/Down, `Ctrl+G`/`G`)
@@ -270,15 +271,16 @@ Launch the app, then use the keys below:
   - Stars: Number of stars
 - **Sort Direction**: `D` to open sort direction modal (ascending/descending)
 - **Display Density**: `T` to toggle compact/cozy/comfy
-- **Fork Status**: Always enabled - shows commits behind upstream for all forks
+- **Fork Status**: Always enabled — shows commits **ahead** and **behind** upstream once enrichment completes (see below)
 - **Visibility Filter**: `V` opens modal (All, Public, Private/Internal for enterprise)
 - **Archive Filter**: `A` toggles archive filter (All → Unarchived → Archived)
 - **Stars Mode**: `Shift+S` (personal account only) to view starred repositories
 
 ### Navigation & Account
-- **Open in browser**: Enter or `O`
+- **Open in browser**: Enter or `O` — non-forks open directly; forks show a chooser (**This repository** / **Parent/upstream**, Esc cancels)
+- **Jump to upstream**: `P` (on a fork) — moves cursor to the parent if it is already loaded; otherwise fetches the parent and shows it in the Info modal
 - **Refresh**: `R`
-- **Organization switcher**: `W` to switch between personal account and organizations
+- **Organisation switcher**: `W` to switch between personal account and organisations
 - **Logout**: `Ctrl+L`
 - **Quit**: `Q`
 
@@ -291,7 +293,7 @@ Launch the app, then use the keys below:
   - Type confirmation code → confirm (Y/Enter)
   - Cancel: press `C` or Esc
 - **Star/Unstar**: `Ctrl+S` to toggle star status for any repository
-- **Sync fork**: `Ctrl+F` (for forks only, shows commit status and handles conflicts)
+- **Sync fork**: `Ctrl+F` (for forks only, shows ahead/behind counts and handles conflicts)
 - **Rename repository**: `Ctrl+R` with inline validation
 - **Copy URL**: `C` to copy repository URL to clipboard (SSH/HTTPS options)
 

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -1540,7 +1540,13 @@ export async function enrichForksWithAheadBehind(
       `);
     });
 
-    if (queryParts.length === 0) continue;
+    if (queryParts.length === 0) {
+      // Every fork in this batch had an unparseable parent (no owner/name) —
+      // emit null rows so the function always returns exactly one entry per
+      // input fork, keeping the result contract complete for callers.
+      batch.forEach(fork => results.push({ id: fork.id, forkHistoryCount: null, parentHistoryCount: null }));
+      continue;
+    }
 
     const varDefs = Object.entries(variables)
       .map(([k]) => `$${k}: ID!`)

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -1480,3 +1480,152 @@ export async function inspectCacheStatus(): Promise<void> {
     process.stderr.write(`❌ Cache inspection failed: ${e.message}\n`);
   }
 }
+
+export interface ForkEnrichment {
+  id: string;
+  forkHistoryCount: number | null;
+  parentHistoryCount: number | null;
+}
+
+// Batch-enrich forks with ahead/behind counts using aliased node(id:) + repository(owner,name) queries.
+// Batch size is capped at 5 forks (10 history queries) to stay well within GitHub's per-query budget.
+export async function enrichForksWithAheadBehind(
+  client: ReturnType<typeof makeClient>,
+  forks: Array<{ id: string; parentNameWithOwner: string }>
+): Promise<ForkEnrichment[]> {
+  if (forks.length === 0) return [];
+
+  const results: ForkEnrichment[] = [];
+  const BATCH_SIZE = 5;
+
+  for (let batchStart = 0; batchStart < forks.length; batchStart += BATCH_SIZE) {
+    const batch = forks.slice(batchStart, batchStart + BATCH_SIZE);
+
+    const queryParts: string[] = [];
+    const variables: Record<string, string> = {};
+
+    batch.forEach((fork, i) => {
+      const [parentOwner, parentName] = fork.parentNameWithOwner.split('/');
+      if (!parentOwner || !parentName) return;
+
+      const varName = `fid${i}`;
+      variables[varName] = fork.id;
+
+      // Sanitise owner/name: only alphanumeric, hyphens, dots and underscores are valid
+      const safeOwner = parentOwner.replace(/[^a-zA-Z0-9_.\-]/g, '');
+      const safeName = parentName.replace(/[^a-zA-Z0-9_.\-]/g, '');
+
+      queryParts.push(`
+        fork${i}: node(id: $${varName}) {
+          ... on Repository {
+            id
+            defaultBranchRef {
+              target {
+                ... on Commit {
+                  history(first: 0) { totalCount }
+                }
+              }
+            }
+          }
+        }
+        parent${i}: repository(owner: "${safeOwner}", name: "${safeName}") {
+          defaultBranchRef {
+            target {
+              ... on Commit {
+                history(first: 0) { totalCount }
+              }
+            }
+          }
+        }
+      `);
+    });
+
+    if (queryParts.length === 0) continue;
+
+    const varDefs = Object.entries(variables)
+      .map(([k]) => `$${k}: ID!`)
+      .join(', ');
+
+    const query = `query EnrichForks(${varDefs}) { ${queryParts.join('\n')} }`;
+
+    try {
+      const res: any = await client(query, variables);
+
+      batch.forEach((fork, i) => {
+        const forkNode = res[`fork${i}`];
+        const parentNode = res[`parent${i}`];
+
+        const forkHistoryCount: number | null =
+          forkNode?.defaultBranchRef?.target?.history?.totalCount ?? null;
+        const parentHistoryCount: number | null =
+          parentNode?.defaultBranchRef?.target?.history?.totalCount ?? null;
+
+        results.push({ id: fork.id, forkHistoryCount, parentHistoryCount });
+      });
+    } catch (err: any) {
+      logger.error('enrichForksWithAheadBehind batch failed', {
+        error: err.message,
+        batchSize: batch.length,
+      });
+      // Push nulls for this batch so callers know they weren't enriched
+      batch.forEach(fork => results.push({ id: fork.id, forkHistoryCount: null, parentHistoryCount: null }));
+    }
+  }
+
+  return results;
+}
+
+export async function fetchRepositoryByOwnerAndName(
+  client: ReturnType<typeof makeClient>,
+  owner: string,
+  name: string
+): Promise<RepoNode | null> {
+  const query = /* GraphQL */ `
+    query GetRepoByOwnerName($owner: String!, $name: String!) {
+      repository(owner: $owner, name: $name) {
+        id
+        name
+        nameWithOwner
+        description
+        pushedAt
+        updatedAt
+        isPrivate
+        isArchived
+        isFork
+        visibility
+        stargazerCount
+        forkCount
+        diskUsage
+        viewerHasStarred
+        owner { __typename login }
+        primaryLanguage { name color }
+        parent {
+          nameWithOwner
+          defaultBranchRef {
+            target {
+              ... on Commit {
+                history(first: 0) { totalCount }
+              }
+            }
+          }
+        }
+        defaultBranchRef {
+          name
+          target {
+            ... on Commit {
+              history(first: 0) { totalCount }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  try {
+    const result: any = await client(query, { owner, name });
+    return result.repository as RepoNode | null;
+  } catch (err: any) {
+    logger.error('fetchRepositoryByOwnerAndName failed', { owner, name, error: err.message });
+    return null;
+  }
+}

--- a/src/ui/components/modals/OpenInBrowserModal.tsx
+++ b/src/ui/components/modals/OpenInBrowserModal.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import chalk from 'chalk';
+import type { RepoNode } from '../../../types';
+
+interface OpenInBrowserModalProps {
+  repo: RepoNode;
+  onOpen: (url: string) => void;
+  onCancel: () => void;
+}
+
+export default function OpenInBrowserModal({ repo, onOpen, onCancel }: OpenInBrowserModalProps) {
+  const [focus, setFocus] = useState<'this' | 'upstream'>('this');
+
+  const forkUrl = `https://github.com/${repo.nameWithOwner}`;
+  const upstreamUrl = repo.parent ? `https://github.com/${repo.parent.nameWithOwner}` : null;
+
+  useInput((input, key) => {
+    if (key.escape || input.toLowerCase() === 'c') {
+      onCancel();
+      return;
+    }
+
+    if (key.leftArrow || key.rightArrow) {
+      setFocus(prev => prev === 'this' ? 'upstream' : 'this');
+      return;
+    }
+
+    if (key.return) {
+      if (focus === 'this') {
+        onOpen(forkUrl);
+      } else if (upstreamUrl) {
+        onOpen(upstreamUrl);
+      }
+      return;
+    }
+
+    if (input.toLowerCase() === 't') {
+      onOpen(forkUrl);
+      return;
+    }
+
+    if (input.toLowerCase() === 'u' && upstreamUrl) {
+      onOpen(upstreamUrl);
+      return;
+    }
+  });
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="cyan"
+      paddingX={3}
+      paddingY={2}
+      width={62}
+    >
+      <Text bold color="cyan">Open in Browser</Text>
+      <Box height={1}><Text> </Text></Box>
+      <Text bold>{repo.nameWithOwner}</Text>
+      {repo.parent && (
+        <Text color="gray">Fork of {repo.parent.nameWithOwner}</Text>
+      )}
+      <Box height={1}><Text> </Text></Box>
+      <Text>Which repository would you like to open?</Text>
+      <Box height={1}><Text> </Text></Box>
+
+      <Box marginTop={1} flexDirection="row" justifyContent="center" gap={4}>
+        <Box paddingX={2} paddingY={1}>
+          <Text>
+            {focus === 'this'
+              ? chalk.bgCyan.white.bold(' This Repository ')
+              : chalk.cyan.bold('This Repository')}
+          </Text>
+        </Box>
+        <Box paddingX={2} paddingY={1}>
+          <Text>
+            {focus === 'upstream'
+              ? chalk.bgGreen.white.bold(' Parent/Upstream ')
+              : chalk.green.bold('Parent/Upstream')}
+          </Text>
+        </Box>
+      </Box>
+
+      <Box marginTop={1} flexDirection="row" justifyContent="center">
+        <Text color="gray">
+          ←/→ Choose • Enter to Open • T This • U Upstream • C/Esc Cancel
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/components/modals/OpenInBrowserModal.tsx
+++ b/src/ui/components/modals/OpenInBrowserModal.tsx
@@ -1,15 +1,18 @@
 import React, { useState } from 'react';
 import { Box, Text, useInput } from 'ink';
-import chalk from 'chalk';
 import type { RepoNode } from '../../../types';
+import type { Theme } from '../../../config/themes';
+import { useTheme } from '../../hooks/useTheme';
 
 interface OpenInBrowserModalProps {
   repo: RepoNode;
   onOpen: (url: string) => void;
   onCancel: () => void;
+  theme?: Theme;
 }
 
-export default function OpenInBrowserModal({ repo, onOpen, onCancel }: OpenInBrowserModalProps) {
+export default function OpenInBrowserModal({ repo, onOpen, onCancel, theme: themeProp }: OpenInBrowserModalProps) {
+  const { theme, c } = useTheme(themeProp?.name ?? 'default');
   const [focus, setFocus] = useState<'this' | 'upstream'>('this');
 
   const forkUrl = `https://github.com/${repo.nameWithOwner}`;
@@ -50,16 +53,16 @@ export default function OpenInBrowserModal({ repo, onOpen, onCancel }: OpenInBro
     <Box
       flexDirection="column"
       borderStyle="round"
-      borderColor="cyan"
+      borderColor={theme.primary}
       paddingX={3}
       paddingY={2}
       width={62}
     >
-      <Text bold color="cyan">Open in Browser</Text>
+      <Text bold color={theme.primary}>Open in Browser</Text>
       <Box height={1}><Text> </Text></Box>
       <Text bold>{repo.nameWithOwner}</Text>
       {repo.parent && (
-        <Text color="gray">Fork of {repo.parent.nameWithOwner}</Text>
+        <Text color={theme.muted}>Fork of {repo.parent.nameWithOwner}</Text>
       )}
       <Box height={1}><Text> </Text></Box>
       <Text>Which repository would you like to open?</Text>
@@ -69,21 +72,21 @@ export default function OpenInBrowserModal({ repo, onOpen, onCancel }: OpenInBro
         <Box paddingX={2} paddingY={1}>
           <Text>
             {focus === 'this'
-              ? chalk.bgCyan.white.bold(' This Repository ')
-              : chalk.cyan.bold('This Repository')}
+              ? c.primary.inverse.bold(' This Repository ')
+              : c.primary.bold('This Repository')}
           </Text>
         </Box>
         <Box paddingX={2} paddingY={1}>
           <Text>
             {focus === 'upstream'
-              ? chalk.bgGreen.white.bold(' Parent/Upstream ')
-              : chalk.green.bold('Parent/Upstream')}
+              ? c.success.inverse.bold(' Parent/Upstream ')
+              : c.success.bold('Parent/Upstream')}
           </Text>
         </Box>
       </Box>
 
       <Box marginTop={1} flexDirection="row" justifyContent="center">
-        <Text color="gray">
+        <Text color={theme.muted}>
           ←/→ Choose • Enter to Open • T This • U Upstream • C/Esc Cancel
         </Text>
       </Box>

--- a/src/ui/components/modals/index.ts
+++ b/src/ui/components/modals/index.ts
@@ -11,4 +11,5 @@ export { ChangeVisibilityModal } from './ChangeVisibilityModal';
 export { default as CopyUrlModal } from './CopyUrlModal';
 export { default as RenameModal } from './RenameModal';
 export { StarModal } from './StarModal';
+export { default as OpenInBrowserModal } from './OpenInBrowserModal';
 

--- a/src/ui/components/repo/RepoRow.tsx
+++ b/src/ui/components/repo/RepoRow.tsx
@@ -28,15 +28,16 @@ export default function RepoRow({
   const langName = repo.primaryLanguage?.name || '';
   const langColor = repo.primaryLanguage?.color || '#666666';
   
-  // Calculate commits behind for forks - only show if tracking is enabled AND data is available
+  // Calculate ahead/behind for forks - only show if tracking is enabled AND enriched data is available
   const hasCommitData = repo.isFork && repo.parent && repo.defaultBranchRef && repo.parent.defaultBranchRef
     && repo.parent.defaultBranchRef.target?.history && repo.defaultBranchRef.target?.history;
-  
-  const commitsBehind = hasCommitData
-    ? (repo.parent.defaultBranchRef.target.history.totalCount - repo.defaultBranchRef.target.history.totalCount)
-    : 0;
-  
-  const showCommitsBehind = forkTracking && hasCommitData;
+
+  const forkCount = hasCommitData ? repo.defaultBranchRef.target.history.totalCount : 0;
+  const parentCount = hasCommitData ? repo.parent.defaultBranchRef.target.history.totalCount : 0;
+  const commitsBehind = hasCommitData ? Math.max(0, parentCount - forkCount) : 0;
+  const commitsAhead = hasCommitData ? Math.max(0, forkCount - parentCount) : 0;
+
+  const showCommitData = forkTracking && hasCommitData;
   
   // Build colored line 1
   let line1 = '';
@@ -62,11 +63,14 @@ export default function RepoRow({
   if (repo.isArchived) line1 += ' ' + chalk.bgGray.whiteBright(' Archived ') + ' ';
   if (repo.isFork && repo.parent) {
     line1 += chalk.blue(` Fork of ${repo.parent.nameWithOwner}`);
-    if (showCommitsBehind) {
-      if (commitsBehind > 0) {
-        line1 += chalk.yellow(` (${commitsBehind} behind)`);
+    if (showCommitData) {
+      const parts: string[] = [];
+      if (commitsAhead > 0) parts.push(chalk.green(`${commitsAhead} ahead`));
+      if (commitsBehind > 0) parts.push(chalk.yellow(`${commitsBehind} behind`));
+      if (parts.length > 0) {
+        line1 += chalk.gray(` (${parts.join(', ')})`);
       } else {
-        line1 += chalk.green(` (0 behind)`);
+        line1 += chalk.green(` (up to date)`);
       }
     }
   }

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -2409,6 +2409,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                 setOpenInBrowserMode(false);
                 setOpenInBrowserTarget(null);
               }}
+              theme={theme}
             />
           </Box>
         ) : (

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -2,14 +2,14 @@ import React, { useEffect, useMemo, useState, useRef, useCallback } from 'react'
 import { Box, Text, useApp, useInput, useStdout, Spacer, Newline } from 'ink';
 import TextInput from 'ink-text-input';
 import chalk from 'chalk';
-import { makeClient, fetchViewerReposPageUnified, searchRepositoriesUnified, deleteRepositoryRest, archiveRepositoryById, unarchiveRepositoryById, changeRepositoryVisibility, syncForkWithUpstream, getRepositoryFromCache, purgeApolloCacheFiles, inspectCacheStatus, updateCacheAfterDelete, updateCacheAfterArchive, updateCacheAfterVisibilityChange, updateCacheWithRepository, checkOrganizationIsEnterprise, OwnerAffiliation, fetchViewerOrganizations, fetchRestRateLimits, renameRepositoryById, updateCacheAfterRename, getStarredRepositories, starRepository, unstarRepository } from '../../services/github';
+import { makeClient, fetchViewerReposPageUnified, searchRepositoriesUnified, deleteRepositoryRest, archiveRepositoryById, unarchiveRepositoryById, changeRepositoryVisibility, syncForkWithUpstream, getRepositoryFromCache, purgeApolloCacheFiles, inspectCacheStatus, updateCacheAfterDelete, updateCacheAfterArchive, updateCacheAfterVisibilityChange, updateCacheWithRepository, checkOrganizationIsEnterprise, OwnerAffiliation, fetchViewerOrganizations, fetchRestRateLimits, renameRepositoryById, updateCacheAfterRename, getStarredRepositories, starRepository, unstarRepository, enrichForksWithAheadBehind, fetchRepositoryByOwnerAndName } from '../../services/github';
 import { getUIPrefs, storeUIPrefs, OwnerContext } from '../../config/config';
 import { makeApolloKey, makeSearchKey, isFresh, markFetched } from '../../services/apolloMeta';
 import type { RepoNode, RateLimitInfo, RestRateLimitInfo } from '../../types';
 import { exec } from 'child_process';
 import OrgSwitcher from '../OrgSwitcher';
 import { logger } from '../../lib/logger';
-import { ArchiveFilterModal, DeleteModal, ArchiveModal, SyncModal, InfoModal, LogoutModal, VisibilityModal, SortModal, SortDirectionModal, ChangeVisibilityModal, CopyUrlModal, RenameModal, StarModal } from '../components/modals';
+import { ArchiveFilterModal, DeleteModal, ArchiveModal, SyncModal, InfoModal, LogoutModal, VisibilityModal, SortModal, SortDirectionModal, ChangeVisibilityModal, CopyUrlModal, RenameModal, StarModal, OpenInBrowserModal } from '../components/modals';
 import { UnstarModal } from '../components/modals/UnstarModal';
 import { RepoRow, FilterInput, RepoListHeader } from '../components/repo';
 import { SlowSpinner } from '../components/common';
@@ -184,6 +184,14 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   const [starTarget, setStarTarget] = useState<RepoNode | null>(null);
   const [starring, setStarring] = useState(false);
   const [starError, setStarError] = useState<string | null>(null);
+
+  // Open-in-browser chooser modal state (fork vs upstream)
+  const [openInBrowserMode, setOpenInBrowserMode] = useState(false);
+  const [openInBrowserTarget, setOpenInBrowserTarget] = useState<RepoNode | null>(null);
+
+  // Fork enrichment (ahead/behind) state
+  const [enrichingForks, setEnrichingForks] = useState(false);
+  const enrichmentDoneRef = useRef<Set<string>>(new Set()); // ids already enriched
 
   // Apply initial --org flag once (if provided)
   const appliedInitialOrg = useRef(false);
@@ -725,7 +733,98 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   
   // Fork tracking toggle - default ON to show commits behind
   const [forkTracking, setForkTracking] = useState<boolean>(true);
-  
+
+  // Fork ahead/behind enrichment: runs after the full list is loaded.
+  // Uses batched aliased GraphQL queries (5 forks/batch) to stay within per-query budget.
+  useEffect(() => {
+    // Only run when the owned list is fully loaded and we have forks to enrich
+    if (loading || loadingMore || hasNextPage || items.length === 0) return;
+    if (!forkTracking) return;
+
+    const unenriched = items.filter(r =>
+      r.isFork &&
+      r.parent?.nameWithOwner &&
+      !enrichmentDoneRef.current.has(r.id) &&
+      !(r.defaultBranchRef?.target?.history && r.parent?.defaultBranchRef?.target?.history)
+    );
+
+    if (unenriched.length === 0) return;
+    if (enrichingForks) return;
+
+    let cancelled = false;
+    setEnrichingForks(true);
+
+    ;(async () => {
+      const BATCH_DELAY_MS = 200;
+
+      try {
+        const BATCH_SIZE = 5;
+        for (let i = 0; i < unenriched.length; i += BATCH_SIZE) {
+          if (cancelled) break;
+          const batch = unenriched.slice(i, i + BATCH_SIZE).map(r => ({
+            id: r.id,
+            parentNameWithOwner: r.parent!.nameWithOwner,
+          }));
+
+          const enriched = await enrichForksWithAheadBehind(client, batch);
+
+          if (cancelled) break;
+
+          // Merge history counts back into items
+          setItems(prev => prev.map(repo => {
+            const hit = enriched.find(e => e.id === repo.id);
+            if (!hit || hit.forkHistoryCount === null || hit.parentHistoryCount === null) return repo;
+
+            enrichmentDoneRef.current.add(repo.id);
+            return {
+              ...repo,
+              defaultBranchRef: repo.defaultBranchRef ? {
+                ...repo.defaultBranchRef,
+                target: {
+                  ...(repo.defaultBranchRef.target || {}),
+                  history: { totalCount: hit.forkHistoryCount! },
+                },
+              } : { name: undefined, target: { history: { totalCount: hit.forkHistoryCount! } } },
+              parent: repo.parent ? {
+                ...repo.parent,
+                defaultBranchRef: {
+                  ...(repo.parent.defaultBranchRef || {}),
+                  target: {
+                    ...(repo.parent.defaultBranchRef?.target || {}),
+                    history: { totalCount: hit.parentHistoryCount! },
+                  },
+                },
+              } : repo.parent,
+            };
+          }));
+
+          // Small delay between batches to avoid rate-limit pressure
+          if (i + BATCH_SIZE < unenriched.length) {
+            await new Promise(resolve => setTimeout(resolve, BATCH_DELAY_MS));
+          }
+        }
+      } catch (err: any) {
+        logger.error('Fork enrichment failed', { error: err.message });
+      } finally {
+        if (!cancelled) setEnrichingForks(false);
+      }
+    })();
+
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, loadingMore, hasNextPage, items.length, forkTracking]);
+
+  // Fetch a parent repo by nameWithOwner and display it in the Info modal (P key fallback)
+  async function jumpToUpstreamRepo(parentNameWithOwner: string) {
+    const [parentOwner, parentName] = parentNameWithOwner.split('/');
+    if (!parentOwner || !parentName) return;
+    const repo = await fetchRepositoryByOwnerAndName(client, parentOwner, parentName);
+    if (repo) {
+      setInfoRepo(repo);
+      setInfoMode(true);
+    }
+  }
+
   // Visibility filter - 'all' | 'public' | 'private'
   type VisibilityFilter = 'all' | 'public' | 'private';
   const [visibilityFilter, setVisibilityFilter] = useState<VisibilityFilter>('all');
@@ -1259,6 +1358,11 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return; // RenameModal component handles its own keyboard input
     }
 
+    // When open-in-browser modal is open, trap inputs for modal
+    if (openInBrowserMode) {
+      return; // OpenInBrowserModal component handles its own keyboard input
+    }
+
     // When copy URL modal is open, trap inputs for modal
     if (copyUrlMode) {
       return; // CopyUrlModal component handles its own keyboard input
@@ -1345,9 +1449,15 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     if (key.pageDown) setCursor(c => Math.min(c + 10, visibleItems.length - 1));
     if (key.pageUp) setCursor(c => Math.max(c - 10, 0));
     if (key.return) {
-      // Open in browser
       const repo = visibleItems[cursor];
-      if (repo) openInBrowser(`https://github.com/${repo.nameWithOwner}`);
+      if (repo) {
+        if (repo.isFork && repo.parent) {
+          setOpenInBrowserTarget(repo);
+          setOpenInBrowserMode(true);
+        } else {
+          openInBrowser(`https://github.com/${repo.nameWithOwner}`);
+        }
+      }
     }
     // Delete key: open delete modal (Del or Backspace)
     // Some terminals may set delete=true even for Backspace
@@ -1568,10 +1678,31 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return;
     }
 
-    // Explicit open in browser
+    // Explicit open in browser (O) - shows chooser for forks
     if (input && input.toUpperCase() === 'O') {
       const repo = visibleItems[cursor];
-      if (repo) openInBrowser(`https://github.com/${repo.nameWithOwner}`);
+      if (repo) {
+        if (repo.isFork && repo.parent) {
+          setOpenInBrowserTarget(repo);
+          setOpenInBrowserMode(true);
+        } else {
+          openInBrowser(`https://github.com/${repo.nameWithOwner}`);
+        }
+      }
+      return;
+    }
+
+    // Jump to upstream (P) - move cursor if parent is in list, else fetch and show in Info modal
+    if (input && input.toUpperCase() === 'P') {
+      const repo = visibleItems[cursor];
+      if (repo && repo.isFork && repo.parent?.nameWithOwner) {
+        const parentIdx = visibleItems.findIndex(r => r.nameWithOwner === repo.parent!.nameWithOwner);
+        if (parentIdx >= 0) {
+          setCursor(parentIdx);
+        } else {
+          jumpToUpstreamRepo(repo.parent.nameWithOwner);
+        }
+      }
       return;
     }
 
@@ -1777,7 +1908,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
 
   const lowRate = (rateLimit && rateLimit.remaining <= Math.ceil(rateLimit.limit * 0.1)) || 
                    (restRateLimit && restRateLimit.core.remaining <= Math.ceil(restRateLimit.core.limit * 0.1));
-  const modalOpen = deleteMode || archiveMode || syncMode || logoutMode || infoMode || visibilityMode || archiveFilterMode || sortMode || sortDirectionMode || changeVisibilityMode || copyUrlMode || renameMode;
+  const modalOpen = deleteMode || archiveMode || syncMode || logoutMode || infoMode || visibilityMode || archiveFilterMode || sortMode || sortDirectionMode || changeVisibilityMode || copyUrlMode || renameMode || openInBrowserMode;
 
   // Memoize header to prevent re-renders - must be before any returns
   const headerBar = useMemo(() => (
@@ -1793,6 +1924,9 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         <Text color="gray">({visibleItems.length}/{searchActive ? searchTotalCount : totalCount})</Text>
         {loadingMore && hasNextPage && !starsMode && !searchActive && totalCount > 0 && (
           <Text color="cyan">{` · loading ${items.length}/${totalCount}`}</Text>
+        )}
+        {enrichingForks && (
+          <Text color="gray">{` · enriching forks…`}</Text>
         )}
         {(loading || searchLoading || loadingMore) && (
           <Box width={2} flexShrink={0} flexGrow={0} marginLeft={1}>
@@ -1822,7 +1956,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         </Text>
       )}
     </Box>
-  ), [visibleItems.length, searchActive, searchTotalCount, totalCount, loading, searchLoading, rateLimit, lowRate, modalOpen, prevRateLimit, ownerContext, isEnterpriseOrg, restRateLimit, prevRestRateLimit]);
+  ), [visibleItems.length, searchActive, searchTotalCount, totalCount, loading, searchLoading, rateLimit, lowRate, modalOpen, prevRateLimit, ownerContext, isEnterpriseOrg, restRateLimit, prevRestRateLimit, enrichingForks, loadingMore, hasNextPage, starsMode, items.length]);
 
   if (error) {
     return (
@@ -2134,6 +2268,23 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               {syncTarget.parent && (
                 <Text color="gray">Upstream: {syncTarget.parent.nameWithOwner}</Text>
               )}
+              {(() => {
+                const hasData = syncTarget.isFork && syncTarget.parent &&
+                  syncTarget.defaultBranchRef?.target?.history &&
+                  syncTarget.parent.defaultBranchRef?.target?.history;
+                if (!hasData) return null;
+                const forkC = syncTarget.defaultBranchRef!.target!.history!.totalCount;
+                const parentC = syncTarget.parent!.defaultBranchRef!.target!.history!.totalCount;
+                const behind = Math.max(0, parentC - forkC);
+                const ahead = Math.max(0, forkC - parentC);
+                const parts: string[] = [];
+                if (ahead > 0) parts.push(chalk.green(`${ahead} ahead`));
+                if (behind > 0) parts.push(chalk.yellow(`${behind} behind`));
+                const statusText = parts.length === 0
+                  ? chalk.green('Your fork is up to date with upstream.')
+                  : `This fork is ${parts.join(', ')} of upstream.`;
+                return <Text>{statusText}</Text>;
+              })()}
               <Box marginTop={1}>
                 <Text>
                   This will merge upstream changes into your fork.
@@ -2399,6 +2550,21 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               error={starError}
             />
           </Box>
+        ) : openInBrowserMode && openInBrowserTarget ? (
+          <Box height={contentHeight} alignItems="center" justifyContent="center">
+            <OpenInBrowserModal
+              repo={openInBrowserTarget}
+              onOpen={(url) => {
+                openInBrowser(url);
+                setOpenInBrowserMode(false);
+                setOpenInBrowserTarget(null);
+              }}
+              onCancel={() => {
+                setOpenInBrowserMode(false);
+                setOpenInBrowserTarget(null);
+              }}
+            />
+          </Box>
         ) : (
           <>
             {/* Context/Filter/sort status */}
@@ -2541,9 +2707,9 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         {/* Line 3: Repository actions */}
         <Box width={terminalWidth} justifyContent="center">
           <Text color="gray" dimColor={modalOpen ? true : undefined}>
-            {starsMode ? 
+            {starsMode ?
               'I Info • C Copy URL • U Unstar Repository' :
-              'I Info • C Copy URL • Ctrl+S Un/Star • Ctrl+R Rename • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+F Sync Fork'
+              'I Info • C Copy URL • Ctrl+S Un/Star • Ctrl+R Rename • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+F Sync Fork • P Jump to upstream'
             }
           </Text>
         </Box>

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -733,7 +733,10 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     );
 
     if (unenriched.length === 0) return;
-    if (enrichingForks) return;
+    // No re-entrancy guard on `enrichingForks` here: React always runs the
+    // cleanup (setting `cancelled`) before re-running this effect, so two
+    // un-cancelled passes can never overlap. Gating on the UI flag was what
+    // left it stuck `true` after a torn-down pass.
 
     let cancelled = false;
     setEnrichingForks(true);
@@ -745,7 +748,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         const BATCH_SIZE = 5;
         for (let i = 0; i < unenriched.length; i += BATCH_SIZE) {
           if (cancelled) break;
-          const batch = unenriched.slice(i, i + BATCH_SIZE).map(r => ({
+          const slice = unenriched.slice(i, i + BATCH_SIZE);
+          const batch = slice.map(r => ({
             id: r.id,
             parentNameWithOwner: r.parent!.nameWithOwner,
           }));
@@ -754,12 +758,17 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
 
           if (cancelled) break;
 
+          // Mark every fork in the batch as processed — even ones that came
+          // back with null/missing counts — so a failed lookup isn't retried
+          // forever (the effect would otherwise re-fire on the next items
+          // change with these still "unenriched").
+          slice.forEach(r => enrichmentDoneRef.current.add(r.id));
+
           // Merge history counts back into items
           setItems(prev => prev.map(repo => {
             const hit = enriched.find(e => e.id === repo.id);
             if (!hit || hit.forkHistoryCount === null || hit.parentHistoryCount === null) return repo;
 
-            enrichmentDoneRef.current.add(repo.id);
             return {
               ...repo,
               defaultBranchRef: repo.defaultBranchRef ? {
@@ -790,11 +799,13 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       } catch (err: any) {
         logger.error('Fork enrichment failed', { error: err.message });
       } finally {
+        // Only clear when this pass wasn't torn down; a cancelled pass has the
+        // flag reset by the cleanup below so it can never stick `true`.
         if (!cancelled) setEnrichingForks(false);
       }
     })();
 
-    return () => { cancelled = true; };
+    return () => { cancelled = true; setEnrichingForks(false); };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loading, loadingMore, hasNextPage, items.length, forkTracking]);
 
@@ -878,6 +889,12 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         privacy
       );
       
+      // A fresh list load (refresh, sort change, org switch, first page)
+      // replaces items with un-enriched nodes — clear the enrichment tracker
+      // so forks get their ahead/behind counts recomputed against the new data.
+      if (reset || !after) {
+        enrichmentDoneRef.current.clear();
+      }
       setItems(prev => (reset || !after ? page.nodes : [...prev, ...page.nodes]));
       setEndCursor(page.endCursor);
       setHasNextPage(page.hasNextPage);

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -1556,11 +1556,24 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     if (input && input.toUpperCase() === 'P') {
       const repo = visibleItems[cursor];
       if (repo && repo.isFork && repo.parent?.nameWithOwner) {
-        const parentIdx = visibleItems.findIndex(r => r.nameWithOwner === repo.parent!.nameWithOwner);
+        const parentName = repo.parent.nameWithOwner;
+        const parentIdx = visibleItems.findIndex(r => r.nameWithOwner === parentName);
         if (parentIdx >= 0) {
+          // Parent is visible — move the cursor to it.
           setCursor(parentIdx);
         } else {
-          jumpToUpstreamRepo(repo.parent.nameWithOwner);
+          // Not visible. It may still be loaded (in items/starredItems) but
+          // hidden by a search/archive/visibility filter — prefer that cached
+          // copy and open it in Info, only fetching when it isn't loaded at all.
+          const cachedParent =
+            items.find(r => r.nameWithOwner === parentName) ||
+            starredItems.find(r => r.nameWithOwner === parentName);
+          if (cachedParent) {
+            setInfoRepo(cachedParent);
+            setInfoMode(true);
+          } else {
+            jumpToUpstreamRepo(parentName);
+          }
         }
       }
       return;


### PR DESCRIPTION
Assignee: @wiiiimm ([wiiiimm](https://linear.app/stealths/profiles/wiiiimm))
Closes: #38 

## Summary

Implements all fork↔upstream features from [SWR-362](https://linear.app/stealths/issue/SWR-362/forkupstream-features-post-360-aheadbehind-enrichment-jump-to-upstream), built on top of SWR-360's light bulk query:

- **Fork ahead/behind enrichment**: After the background fetch-all completes, a separate pass enriches forks-only with commit counts. Uses batched aliased GraphQL queries (`fork_N: node(id:)` + `parent_N: repository(owner,name)`) capped at 5 forks per request (10 history queries) to stay within GitHub's per-query budget. 200ms delay between batches. Results merge into `items` state; tracked via `enrichmentDoneRef` to avoid re-fetching. Never touches the bulk query.
- **Ahead/behind display**: `RepoRow` now shows `(N ahead, M behind)` / `(up to date)` once enriched. Sync confirmation modal also reflects both counts.
- **Jump to upstream (`P`)**: On a fork row, `P` moves the cursor to the parent if it is already in the loaded list; otherwise fetches the parent via `fetchRepositoryByOwnerAndName` and opens it in the Info modal.
- **Open-in-browser chooser**: Enter/`O` on a fork now shows `OpenInBrowserModal` — **This Repository** / **Parent/upstream** with Left/Right, T/U shortcuts, and Esc to cancel. Non-forks continue to open directly.

## Acceptance Criteria

- [x] Forks show both **ahead** and **behind**, populated by a forks-only enrichment pass (no 502, never in the bulk query)
- [x] Counts merge into items state; RepoRow + sync modal reflect them; respects `forkTracking` + rate limits
- [x] `P` jumps to upstream (cursor if loaded; else fetch + Info modal)
- [x] Open-in-browser shows a repo/parent chooser for forks; direct for non-forks; Esc cancels
- [x] Built on current `main` (post-360); no reintroduction of the heavy bulk query
- [x] README.md, AGENTS.md updated

## Files Changed

- `src/services/github.ts` — `enrichForksWithAheadBehind()` (batched enrichment), `fetchRepositoryByOwnerAndName()` (P fallback)
- `src/ui/components/modals/OpenInBrowserModal.tsx` — new chooser modal
- `src/ui/components/modals/index.ts` — export new modal
- `src/ui/components/repo/RepoRow.tsx` — show ahead + behind counts
- `src/ui/views/RepoList.tsx` — enrichment effect, P key, open-in-browser fork path, sync modal ahead/behind

## Test Notes

Pre-existing test failures (sponsorship docs and ArchiveModal tests) are unrelated to this change. Build passes cleanly with tsup/esbuild.

---
> **Tip:** I will respond to comments that @ mention @cyrus-mini-5 on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds extra GraphQL after full list load (rate-limit surface) and new keyboard paths in RepoList; no auth or destructive-action changes.
> 
> **Overview**
> Adds **fork ahead/behind enrichment** after the repo list finishes background loading: batched GraphQL via `enrichForksWithAheadBehind` (5 forks per request, 200ms between batches), merged into list state with `enrichmentDoneRef` so the light bulk query stays unchanged.
> 
> **UI/keyboard:** `RepoRow` and the sync confirmation show **ahead** and **behind** (or “up to date”); **`P`** jumps to the parent in the list or opens Info after `fetchRepositoryByOwnerAndName`; Enter/**`O`** on forks opens new **`OpenInBrowserModal`** (this repo vs parent). Docs (`README.md`, `AGENTS.md`) and footer hints updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed52db50ebebf3c900ca79805a51cbc104878fc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->