### PR TITLE
feat: colour themes with Shift+T cycle keybinding and persisted preference (SWR-354) [semantic pr title]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,7 @@ First run prompts for a PAT if not provided via env vars. The token is validated
 - **Automation:** semantic-release handles version bumping and git tags
 - **Release process:** Automated via GitHub Actions on main branch push
 - **Change tracking:** All releases documented in [CHANGELOG.md](./CHANGELOG.md)
+- **Do NOT manually edit [CHANGELOG.md](./CHANGELOG.md):** it is generated automatically by the semantic-release GitHub Actions workflow (`.github/workflows/automated-release.yml`) from conventional commit messages on `main`. Manual edits cause merge conflicts and are overwritten on the next release. To influence the changelog, write a well-formed conventional commit / PR title instead. When a feature branch conflicts with `main` on CHANGELOG.md, resolve by taking `main`'s version.
 
 ### Code Standards
 - **TypeScript:** Strict mode with comprehensive type definitions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ gh-manager-cli/
 - Repository actions: delete, archive/unarchive, change visibility, sync forks
 - Organization and Enterprise GitHub support
 - Modal-based UI for sorting, filtering, and actions
-- Persistent UI preferences (sort, density, visibility filter, fork tracking)
+- Persistent UI preferences (sort, density, visibility filter, fork tracking, colour theme)
 - Real-time rate limit monitoring for GraphQL and REST APIs
 
 ### Planned Enhancements
@@ -120,6 +120,7 @@ See the living roadmap in [TODOs.md](./TODOs.md) for the canonical, up-to-date l
 - `S`: sort modal (updated, pushed, name, stars)
 - `D`: toggle sort direction
 - `T`: toggle display density (compact/cozy/comfy)
+- `Shift+T`: cycle colour theme (Default → Ocean → Forest → Monochrome); persists across restarts
 - `F`: toggle fork commit tracking
 - `V`: visibility filter modal (All, Public, Private/Internal)
 - `W`: organization switcher

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [Unreleased]
+
+### Added
+
+* Colour themes with `Shift+T` cycle keybinding and persisted preference ([SWR-354](https://linear.app/stealths/issue/SWR-354/color-themes-with-cycle-keybinding-and-persisted-preference))
+  * Four built-in themes: Default, Ocean, Forest, Monochrome (accessibility-friendly)
+  * `Shift+T` cycles to the next theme with a brief toast notification
+  * Theme selection persists across restarts via UI preferences
+  * Theme colors applied consistently across all components: list, rows, header, and all modals
+
 ## [1.40.1](https://github.com/wiiiimm/gh-manager-cli/compare/v1.40.0...v1.40.1) (2026-06-05)
 
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ On first run, you'll be prompted to authenticate with GitHub (OAuth recommended)
 ### User Interface & Experience
 - **Keyboard Navigation**: Full keyboard control (arrow keys, PageUp/Down, `Ctrl+G`/`G`)
 - **Display Density**: Toggle between compact/cozy/comfy spacing (`T`)
+- **Colour Themes**: Four themes (Default, Ocean, Forest, Monochrome) cycled with `Shift+T`, persisted across restarts
 - **Visual Indicators**: Fork status, private/internal/archived badges, language colors, visibility status
 - **Enterprise Support**: Full support for GitHub Enterprise with Internal repository visibility
 - **Organization Context**: Switch between personal and organization accounts with ENT badge for enterprise orgs
@@ -270,6 +271,7 @@ Launch the app, then use the keys below:
   - Stars: Number of stars
 - **Sort Direction**: `D` to open sort direction modal (ascending/descending)
 - **Display Density**: `T` to toggle compact/cozy/comfy
+- **Colour Theme**: `Shift+T` to cycle themes (Default → Ocean → Forest → Monochrome); selection persists across restarts
 - **Fork Status**: Always enabled - shows commits behind upstream for all forks
 - **Visibility Filter**: `V` opens modal (All, Public, Private/Internal for enterprise)
 - **Archive Filter**: `A` toggles archive filter (All → Unarchived → Archived)

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import envPaths from 'env-paths';
+import type { ThemeName } from './themes';
 
 type Density = 0 | 1 | 2;
 
@@ -14,6 +15,8 @@ interface UIPrefs {
   ownerAffiliations?: string[];
   ownerContext?: OwnerContext;
   visibilityFilter?: 'all' | 'public' | 'private';
+  archiveFilter?: 'all' | 'unarchived' | 'archived';
+  theme?: ThemeName;
 }
 
 export type TokenSource = 'pat' | 'oauth';

--- a/src/config/themes.ts
+++ b/src/config/themes.ts
@@ -1,0 +1,101 @@
+export type ThemeName = 'default' | 'ocean' | 'forest' | 'monochrome';
+
+export interface Theme {
+  name: ThemeName;
+  label: string;
+  primary: string;
+  secondary: string;
+  success: string;
+  warning: string;
+  error: string;
+  muted: string;
+  text: string;
+  selected: string;
+  private: string;
+  archived: string;
+  internal: string;
+  fork: string;
+  dim: string;
+}
+
+export const THEMES: Record<ThemeName, Theme> = {
+  default: {
+    name: 'default',
+    label: 'Default',
+    primary: 'cyan',
+    secondary: 'blue',
+    success: 'green',
+    warning: 'yellow',
+    error: 'red',
+    muted: 'gray',
+    text: 'white',
+    selected: 'cyan',
+    private: 'yellow',
+    archived: 'gray',
+    internal: 'magenta',
+    fork: 'blue',
+    dim: 'gray',
+  },
+  ocean: {
+    name: 'ocean',
+    label: 'Ocean',
+    primary: 'blueBright',
+    secondary: 'cyan',
+    success: 'greenBright',
+    warning: 'yellowBright',
+    error: 'redBright',
+    muted: 'blue',
+    text: 'whiteBright',
+    selected: 'blueBright',
+    private: 'cyan',
+    archived: 'blue',
+    internal: 'magenta',
+    fork: 'cyanBright',
+    dim: 'blue',
+  },
+  forest: {
+    name: 'forest',
+    label: 'Forest',
+    primary: 'green',
+    secondary: 'greenBright',
+    success: 'greenBright',
+    warning: 'yellow',
+    error: 'red',
+    muted: 'gray',
+    text: 'white',
+    selected: 'green',
+    private: 'yellow',
+    archived: 'gray',
+    internal: 'magenta',
+    fork: 'greenBright',
+    dim: 'gray',
+  },
+  monochrome: {
+    name: 'monochrome',
+    label: 'Monochrome',
+    primary: 'white',
+    secondary: 'whiteBright',
+    success: 'whiteBright',
+    warning: 'white',
+    error: 'white',
+    muted: 'gray',
+    text: 'white',
+    selected: 'whiteBright',
+    private: 'white',
+    archived: 'gray',
+    internal: 'white',
+    fork: 'white',
+    dim: 'gray',
+  },
+};
+
+export const THEME_ORDER: ThemeName[] = ['default', 'ocean', 'forest', 'monochrome'];
+
+export function getTheme(name: ThemeName): Theme {
+  return THEMES[name] ?? THEMES.default;
+}
+
+export function nextTheme(current: ThemeName): ThemeName {
+  const idx = THEME_ORDER.indexOf(current);
+  return THEME_ORDER[(idx + 1) % THEME_ORDER.length];
+}

--- a/src/ui/components/modals/ArchiveFilterModal.tsx
+++ b/src/ui/components/modals/ArchiveFilterModal.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import chalk from 'chalk';
+import type { Theme } from '../../../config/themes';
+import { useTheme } from '../../hooks/useTheme';
 
 type ArchiveFilter = 'all' | 'unarchived' | 'archived';
 
@@ -8,13 +10,16 @@ interface ArchiveFilterModalProps {
   currentFilter: ArchiveFilter;
   onSelect: (filter: ArchiveFilter) => void;
   onCancel: () => void;
+  theme?: Theme;
 }
 
 export default function ArchiveFilterModal({
   currentFilter,
   onSelect,
   onCancel,
+  theme: themeProp,
 }: ArchiveFilterModalProps) {
+  const { theme, c } = useTheme(themeProp?.name ?? 'default');
   const options: ArchiveFilter[] = ['all', 'unarchived', 'archived'];
 
   const [focusedOption, setFocusedOption] = useState<ArchiveFilter | 'cancel'>(currentFilter);
@@ -31,8 +36,7 @@ export default function ArchiveFilterModal({
 
     if (key.leftArrow || key.upArrow) {
       if (focusedOption === 'cancel') {
-        const lastIndex = options.length - 1;
-        setFocusedOption(options[lastIndex]);
+        setFocusedOption(options[options.length - 1]);
       } else {
         const idx = options.indexOf(focusedOption as ArchiveFilter);
         if (idx > 0) setFocusedOption(options[idx - 1]);
@@ -42,11 +46,8 @@ export default function ArchiveFilterModal({
     if (key.rightArrow || key.downArrow) {
       if (focusedOption !== 'cancel') {
         const idx = options.indexOf(focusedOption as ArchiveFilter);
-        if (idx < options.length - 1) {
-          setFocusedOption(options[idx + 1]);
-        } else {
-          setFocusedOption('cancel');
-        }
+        if (idx < options.length - 1) setFocusedOption(options[idx + 1]);
+        else setFocusedOption('cancel');
       }
     }
 
@@ -55,23 +56,16 @@ export default function ArchiveFilterModal({
         setFocusedOption(options[0]);
       } else {
         const idx = options.indexOf(focusedOption as ArchiveFilter);
-        if (idx < options.length - 1) {
-          setFocusedOption(options[idx + 1]);
-        } else {
-          setFocusedOption('cancel');
-        }
+        if (idx < options.length - 1) setFocusedOption(options[idx + 1]);
+        else setFocusedOption('cancel');
       }
     }
 
     if (key.return) {
-      if (focusedOption === 'cancel') {
-        onCancel();
-      } else {
-        onSelect(focusedOption as ArchiveFilter);
-      }
+      if (focusedOption === 'cancel') onCancel();
+      else onSelect(focusedOption as ArchiveFilter);
     }
 
-    // Quick select shortcuts
     if (input) {
       const u = input.toUpperCase();
       if (u === 'L') onSelect('all');
@@ -88,24 +82,25 @@ export default function ArchiveFilterModal({
     }
   };
 
-  const getColor = (filter: ArchiveFilter): string => {
-    if (filter === currentFilter) return 'green';
-    return focusedOption === filter ? 'cyan' : 'gray';
+  const getOptionChalk = (filter: ArchiveFilter) => {
+    if (filter === currentFilter) return c.success;
+    return focusedOption === filter ? c.primary : c.muted;
   };
 
   return (
-    <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={2} paddingY={1} width={45}>
+    <Box flexDirection="column" borderStyle="round" borderColor={theme.primary} paddingX={2} paddingY={1} width={45}>
       <Text bold>Archive Filter</Text>
 
       <Box flexDirection="column" marginTop={1}>
         {options.map((option) => (
           <Box key={option} paddingX={1}>
             <Text>
-              {focusedOption === option ? chalk.bgCyan.black(' → ') : '   '}
+              {focusedOption === option ? c.arrow(' → ') : '   '}
               {focusedOption === option
-                ? chalk[getColor(option)].bold(getLabel(option))
-                : chalk[getColor(option)](getLabel(option))}
-              {option === currentFilter && chalk.green(' ✓')}
+                ? getOptionChalk(option).bold(getLabel(option))
+                : getOptionChalk(option)(getLabel(option))
+              }
+              {option === currentFilter && c.success(' ✓')}
             </Text>
           </Box>
         ))}
@@ -113,13 +108,13 @@ export default function ArchiveFilterModal({
         <Box paddingX={1}>
           <Text>
             {focusedOption === 'cancel' ? chalk.bgWhite.black(' → ') : '   '}
-            {focusedOption === 'cancel' ? chalk.white.bold('Cancel') : chalk.gray('Cancel')}
+            {focusedOption === 'cancel' ? chalk.white.bold('Cancel') : c.muted('Cancel')}
           </Text>
         </Box>
       </Box>
 
       <Box marginTop={1}>
-        <Text color="gray" dimColor>
+        <Text color={theme.muted} dimColor>
           ↑↓/Enter • L All • U Unarchived • R Archived • Esc
         </Text>
       </Box>

--- a/src/ui/components/modals/ArchiveFilterModal.tsx
+++ b/src/ui/components/modals/ArchiveFilterModal.tsx
@@ -107,7 +107,7 @@ export default function ArchiveFilterModal({
 
         <Box paddingX={1}>
           <Text>
-            {focusedOption === 'cancel' ? chalk.bgWhite.black(' → ') : '   '}
+            {focusedOption === 'cancel' ? c.arrowMuted(' → ') : '   '}
             {focusedOption === 'cancel' ? chalk.white.bold('Cancel') : c.muted('Cancel')}
           </Text>
         </Box>

--- a/src/ui/components/modals/ChangeVisibilityModal.tsx
+++ b/src/ui/components/modals/ChangeVisibilityModal.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import TextInput from 'ink-text-input';
 import chalk from 'chalk';
+import type { Theme } from '../../../config/themes';
+import { useTheme } from '../../hooks/useTheme';
 
 interface ChangeVisibilityModalProps {
   isOpen: boolean;
@@ -13,6 +15,7 @@ interface ChangeVisibilityModalProps {
   onClose: () => void;
   changing?: boolean;
   error?: string | null;
+  theme?: Theme;
 }
 
 export const ChangeVisibilityModal: React.FC<ChangeVisibilityModalProps> = ({
@@ -25,7 +28,9 @@ export const ChangeVisibilityModal: React.FC<ChangeVisibilityModalProps> = ({
   onClose,
   changing: externalChanging,
   error: externalError,
+  theme: themeProp,
 }) => {
+  const { c } = useTheme(themeProp?.name ?? 'default');
   // Determine available visibility options based on current visibility and enterprise status
   const getAvailableOptions = () => {
     if (currentVisibility === 'PUBLIC') {
@@ -164,9 +169,7 @@ export const ChangeVisibilityModal: React.FC<ChangeVisibilityModalProps> = ({
               justifyContent="center"
               flexDirection="column"
             >
-              <Text>
-                {chalk.bgGray.white.bold(' Cancel ')}
-              </Text>
+              <Text>{c.btnMuted(' Cancel ')}</Text>
             </Box>
           </Box>
           <Box marginTop={1} flexDirection="row" justifyContent="center">
@@ -225,10 +228,7 @@ export const ChangeVisibilityModal: React.FC<ChangeVisibilityModalProps> = ({
               flexDirection="column"
             >
               <Text>
-                {focusedButton === 'cancel' ? 
-                  chalk.bgGray.white.bold(' Cancel ') : 
-                  chalk.gray.bold('Cancel')
-                }
+                {focusedButton === 'cancel' ? c.btnMuted(' Cancel ') : c.muted.bold('Cancel')}
               </Text>
             </Box>
           </Box>

--- a/src/ui/components/modals/CopyUrlModal.tsx
+++ b/src/ui/components/modals/CopyUrlModal.tsx
@@ -2,17 +2,21 @@ import React, { useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import chalk from 'chalk';
 import type { RepoNode } from '../../../types';
+import type { Theme } from '../../../config/themes';
+import { useTheme } from '../../hooks/useTheme';
 
 interface CopyUrlModalProps {
   repo: RepoNode | null;
   terminalWidth: number;
   onClose: () => void;
   onCopy: (url: string, type: 'SSH' | 'HTTPS') => Promise<void>;
+  theme?: Theme;
 }
 
 type UrlType = 'SSH' | 'HTTPS';
 
-export default function CopyUrlModal({ repo, terminalWidth, onClose, onCopy }: CopyUrlModalProps) {
+export default function CopyUrlModal({ repo, terminalWidth, onClose, onCopy, theme: themeProp }: CopyUrlModalProps) {
+  const { theme, c } = useTheme(themeProp?.name ?? 'default');
   const [copyError, setCopyError] = useState<string | null>(null);
   const [selectedType, setSelectedType] = useState<UrlType>('SSH'); // SSH selected by default
 
@@ -99,54 +103,54 @@ export default function CopyUrlModal({ repo, terminalWidth, onClose, onCopy }: C
   };
 
   return (
-    <Box 
-      flexDirection="column" 
-      borderStyle="round" 
-      borderColor="blue" 
-      paddingX={3} 
-      paddingY={2} 
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={theme.secondary}
+      paddingX={3}
+      paddingY={2}
       width={Math.min(terminalWidth - 8, 80)}
     >
-      <Text bold color="blue">Copy Repository URL</Text>
+      <Text bold color={theme.secondary}>Copy Repository URL</Text>
       <Box height={1}><Text> </Text></Box>
-      
+
       <Text>{chalk.bold(repo.nameWithOwner)}</Text>
       <Box height={1}><Text> </Text></Box>
 
-      <Text color="gray">SSH URL:</Text>
-      <Box 
-        paddingX={2} 
-        paddingY={1} 
-        borderStyle="single" 
-        borderColor={selectedType === 'SSH' ? 'blue' : 'gray'}
+      <Text color={theme.muted}>SSH URL:</Text>
+      <Box
+        paddingX={2}
+        paddingY={1}
+        borderStyle="single"
+        borderColor={selectedType === 'SSH' ? theme.secondary : theme.muted}
       >
-        <Text color={selectedType === 'SSH' ? 'blue' : undefined}>
+        <Text color={selectedType === 'SSH' ? theme.secondary : undefined}>
           {selectedType === 'SSH' ? '▶ ' : '  '}{sshUrl}
         </Text>
       </Box>
       <Box height={1}><Text> </Text></Box>
 
-      <Text color="gray">HTTPS URL:</Text>
-      <Box 
-        paddingX={2} 
-        paddingY={1} 
-        borderStyle="single" 
-        borderColor={selectedType === 'HTTPS' ? 'blue' : 'gray'}
+      <Text color={theme.muted}>HTTPS URL:</Text>
+      <Box
+        paddingX={2}
+        paddingY={1}
+        borderStyle="single"
+        borderColor={selectedType === 'HTTPS' ? theme.secondary : theme.muted}
       >
-        <Text color={selectedType === 'HTTPS' ? 'blue' : undefined}>
+        <Text color={selectedType === 'HTTPS' ? theme.secondary : undefined}>
           {selectedType === 'HTTPS' ? '▶ ' : '  '}{httpsUrl}
         </Text>
       </Box>
       <Box height={1}><Text> </Text></Box>
 
-      <Text color="gray">
+      <Text color={theme.muted}>
         ↑↓ Select • Enter/Y to copy {selectedType} • S copy SSH • H copy HTTPS • Esc/Q/C to close
       </Text>
-      
+
       {copyError && (
         <>
           <Box height={1}><Text> </Text></Box>
-          <Text color="red">{copyError}</Text>
+          <Text color={theme.error}>{copyError}</Text>
         </>
       )}
     </Box>

--- a/src/ui/components/modals/RenameModal.tsx
+++ b/src/ui/components/modals/RenameModal.tsx
@@ -1,17 +1,20 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import TextInput from 'ink-text-input';
-import chalk from 'chalk';
 import type { RepoNode } from '../../../types';
+import type { Theme } from '../../../config/themes';
+import { useTheme } from '../../hooks/useTheme';
 import { SlowSpinner } from '../common';
 
 interface RenameModalProps {
   repo: RepoNode | null;
   onRename: (repo: RepoNode, newName: string) => Promise<void>;
   onCancel: () => void;
+  theme?: Theme;
 }
 
-export default function RenameModal({ repo, onRename, onCancel }: RenameModalProps) {
+export default function RenameModal({ repo, onRename, onCancel, theme: themeProp }: RenameModalProps) {
+  const { theme } = useTheme(themeProp?.name ?? 'default');
   const [newName, setNewName] = useState('');
   const [renaming, setRenaming] = useState(false);
   const [renameError, setRenameError] = useState<string | null>(null);
@@ -69,20 +72,20 @@ export default function RenameModal({ repo, onRename, onCancel }: RenameModalPro
   const isDisabled = !newName.trim() || newName === repo.name;
 
   return (
-    <Box 
-      flexDirection="column" 
-      borderStyle="round" 
-      borderColor="cyan" 
-      paddingX={3} 
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={theme.primary}
+      paddingX={3}
       paddingY={2}
       width={80}
     >
-      <Text bold color="cyan">Rename Repository</Text>
+      <Text bold color={theme.primary}>Rename Repository</Text>
       <Box height={1}><Text> </Text></Box>
-      
-      <Text color="gray">Current: {repo.nameWithOwner}</Text>
+
+      <Text color={theme.muted}>Current: {repo.nameWithOwner}</Text>
       <Box height={1}><Text> </Text></Box>
-      
+
       <Text>New name:</Text>
       <Box flexDirection="row" alignItems="center">
         <Text>{owner}/</Text>
@@ -93,35 +96,35 @@ export default function RenameModal({ repo, onRename, onCancel }: RenameModalPro
           focus={!renaming}
         />
       </Box>
-      
+
       {renaming ? (
         <Box marginTop={2} justifyContent="center">
           <Box flexDirection="row">
             <Box marginRight={1}>
               <SlowSpinner />
             </Box>
-            <Text color="cyan">Renaming repository...</Text>
+            <Text color={theme.primary}>Renaming repository...</Text>
           </Box>
         </Box>
       ) : (
         <>
           <Box marginTop={2}>
-            <Text color="gray">
-              {isDisabled ? 
-                'Enter a different name to rename' : 
+            <Text color={theme.muted}>
+              {isDisabled ?
+                'Enter a different name to rename' :
                 `Press Enter to rename to "${newName}"`
               }
             </Text>
           </Box>
           <Box marginTop={1}>
-            <Text color="gray">Press Esc to cancel</Text>
+            <Text color={theme.muted}>Press Esc to cancel</Text>
           </Box>
         </>
       )}
-      
+
       {renameError && (
         <Box marginTop={1}>
-          <Text color="red">{renameError}</Text>
+          <Text color={theme.error}>{renameError}</Text>
         </Box>
       )}
     </Box>

--- a/src/ui/components/modals/SortDirectionModal.tsx
+++ b/src/ui/components/modals/SortDirectionModal.tsx
@@ -136,7 +136,7 @@ export default function SortDirectionModal({
 
         <Box paddingX={1} marginTop={1}>
           <Text>
-            {focusedOption === 'cancel' ? chalk.bgWhite.black(' → ') : '   '}
+            {focusedOption === 'cancel' ? c.arrowMuted(' → ') : '   '}
             {focusedOption === 'cancel' ? chalk.white.bold('Cancel') : c.muted('Cancel')}
           </Text>
         </Box>

--- a/src/ui/components/modals/SortDirectionModal.tsx
+++ b/src/ui/components/modals/SortDirectionModal.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import chalk from 'chalk';
 import { SortKey } from './SortModal';
+import type { Theme } from '../../../config/themes';
+import { useTheme } from '../../hooks/useTheme';
 
 export type SortDirection = 'asc' | 'desc';
 
@@ -10,92 +12,72 @@ interface SortDirectionModalProps {
   currentSortKey: SortKey;
   onSelect: (direction: SortDirection) => void;
   onCancel: () => void;
+  theme?: Theme;
 }
 
-export default function SortDirectionModal({ 
-  currentDirection, 
+export default function SortDirectionModal({
+  currentDirection,
   currentSortKey,
-  onSelect, 
-  onCancel 
+  onSelect,
+  onCancel,
+  theme: themeProp,
 }: SortDirectionModalProps) {
+  const { theme, c } = useTheme(themeProp?.name ?? 'default');
   const options: SortDirection[] = ['desc', 'asc'];
-  
+
   const [focusedOption, setFocusedOption] = useState<SortDirection | 'cancel'>(currentDirection);
-  
-  // Set initial focus to current direction
+
   useEffect(() => {
     setFocusedOption(currentDirection);
   }, [currentDirection]);
-  
+
   useInput((input, key) => {
     if (key.escape || (input && input.toUpperCase() === 'C')) {
       onCancel();
       return;
     }
-    
+
     if (key.leftArrow || key.upArrow) {
-      // Move selection up
       if (focusedOption === 'cancel') {
-        // Move from cancel to last option
         setFocusedOption(options[options.length - 1]);
       } else if (focusedOption === 'asc') {
         setFocusedOption('desc');
-      } else if (focusedOption === 'desc') {
-        // Stay at top
       }
     }
-    
+
     if (key.rightArrow || key.downArrow) {
-      // Move selection down
-      if (focusedOption === 'desc') {
-        setFocusedOption('asc');
-      } else if (focusedOption === 'asc') {
-        setFocusedOption('cancel');
-      } else if (focusedOption === 'cancel') {
-        // Stay at bottom
-      }
+      if (focusedOption === 'desc') setFocusedOption('asc');
+      else if (focusedOption === 'asc') setFocusedOption('cancel');
     }
-    
+
     if (key.tab) {
-      // Tab through all options including cancel
-      if (focusedOption === 'desc') {
-        setFocusedOption('asc');
-      } else if (focusedOption === 'asc') {
-        setFocusedOption('cancel');
-      } else if (focusedOption === 'cancel') {
-        setFocusedOption('desc');
-      }
+      if (focusedOption === 'desc') setFocusedOption('asc');
+      else if (focusedOption === 'asc') setFocusedOption('cancel');
+      else if (focusedOption === 'cancel') setFocusedOption('desc');
     }
-    
+
     if (key.return) {
-      if (focusedOption === 'cancel') {
-        onCancel();
-      } else {
-        onSelect(focusedOption as SortDirection);
-      }
+      if (focusedOption === 'cancel') onCancel();
+      else onSelect(focusedOption as SortDirection);
     }
-    
-    // Quick select shortcuts
+
     if (input) {
       const upperInput = input.toUpperCase();
-      if (upperInput === 'A') {
-        onSelect('asc');
-      } else if (upperInput === 'D') {
-        onSelect('desc');
-      }
+      if (upperInput === 'A') onSelect('asc');
+      else if (upperInput === 'D') onSelect('desc');
     }
   });
-  
+
   const getButtonLabel = (direction: SortDirection): string => {
     switch (direction) {
       case 'desc': return 'Descending ↓';
       case 'asc': return 'Ascending ↑';
     }
   };
-  
+
   const getButtonDescription = (direction: SortDirection): string => {
     switch (direction) {
-      case 'desc': 
+      case 'desc':
         switch (currentSortKey) {
           case 'updated': return 'Most recently updated first';
           case 'pushed': return 'Most recently pushed first';
@@ -113,14 +95,12 @@ export default function SortDirectionModal({
         }
     }
   };
-  
-  const getButtonColor = (direction: SortDirection): string => {
-    if (direction === currentDirection) {
-      return 'green'; // Current selection
-    }
-    return focusedOption === direction ? 'cyan' : 'gray';
+
+  const getOptionChalk = (direction: SortDirection) => {
+    if (direction === currentDirection) return c.success;
+    return focusedOption === direction ? c.primary : c.muted;
   };
-  
+
   const formatSortKey = (): string => {
     switch (currentSortKey) {
       case 'updated': return 'Last Updated';
@@ -129,48 +109,41 @@ export default function SortDirectionModal({
       case 'stars': return 'Stars';
     }
   };
-  
+
   return (
-    <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={2} paddingY={1} width={45}>
+    <Box flexDirection="column" borderStyle="round" borderColor={theme.primary} paddingX={2} paddingY={1} width={45}>
       <Text bold>Sort Direction</Text>
-      <Text color="gray" dimColor>Sorting by: {formatSortKey()}</Text>
-      
-      {/* Option buttons with descriptions */}
+      <Text color={theme.muted} dimColor>Sorting by: {formatSortKey()}</Text>
+
       <Box flexDirection="column" marginTop={1}>
         {options.map((option) => (
           <Box key={option} paddingX={1} marginBottom={0}>
             <Box flexDirection="column">
               <Text>
-                {focusedOption === option ? 
-                  chalk.bgCyan.black(' → ') : '   '}
-                {focusedOption === option ? 
-                  chalk[getButtonColor(option)].bold(getButtonLabel(option)) : 
-                  chalk[getButtonColor(option)](getButtonLabel(option))
+                {focusedOption === option ? c.arrow(' → ') : '   '}
+                {focusedOption === option
+                  ? getOptionChalk(option).bold(getButtonLabel(option))
+                  : getOptionChalk(option)(getButtonLabel(option))
                 }
-                {option === currentDirection && chalk.green(' ✓')}
+                {option === currentDirection && c.success(' ✓')}
               </Text>
-              <Text color="gray" dimColor>
+              <Text color={theme.muted} dimColor>
                 {'      '}{getButtonDescription(option)}
               </Text>
             </Box>
           </Box>
         ))}
-        
-        {/* Cancel option */}
+
         <Box paddingX={1} marginTop={1}>
           <Text>
-            {focusedOption === 'cancel' ? 
-              chalk.bgWhite.black(' → ') : '   '}
-            {focusedOption === 'cancel' ? 
-              chalk.white.bold('Cancel') : 
-              chalk.gray('Cancel')
-            }
+            {focusedOption === 'cancel' ? chalk.bgWhite.black(' → ') : '   '}
+            {focusedOption === 'cancel' ? chalk.white.bold('Cancel') : c.muted('Cancel')}
           </Text>
         </Box>
       </Box>
-      
+
       <Box marginTop={1}>
-        <Text color="gray" dimColor>
+        <Text color={theme.muted} dimColor>
           ↑↓/Enter • A/D • Esc
         </Text>
       </Box>

--- a/src/ui/components/modals/SortModal.tsx
+++ b/src/ui/components/modals/SortModal.tsx
@@ -131,7 +131,7 @@ export default function SortModal({
 
         <Box paddingX={1}>
           <Text>
-            {focusedOption === 'cancel' ? chalk.bgWhite.black(' → ') : '   '}
+            {focusedOption === 'cancel' ? c.arrowMuted(' → ') : '   '}
             {focusedOption === 'cancel' ? chalk.white.bold('Cancel') : c.muted('Cancel')}
           </Text>
         </Box>

--- a/src/ui/components/modals/SortModal.tsx
+++ b/src/ui/components/modals/SortModal.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import chalk from 'chalk';
+import type { Theme } from '../../../config/themes';
+import { useTheme } from '../../hooks/useTheme';
 
 export type SortKey = 'updated' | 'pushed' | 'name' | 'stars';
 
@@ -8,19 +10,21 @@ interface SortModalProps {
   currentSort: SortKey;
   onSelect: (sort: SortKey) => void;
   onCancel: () => void;
+  theme?: Theme;
 }
 
-export default function SortModal({ 
-  currentSort, 
-  onSelect, 
-  onCancel 
+export default function SortModal({
+  currentSort,
+  onSelect,
+  onCancel,
+  theme: themeProp,
 }: SortModalProps) {
+  const { theme, c } = useTheme(themeProp?.name ?? 'default');
   const options: SortKey[] = ['updated', 'pushed', 'name', 'stars'];
-  
+
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [focusedOption, setFocusedOption] = useState<SortKey | 'cancel'>('updated');
-  
-  // Set initial focus to current sort
+
   useEffect(() => {
     const currentIndex = options.indexOf(currentSort);
     if (currentIndex !== -1) {
@@ -28,17 +32,15 @@ export default function SortModal({
       setFocusedOption(currentSort);
     }
   }, [currentSort]);
-  
+
   useInput((input, key) => {
     if (key.escape || (input && input.toUpperCase() === 'C')) {
       onCancel();
       return;
     }
-    
+
     if (key.leftArrow || key.upArrow) {
-      // Move selection left/up
       if (focusedOption === 'cancel') {
-        // Move from cancel to last option
         const lastIndex = options.length - 1;
         setSelectedIndex(lastIndex);
         setFocusedOption(options[lastIndex]);
@@ -50,23 +52,20 @@ export default function SortModal({
         }
       }
     }
-    
+
     if (key.rightArrow || key.downArrow) {
-      // Move selection right/down
       if (focusedOption !== 'cancel') {
         const currentIdx = options.indexOf(focusedOption as SortKey);
         if (currentIdx < options.length - 1) {
           setSelectedIndex(currentIdx + 1);
           setFocusedOption(options[currentIdx + 1]);
         } else {
-          // Move to cancel button
           setFocusedOption('cancel');
         }
       }
     }
-    
+
     if (key.tab) {
-      // Tab through all options including cancel
       if (focusedOption === 'cancel') {
         setSelectedIndex(0);
         setFocusedOption(options[0]);
@@ -80,7 +79,7 @@ export default function SortModal({
         }
       }
     }
-    
+
     if (key.return) {
       if (focusedOption === 'cancel') {
         onCancel();
@@ -88,22 +87,16 @@ export default function SortModal({
         onSelect(focusedOption as SortKey);
       }
     }
-    
-    // Quick select shortcuts
+
     if (input) {
       const upperInput = input.toUpperCase();
-      if (upperInput === 'U') {
-        onSelect('updated');
-      } else if (upperInput === 'P') {
-        onSelect('pushed');
-      } else if (upperInput === 'N') {
-        onSelect('name');
-      } else if (upperInput === 'S') {
-        onSelect('stars');
-      }
+      if (upperInput === 'U') onSelect('updated');
+      else if (upperInput === 'P') onSelect('pushed');
+      else if (upperInput === 'N') onSelect('name');
+      else if (upperInput === 'S') onSelect('stars');
     }
   });
-  
+
   const getButtonLabel = (sort: SortKey): string => {
     switch (sort) {
       case 'updated': return 'Last Updated';
@@ -112,58 +105,40 @@ export default function SortModal({
       case 'stars': return 'Stars';
     }
   };
-  
-  const getButtonDescription = (sort: SortKey): string => {
-    switch (sort) {
-      case 'updated': return 'When the repository was last modified';
-      case 'pushed': return 'When code was last pushed';
-      case 'name': return 'Alphabetical by repository name';
-      case 'stars': return 'Number of stars';
-    }
+
+  const getOptionChalk = (option: SortKey) => {
+    if (option === currentSort) return c.success;
+    return focusedOption === option ? c.primary : c.muted;
   };
-  
-  const getButtonColor = (sort: SortKey): string => {
-    if (sort === currentSort) {
-      return 'green'; // Current selection
-    }
-    return focusedOption === sort ? 'cyan' : 'gray';
-  };
-  
+
   return (
-    <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={2} paddingY={1} width={40}>
+    <Box flexDirection="column" borderStyle="round" borderColor={theme.primary} paddingX={2} paddingY={1} width={40}>
       <Text bold>Sort By</Text>
-      
-      {/* Option buttons */}
+
       <Box flexDirection="column" marginTop={1}>
         {options.map((option) => (
           <Box key={option} paddingX={1}>
             <Text>
-              {focusedOption === option ? 
-                chalk.bgCyan.black(' → ') : '   '}
-              {focusedOption === option ? 
-                chalk[getButtonColor(option)].bold(getButtonLabel(option)) : 
-                chalk[getButtonColor(option)](getButtonLabel(option))
+              {focusedOption === option ? c.arrow(' → ') : '   '}
+              {focusedOption === option
+                ? getOptionChalk(option).bold(getButtonLabel(option))
+                : getOptionChalk(option)(getButtonLabel(option))
               }
-              {option === currentSort && chalk.green(' ✓')}
+              {option === currentSort && c.success(' ✓')}
             </Text>
           </Box>
         ))}
-        
-        {/* Cancel option */}
+
         <Box paddingX={1}>
           <Text>
-            {focusedOption === 'cancel' ? 
-              chalk.bgWhite.black(' → ') : '   '}
-            {focusedOption === 'cancel' ? 
-              chalk.white.bold('Cancel') : 
-              chalk.gray('Cancel')
-            }
+            {focusedOption === 'cancel' ? chalk.bgWhite.black(' → ') : '   '}
+            {focusedOption === 'cancel' ? chalk.white.bold('Cancel') : c.muted('Cancel')}
           </Text>
         </Box>
       </Box>
-      
+
       <Box marginTop={1}>
-        <Text color="gray" dimColor>
+        <Text color={theme.muted} dimColor>
           ↑↓/Enter • U/P/N/S • Esc
         </Text>
       </Box>

--- a/src/ui/components/modals/StarModal.tsx
+++ b/src/ui/components/modals/StarModal.tsx
@@ -113,7 +113,7 @@ export function StarModal({
 
       {error && (
         <Box marginBottom={1} flexDirection="column">
-          <Text color="red" wrap="wrap">
+          <Text color={theme.error} wrap="wrap">
             {error.includes('OAuth access restrictions') ? '⚠️ ' : 'Error: '}{error}
           </Text>
         </Box>

--- a/src/ui/components/modals/StarModal.tsx
+++ b/src/ui/components/modals/StarModal.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { Box, Text } from 'ink';
 import { useInput } from 'ink';
 import type { RepoNode } from '../../../types';
+import type { Theme } from '../../../config/themes';
+import { useTheme } from '../../hooks/useTheme';
 
 interface StarModalProps {
   visible: boolean;
@@ -11,6 +13,7 @@ interface StarModalProps {
   onCancel: () => void;
   isStarring?: boolean;
   error?: string | null;
+  theme?: Theme;
 }
 
 export function StarModal({
@@ -21,7 +24,9 @@ export function StarModal({
   onCancel,
   isStarring = false,
   error = null,
+  theme: themeProp,
 }: StarModalProps) {
+  const { theme } = useTheme(themeProp?.name ?? 'default');
   const [focusedButton, setFocusedButton] = useState<'cancel' | 'star'>('cancel');
 
   useInput((input, key) => {
@@ -71,13 +76,13 @@ export function StarModal({
     <Box
       flexDirection="column"
       borderStyle="round"
-      borderColor="yellow"
+      borderColor={theme.warning}
       paddingX={2}
       paddingY={1}
       marginTop={1}
     >
       <Box marginBottom={1}>
-        <Text bold color="yellow">
+        <Text bold color={theme.warning}>
           ⭐ {action} Repository
         </Text>
       </Box>
@@ -85,7 +90,7 @@ export function StarModal({
       <Box marginBottom={1}>
         <Text>
           Are you sure you want to {actionLower}{' '}
-          <Text bold color="cyan">
+          <Text bold color={theme.primary}>
             {repo.nameWithOwner}
           </Text>
           ?
@@ -116,7 +121,7 @@ export function StarModal({
 
       {isStarring ? (
         <Box>
-          <Text color="yellow">{actionGerund}...</Text>
+          <Text color={theme.warning}>{actionGerund}...</Text>
         </Box>
       ) : (
         <>

--- a/src/ui/components/modals/UnstarModal.tsx
+++ b/src/ui/components/modals/UnstarModal.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { Box, Text } from 'ink';
 import { useInput } from 'ink';
 import type { RepoNode } from '../../../types';
+import type { Theme } from '../../../config/themes';
+import { useTheme } from '../../hooks/useTheme';
 
 interface UnstarModalProps {
   visible: boolean;
@@ -10,6 +12,7 @@ interface UnstarModalProps {
   onCancel: () => void;
   isUnstarring?: boolean;
   error?: string | null;
+  theme?: Theme;
 }
 
 export function UnstarModal({
@@ -19,7 +22,9 @@ export function UnstarModal({
   onCancel,
   isUnstarring = false,
   error = null,
+  theme: themeProp,
 }: UnstarModalProps) {
+  const { theme } = useTheme(themeProp?.name ?? 'default');
   const [focusedButton, setFocusedButton] = useState<'cancel' | 'unstar'>('cancel');
 
   useInput((input, key) => {
@@ -37,26 +42,16 @@ export function UnstarModal({
     }
 
     if (key.return || input === 'y' || input === 'Y') {
-      if (focusedButton === 'unstar') {
-        onConfirm();
-      } else {
-        onCancel();
-      }
+      if (focusedButton === 'unstar') onConfirm();
+      else onCancel();
     }
 
-    if (input === 'n' || input === 'N') {
-      onCancel();
-    }
-
-    if (input === 'u' || input === 'U') {
-      onConfirm();
-    }
+    if (input === 'n' || input === 'N') onCancel();
+    if (input === 'u' || input === 'U') onConfirm();
   });
 
   useEffect(() => {
-    if (visible) {
-      setFocusedButton('cancel');
-    }
+    if (visible) setFocusedButton('cancel');
   }, [visible]);
 
   if (!visible || !repo) return null;
@@ -65,13 +60,13 @@ export function UnstarModal({
     <Box
       flexDirection="column"
       borderStyle="round"
-      borderColor="yellow"
+      borderColor={theme.warning}
       paddingX={2}
       paddingY={1}
       marginTop={1}
     >
       <Box marginBottom={1}>
-        <Text bold color="yellow">
+        <Text bold color={theme.warning}>
           ⭐ Unstar Repository
         </Text>
       </Box>
@@ -79,7 +74,7 @@ export function UnstarModal({
       <Box marginBottom={1}>
         <Text>
           Are you sure you want to unstar{' '}
-          <Text bold color="cyan">
+          <Text bold color={theme.primary}>
             {repo.nameWithOwner}
           </Text>
           ?
@@ -102,7 +97,7 @@ export function UnstarModal({
 
       {error && (
         <Box marginBottom={1} flexDirection="column">
-          <Text color="red" wrap="wrap">
+          <Text color={theme.error} wrap="wrap">
             {error.includes('OAuth access restrictions') ? '⚠️ ' : 'Error: '}{error}
           </Text>
         </Box>
@@ -110,7 +105,7 @@ export function UnstarModal({
 
       {isUnstarring ? (
         <Box>
-          <Text color="yellow">Unstarring...</Text>
+          <Text color={theme.warning}>Unstarring...</Text>
         </Box>
       ) : (
         <>
@@ -121,18 +116,16 @@ export function UnstarModal({
                 color={focusedButton === 'cancel' ? 'black' : 'white'}
                 bold={focusedButton === 'cancel'}
               >
-                {' '}
-                Cancel (C/Esc){' '}
+                {' '}Cancel (C/Esc){' '}
               </Text>
             </Box>
             <Box>
               <Text
                 backgroundColor={focusedButton === 'unstar' ? 'yellow' : undefined}
-                color={focusedButton === 'unstar' ? 'black' : 'yellow'}
+                color={focusedButton === 'unstar' ? 'black' : theme.warning}
                 bold={focusedButton === 'unstar'}
               >
-                {' '}
-                Unstar (U/Y){' '}
+                {' '}Unstar (U/Y){' '}
               </Text>
             </Box>
           </Box>

--- a/src/ui/components/modals/VisibilityModal.tsx
+++ b/src/ui/components/modals/VisibilityModal.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import chalk from 'chalk';
+import type { Theme } from '../../../config/themes';
+import { useTheme } from '../../hooks/useTheme';
 
 type VisibilityFilter = 'all' | 'public' | 'private';
 
@@ -9,21 +11,22 @@ interface VisibilityModalProps {
   isEnterprise: boolean;
   onSelect: (filter: VisibilityFilter) => void;
   onCancel: () => void;
+  theme?: Theme;
 }
 
-export default function VisibilityModal({ 
-  currentFilter, 
+export default function VisibilityModal({
+  currentFilter,
   isEnterprise,
-  onSelect, 
-  onCancel 
+  onSelect,
+  onCancel,
+  theme: themeProp,
 }: VisibilityModalProps) {
-  // Same options for all, but label changes for enterprise
+  const { theme, c } = useTheme(themeProp?.name ?? 'default');
   const options: VisibilityFilter[] = ['all', 'public', 'private'];
-  
+
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [focusedOption, setFocusedOption] = useState<VisibilityFilter | 'cancel'>('all');
-  
-  // Set initial focus to current filter
+
   useEffect(() => {
     const currentIndex = options.indexOf(currentFilter);
     if (currentIndex !== -1) {
@@ -31,17 +34,15 @@ export default function VisibilityModal({
       setFocusedOption(currentFilter);
     }
   }, [currentFilter]);
-  
+
   useInput((input, key) => {
     if (key.escape || (input && input.toUpperCase() === 'C')) {
       onCancel();
       return;
     }
-    
+
     if (key.leftArrow || key.upArrow) {
-      // Move selection left/up
       if (focusedOption === 'cancel') {
-        // Move from cancel to last option
         const lastIndex = options.length - 1;
         setSelectedIndex(lastIndex);
         setFocusedOption(options[lastIndex]);
@@ -53,23 +54,20 @@ export default function VisibilityModal({
         }
       }
     }
-    
+
     if (key.rightArrow || key.downArrow) {
-      // Move selection right/down
       if (focusedOption !== 'cancel') {
         const currentIdx = options.indexOf(focusedOption as VisibilityFilter);
         if (currentIdx < options.length - 1) {
           setSelectedIndex(currentIdx + 1);
           setFocusedOption(options[currentIdx + 1]);
         } else {
-          // Move to cancel button
           setFocusedOption('cancel');
         }
       }
     }
-    
+
     if (key.tab) {
-      // Tab through all options including cancel
       if (focusedOption === 'cancel') {
         setSelectedIndex(0);
         setFocusedOption(options[0]);
@@ -83,7 +81,7 @@ export default function VisibilityModal({
         }
       }
     }
-    
+
     if (key.return) {
       if (focusedOption === 'cancel') {
         onCancel();
@@ -91,20 +89,15 @@ export default function VisibilityModal({
         onSelect(focusedOption as VisibilityFilter);
       }
     }
-    
-    // Quick select shortcuts
+
     if (input) {
       const upperInput = input.toUpperCase();
-      if (upperInput === 'A') {
-        onSelect('all');
-      } else if (upperInput === 'P') {
-        onSelect('public');
-      } else if (upperInput === 'R') {
-        onSelect('private');
-      }
+      if (upperInput === 'A') onSelect('all');
+      else if (upperInput === 'P') onSelect('public');
+      else if (upperInput === 'R') onSelect('private');
     }
   });
-  
+
   const getButtonLabel = (filter: VisibilityFilter): string => {
     switch (filter) {
       case 'all': return 'All Repositories';
@@ -112,49 +105,40 @@ export default function VisibilityModal({
       case 'private': return isEnterprise ? 'Private/Internal' : 'Private Only';
     }
   };
-  
-  const getButtonColor = (filter: VisibilityFilter): string => {
-    if (filter === currentFilter) {
-      return 'green'; // Current selection
-    }
-    return focusedOption === filter ? 'cyan' : 'gray';
+
+  const getOptionChalk = (filter: VisibilityFilter) => {
+    if (filter === currentFilter) return c.success;
+    return focusedOption === filter ? c.primary : c.muted;
   };
-  
+
   return (
-    <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={2} paddingY={1} width={45}>
+    <Box flexDirection="column" borderStyle="round" borderColor={theme.primary} paddingX={2} paddingY={1} width={45}>
       <Text bold>Visibility Filter</Text>
-      
-      {/* Option buttons */}
+
       <Box flexDirection="column" marginTop={1}>
         {options.map((option) => (
           <Box key={option} paddingX={1}>
             <Text>
-              {focusedOption === option ? 
-                chalk.bgCyan.black(' → ') : '   '}
-              {focusedOption === option ? 
-                chalk[getButtonColor(option)].bold(getButtonLabel(option)) : 
-                chalk[getButtonColor(option)](getButtonLabel(option))
+              {focusedOption === option ? c.arrow(' → ') : '   '}
+              {focusedOption === option
+                ? getOptionChalk(option).bold(getButtonLabel(option))
+                : getOptionChalk(option)(getButtonLabel(option))
               }
-              {option === currentFilter && chalk.green(' ✓')}
+              {option === currentFilter && c.success(' ✓')}
             </Text>
           </Box>
         ))}
-        
-        {/* Cancel option */}
+
         <Box paddingX={1}>
           <Text>
-            {focusedOption === 'cancel' ? 
-              chalk.bgWhite.black(' → ') : '   '}
-            {focusedOption === 'cancel' ? 
-              chalk.white.bold('Cancel') : 
-              chalk.gray('Cancel')
-            }
+            {focusedOption === 'cancel' ? chalk.bgWhite.black(' → ') : '   '}
+            {focusedOption === 'cancel' ? chalk.white.bold('Cancel') : c.muted('Cancel')}
           </Text>
         </Box>
       </Box>
-      
+
       <Box marginTop={1}>
-        <Text color="gray" dimColor>
+        <Text color={theme.muted} dimColor>
           ↑↓/Enter • A/P/R • Esc
         </Text>
       </Box>

--- a/src/ui/components/modals/VisibilityModal.tsx
+++ b/src/ui/components/modals/VisibilityModal.tsx
@@ -131,7 +131,7 @@ export default function VisibilityModal({
 
         <Box paddingX={1}>
           <Text>
-            {focusedOption === 'cancel' ? chalk.bgWhite.black(' → ') : '   '}
+            {focusedOption === 'cancel' ? c.arrowMuted(' → ') : '   '}
             {focusedOption === 'cancel' ? chalk.white.bold('Cancel') : c.muted('Cancel')}
           </Text>
         </Box>

--- a/src/ui/components/repo/RepoListHeader.tsx
+++ b/src/ui/components/repo/RepoListHeader.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Box, Text } from 'ink';
 import { OwnerContext } from '../../../config/config';
+import type { Theme } from '../../../config/themes';
+import { useTheme } from '../../hooks/useTheme';
 import { SlowSpinner } from '../common';
 
 interface RepoListHeaderProps {
@@ -15,6 +17,7 @@ interface RepoListHeaderProps {
   archiveFilter?: 'all' | 'unarchived' | 'archived';
   isEnterprise?: boolean;
   starsMode?: boolean;
+  theme?: Theme;
 }
 
 export default function RepoListHeader({
@@ -28,12 +31,15 @@ export default function RepoListHeader({
   visibilityFilter = 'all',
   archiveFilter = 'all',
   isEnterprise = false,
-  starsMode = false
+  starsMode = false,
+  theme: themeProp,
 }: RepoListHeaderProps) {
+  const { theme } = useTheme(themeProp?.name ?? 'default');
+
   const contextLabel = ownerContext === 'personal'
     ? 'Personal Account'
     : ownerContext?.type === 'organization'
-      ? `Organization: ${ownerContext.name ?? ownerContext.login}`
+      ? `Organisation: ${ownerContext.name ?? ownerContext.login}`
       : '';
 
   const visibilityLabel = visibilityFilter === 'public'
@@ -50,35 +56,35 @@ export default function RepoListHeader({
         <Text>{contextLabel}</Text>
       )}
       {starsMode && (
-        <Text color="yellow" bold>
+        <Text color={theme.warning} bold>
           ⭐ Stars Mode
         </Text>
       )}
-      <Text color="gray" dimColor>
+      <Text color={theme.muted} dimColor>
         Sort: {sortKey} {sortDir === 'asc' ? '↑' : '↓'}
       </Text>
-      <Text color="gray" dimColor>
+      <Text color={theme.muted} dimColor>
         Fork Status - Commits Behind: {forkTracking ? 'ON' : 'OFF'}
       </Text>
       {!!visibilityLabel && !starsMode && (
-        <Text color="yellow">
+        <Text color={theme.warning}>
           Visibility: {visibilityLabel}
         </Text>
       )}
       {archiveFilter !== 'all' && (
-        <Text color="cyan">
+        <Text color={theme.primary}>
           Archive: {archiveFilter === 'archived' ? 'Archived' : 'Unarchived'}
         </Text>
       )}
       {filter && !searchActive && (
-        <Text color="cyan">Filter: "{filter}"</Text>
+        <Text color={theme.primary}>Filter: "{filter}"</Text>
       )}
       {searchActive && (
         <>
-          <Text color="cyan">Search: "{filter.trim()}"</Text>
+          <Text color={theme.primary}>Search: "{filter.trim()}"</Text>
           {searchLoading && (
             <Box marginLeft={1}>
-              <Text color="cyan"><SlowSpinner /> Searching…</Text>
+              <Text color={theme.primary}><SlowSpinner /> Searching…</Text>
             </Box>
           )}
         </>
@@ -86,4 +92,3 @@ export default function RepoListHeader({
     </Box>
   );
 }
-

--- a/src/ui/components/repo/RepoRow.tsx
+++ b/src/ui/components/repo/RepoRow.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Box, Text } from 'ink';
 import chalk from 'chalk';
 import type { RepoNode } from '../../../types';
+import type { Theme } from '../../../config/themes';
+import { useTheme } from '../../hooks/useTheme';
 import { formatDate, truncate } from '../../../lib/utils';
 
 interface RepoRowProps {
@@ -13,81 +15,78 @@ interface RepoRowProps {
   dim?: boolean;
   forkTracking: boolean;
   starsMode?: boolean;
+  theme?: Theme;
 }
 
-export default function RepoRow({ 
-  repo, 
-  selected, 
-  index, 
-  maxWidth, 
-  spacingLines, 
-  dim, 
+export default function RepoRow({
+  repo,
+  selected,
+  index,
+  maxWidth,
+  spacingLines,
+  dim,
   forkTracking,
-  starsMode = false
+  starsMode = false,
+  theme: themeProp,
 }: RepoRowProps) {
+  const { theme, c } = useTheme(themeProp?.name ?? 'default');
   const langName = repo.primaryLanguage?.name || '';
   const langColor = repo.primaryLanguage?.color || '#666666';
-  
-  // Calculate commits behind for forks - only show if tracking is enabled AND data is available
+
   const hasCommitData = repo.isFork && repo.parent && repo.defaultBranchRef && repo.parent.defaultBranchRef
     && repo.parent.defaultBranchRef.target?.history && repo.defaultBranchRef.target?.history;
-  
+
   const commitsBehind = hasCommitData
     ? (repo.parent.defaultBranchRef.target.history.totalCount - repo.defaultBranchRef.target.history.totalCount)
     : 0;
-  
+
   const showCommitsBehind = forkTracking && hasCommitData;
-  
+
   // Build colored line 1
   let line1 = '';
-  const numColor = selected ? chalk.cyan : chalk.gray;
-  const nameColor = selected ? chalk.cyan.bold : chalk.white;
+  const numColor = selected ? c.selected : c.muted;
+  const nameColor = selected ? c.selected.bold : c.text;
   line1 += numColor(`${String(index).padStart(3, ' ')}.`);
-  // Show star icon if the repo is starred
   if (repo.viewerHasStarred) {
-    line1 += chalk.yellow(' ⭐');
+    line1 += c.warning(' ⭐');
   }
   line1 += nameColor(` ${repo.nameWithOwner}`);
-  // Use visibility field to properly distinguish between PRIVATE and INTERNAL
   if (repo.visibility === 'INTERNAL') {
-    line1 += chalk.magenta(' Internal');
+    line1 += c.internal(' Internal');
   } else if (repo.visibility === 'PRIVATE' || (repo.isPrivate && !repo.visibility)) {
-    line1 += chalk.yellow(' Private');
+    line1 += c.private(' Private');
   }
-  
-  // In stars mode, show indicator for org repos that might have OAuth restrictions
+
   if (starsMode && repo.owner && repo.owner.__typename === 'Organization') {
-    line1 += chalk.gray(' [org]');
+    line1 += c.muted(' [org]');
   }
   if (repo.isArchived) line1 += ' ' + chalk.bgGray.whiteBright(' Archived ') + ' ';
   if (repo.isFork && repo.parent) {
-    line1 += chalk.blue(` Fork of ${repo.parent.nameWithOwner}`);
+    line1 += c.fork(` Fork of ${repo.parent.nameWithOwner}`);
     if (showCommitsBehind) {
       if (commitsBehind > 0) {
-        line1 += chalk.yellow(` (${commitsBehind} behind)`);
+        line1 += c.warning(` (${commitsBehind} behind)`);
       } else {
-        line1 += chalk.green(` (0 behind)`);
+        line1 += c.success(` (0 behind)`);
       }
     }
   }
-  
+
   // Build colored line 2
   let line2 = '     ';
-  const metaColor = selected ? chalk.white : chalk.gray;
+  const metaColor = selected ? c.text : c.muted;
   if (langName) line2 += chalk.hex(langColor)('● ') + metaColor(`${langName}  `);
   line2 += metaColor(`★ ${repo.stargazerCount}  ⑂ ${repo.forkCount}  Updated ${formatDate(repo.updatedAt)}`);
-  
+
   // Build line 3
   const line3 = repo.description ? `     ${truncate(repo.description, Math.max(30, maxWidth - 10))}` : null;
-  
-  // Combine all lines with newlines
+
   let fullText = line1 + '\n' + line2;
   if (line3) fullText += '\n' + metaColor(line3);
-  
-  // Calculate spacing for above and below
+
   const spacingAbove = Math.floor(spacingLines / 2);
   const spacingBelow = spacingLines - spacingAbove;
-  
+
   return (
     <Box flexDirection="column" backgroundColor={selected ? 'gray' : undefined}>
       {spacingAbove > 0 && (
@@ -104,4 +103,3 @@ export default function RepoRow({
     </Box>
   );
 }
-

--- a/src/ui/hooks/useTheme.ts
+++ b/src/ui/hooks/useTheme.ts
@@ -18,6 +18,8 @@ export interface ThemeColors {
   dim: chalk.Chalk;
   /** Selected option arrow indicator in modals, e.g. bgPrimary.black(' → ') */
   arrow: chalk.Chalk;
+  /** Neutral arrow indicator for the focused cancel/muted option in modals */
+  arrowMuted: chalk.Chalk;
   /** Background+text for confirmed/active button */
   btnPrimary: chalk.Chalk;
   /** Background+text for muted/cancel button */
@@ -56,6 +58,7 @@ export function useTheme(name: ThemeName): UseThemeResult {
       fork: chalkFor(theme.fork),
       dim: chalkFor(theme.dim),
       arrow: bgChalkFor(theme.primary).black,
+      arrowMuted: bgChalkFor(theme.muted).whiteBright,
       btnPrimary: bgChalkFor(theme.primary).black.bold,
       btnMuted: chalk.bgGray.white.bold,
     };

--- a/src/ui/hooks/useTheme.ts
+++ b/src/ui/hooks/useTheme.ts
@@ -1,0 +1,64 @@
+import { useMemo } from 'react';
+import chalk from 'chalk';
+import { type Theme, type ThemeName, getTheme } from '../../config/themes';
+
+export interface ThemeColors {
+  primary: chalk.Chalk;
+  secondary: chalk.Chalk;
+  success: chalk.Chalk;
+  warning: chalk.Chalk;
+  error: chalk.Chalk;
+  muted: chalk.Chalk;
+  text: chalk.Chalk;
+  selected: chalk.Chalk;
+  private: chalk.Chalk;
+  archived: chalk.Chalk;
+  internal: chalk.Chalk;
+  fork: chalk.Chalk;
+  dim: chalk.Chalk;
+  /** Selected option arrow indicator in modals, e.g. bgPrimary.black(' → ') */
+  arrow: chalk.Chalk;
+  /** Background+text for confirmed/active button */
+  btnPrimary: chalk.Chalk;
+  /** Background+text for muted/cancel button */
+  btnMuted: chalk.Chalk;
+}
+
+export interface UseThemeResult {
+  theme: Theme;
+  c: ThemeColors;
+}
+
+function chalkFor(color: string): chalk.Chalk {
+  return (chalk as any)[color] ?? chalk.white;
+}
+
+function bgChalkFor(color: string): chalk.Chalk {
+  const bgKey = 'bg' + color.charAt(0).toUpperCase() + color.slice(1);
+  return (chalk as any)[bgKey] ?? chalk.bgWhite;
+}
+
+export function useTheme(name: ThemeName): UseThemeResult {
+  return useMemo(() => {
+    const theme = getTheme(name);
+    const c: ThemeColors = {
+      primary: chalkFor(theme.primary),
+      secondary: chalkFor(theme.secondary),
+      success: chalkFor(theme.success),
+      warning: chalkFor(theme.warning),
+      error: chalkFor(theme.error),
+      muted: chalkFor(theme.muted),
+      text: chalkFor(theme.text),
+      selected: chalkFor(theme.selected),
+      private: chalkFor(theme.private),
+      archived: chalkFor(theme.archived),
+      internal: chalkFor(theme.internal),
+      fork: chalkFor(theme.fork),
+      dim: chalkFor(theme.dim),
+      arrow: bgChalkFor(theme.primary).black,
+      btnPrimary: bgChalkFor(theme.primary).black.bold,
+      btnMuted: chalk.bgGray.white.bold,
+    };
+    return { theme, c };
+  }, [name]);
+}

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -4,6 +4,8 @@ import TextInput from 'ink-text-input';
 import chalk from 'chalk';
 import { makeClient, fetchViewerReposPageUnified, searchRepositoriesUnified, deleteRepositoryRest, archiveRepositoryById, unarchiveRepositoryById, changeRepositoryVisibility, syncForkWithUpstream, getRepositoryFromCache, purgeApolloCacheFiles, inspectCacheStatus, updateCacheAfterDelete, updateCacheAfterArchive, updateCacheAfterVisibilityChange, updateCacheWithRepository, checkOrganizationIsEnterprise, OwnerAffiliation, fetchViewerOrganizations, fetchRestRateLimits, renameRepositoryById, updateCacheAfterRename, getStarredRepositories, starRepository, unstarRepository } from '../../services/github';
 import { getUIPrefs, storeUIPrefs, OwnerContext } from '../../config/config';
+import { type ThemeName, nextTheme, getTheme } from '../../config/themes';
+import { useTheme } from '../hooks/useTheme';
 import { makeApolloKey, makeSearchKey, isFresh, markFetched } from '../../services/apolloMeta';
 import type { RepoNode, RateLimitInfo, RestRateLimitInfo } from '../../types';
 import { exec } from 'child_process';
@@ -88,6 +90,12 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   // Display density: 0 = compact (0 lines), 1 = cozy (1 line), 2 = comfy (2 lines)
   const [density, setDensity] = useState<0 | 1 | 2>(2);
   const [prefsLoaded, setPrefsLoaded] = useState(false);
+
+  // Theme state
+  const [themeName, setThemeName] = useState<ThemeName>('default');
+  const [themeToast, setThemeToast] = useState<string | null>(null);
+  const themeToastTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const { theme, c: tc } = useTheme(themeName);
   
   // Organization context state
   const [ownerContext, setOwnerContext] = useState<OwnerContext>('personal');
@@ -552,12 +560,11 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     }
   }
 
-  // Clear timer on unmount
+  // Clear timers on unmount
   useEffect(() => {
     return () => {
-      if (copyToastTimerRef.current) {
-        clearTimeout(copyToastTimerRef.current);
-      }
+      if (copyToastTimerRef.current) clearTimeout(copyToastTimerRef.current);
+      if (themeToastTimerRef.current) clearTimeout(themeToastTimerRef.current);
     };
   }, []);
   
@@ -949,6 +956,11 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     // Load archive filter
     if (ui.archiveFilter && ['all', 'unarchived', 'archived'].includes(ui.archiveFilter)) {
       setArchiveFilter(ui.archiveFilter as ArchiveFilter);
+    }
+
+    // Load theme
+    if (ui.theme && ['default', 'ocean', 'forest', 'monochrome'].includes(ui.theme)) {
+      setThemeName(ui.theme);
     }
     
     // Load organization context
@@ -1575,8 +1587,21 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return;
     }
 
+    // Cycle theme (Shift+T)
+    if (key.shift && input === 'T') {
+      setThemeName((tn) => {
+        const next = nextTheme(tn);
+        storeUIPrefs({ theme: next });
+        if (themeToastTimerRef.current) clearTimeout(themeToastTimerRef.current);
+        setThemeToast(`Theme: ${getTheme(next).label}`);
+        themeToastTimerRef.current = setTimeout(() => setThemeToast(null), 2500);
+        return next;
+      });
+      return;
+    }
+
     // Toggle display density
-    if (input && input.toUpperCase() === 'T') {
+    if (input && input.toUpperCase() === 'T' && !key.shift) {
       setDensity((d) => {
         const next = (((d + 1) % 3) as 0 | 1 | 2);
         storeUIPrefs({ density: next });
@@ -1783,38 +1808,38 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   const headerBar = useMemo(() => (
     <Box flexDirection="row" justifyContent="space-between" height={1} marginBottom={1}>
       <Box flexDirection="row" gap={1}>
-        <Text color="cyan" bold={!modalOpen} dimColor={modalOpen}>
-          {'  '}{ownerContext === 'personal' 
-            ? 'Personal' 
+        <Text color={theme.primary} bold={!modalOpen} dimColor={modalOpen}>
+          {'  '}{ownerContext === 'personal'
+            ? 'Personal'
             : ownerContext.name || ownerContext.login}
           {ownerContext !== 'personal' && isEnterpriseOrg && ' (ENT)'}
         </Text>
-        <Text bold color={modalOpen ? 'gray' : undefined} dimColor={modalOpen ? true : undefined}>Repositories</Text>
-        <Text color="gray">({visibleItems.length}/{searchActive ? searchTotalCount : totalCount})</Text>
+        <Text bold color={modalOpen ? theme.muted : undefined} dimColor={modalOpen ? true : undefined}>Repositories</Text>
+        <Text color={theme.muted}>({visibleItems.length}/{searchActive ? searchTotalCount : totalCount})</Text>
         {loadingMore && hasNextPage && !starsMode && !searchActive && totalCount > 0 && (
-          <Text color="cyan">{` · loading ${items.length}/${totalCount}`}</Text>
+          <Text color={theme.primary}>{` · loading ${items.length}/${totalCount}`}</Text>
         )}
         {(loading || searchLoading || loadingMore) && (
           <Box width={2} flexShrink={0} flexGrow={0} marginLeft={1}>
-            <Text color="yellow">
+            <Text color={theme.warning}>
               <SlowSpinner />
             </Text>
           </Box>
         )}
       </Box>
-      
+
       {(rateLimit || restRateLimit) && (
-        <Text color={lowRate ? 'yellow' : 'gray'}>
+        <Text color={lowRate ? theme.warning : theme.muted}>
           GraphQL: {rateLimit ? `${rateLimit.remaining}/${rateLimit.limit}` : '---/---'}
           {prevRateLimit !== undefined && rateLimit && prevRateLimit !== rateLimit.remaining && (
-            <Text color={rateLimit.remaining < prevRateLimit ? 'red' : 'green'}>
+            <Text color={rateLimit.remaining < prevRateLimit ? theme.error : theme.success}>
               {` (${rateLimit.remaining - prevRateLimit > 0 ? '+' : ''}${rateLimit.remaining - prevRateLimit})`}
             </Text>
           )}
           {' | '}
           REST: {restRateLimit ? `${restRateLimit.core.remaining}/${restRateLimit.core.limit}` : '---/---'}
           {prevRestRateLimit !== undefined && restRateLimit && prevRestRateLimit !== restRateLimit.core.remaining && (
-            <Text color={restRateLimit.core.remaining < prevRestRateLimit ? 'red' : 'green'}>
+            <Text color={restRateLimit.core.remaining < prevRestRateLimit ? theme.error : theme.success}>
               {` (${restRateLimit.core.remaining - prevRestRateLimit > 0 ? '+' : ''}${restRateLimit.core.remaining - prevRestRateLimit})`}
             </Text>
           )}
@@ -1822,7 +1847,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         </Text>
       )}
     </Box>
-  ), [visibleItems.length, searchActive, searchTotalCount, totalCount, loading, searchLoading, rateLimit, lowRate, modalOpen, prevRateLimit, ownerContext, isEnterpriseOrg, restRateLimit, prevRestRateLimit]);
+  ), [visibleItems.length, searchActive, searchTotalCount, totalCount, loading, searchLoading, rateLimit, lowRate, modalOpen, prevRateLimit, ownerContext, isEnterpriseOrg, restRateLimit, prevRestRateLimit, theme]);
 
   if (error) {
     return (
@@ -1926,7 +1951,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       )}
 
       {/* Main content container with border - fixed height */}
-      <Box borderStyle="single" borderColor={modalOpen ? 'gray' : 'yellow'} paddingX={1} paddingY={1} marginX={1} height={contentHeight + containerPadding + 2} flexDirection="column">
+      <Box borderStyle="single" borderColor={modalOpen ? theme.muted : theme.warning} paddingX={1} paddingY={1} marginX={1} height={contentHeight + containerPadding + 2} flexDirection="column">
         {deleteMode && deleteTarget ? (
           // Centered modal; hide list content while modal is open
           <Box height={contentHeight} alignItems="center" justifyContent="center">
@@ -1940,13 +1965,13 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                         const langName = deleteTarget.primaryLanguage?.name || '';
                         const langColor = deleteTarget.primaryLanguage?.color || '#666666';
                         let line1 = '';
-                        line1 += chalk.white(deleteTarget.nameWithOwner);
-                        if (deleteTarget.isPrivate) line1 += chalk.yellow(' Private');
-                        if (deleteTarget.isArchived) line1 += chalk.gray.dim(' Archived');
-                        if (deleteTarget.isFork && deleteTarget.parent) line1 += chalk.blue(` Fork of ${deleteTarget.parent.nameWithOwner}`);
+                        line1 += tc.text(deleteTarget.nameWithOwner);
+                        if (deleteTarget.isPrivate) line1 += tc.private(' Private');
+                        if (deleteTarget.isArchived) line1 += tc.archived.dim(' Archived');
+                        if (deleteTarget.isFork && deleteTarget.parent) line1 += tc.fork(` Fork of ${deleteTarget.parent.nameWithOwner}`);
                         let line2 = '';
-                        if (langName) line2 += chalk.hex(langColor)('● ') + chalk.gray(`${langName}  `);
-                        line2 += chalk.gray(`★ ${deleteTarget.stargazerCount}  ⑂ ${deleteTarget.forkCount}  Updated ${formatDate(deleteTarget.updatedAt)}`);
+                        if (langName) line2 += chalk.hex(langColor)('● ') + tc.muted(`${langName}  `);
+                        line2 += tc.muted(`★ ${deleteTarget.stargazerCount}  ⑂ ${deleteTarget.forkCount}  Updated ${formatDate(deleteTarget.updatedAt)}`);
                         return (
                           <>
                             <Text>{line1}</Text>
@@ -2002,7 +2027,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                       justifyContent="center"
                       flexDirection="column"
                     >
-                      <Text>{confirmFocus === 'delete' ? chalk.bgRed.white.bold(' Delete ') : chalk.red.bold('Delete')}</Text>
+                      <Text>{confirmFocus === 'delete' ? chalk.bgRed.white.bold(' Delete ') : tc.error.bold('Delete')}</Text>
                     </Box>
                     <Box
                       borderStyle="round"
@@ -2013,7 +2038,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                       justifyContent="center"
                       flexDirection="column"
                     >
-                      <Text>{confirmFocus === 'cancel' ? chalk.bgGray.white.bold(' Cancel ') : chalk.gray.bold('Cancel')}</Text>
+                      <Text>{confirmFocus === 'cancel' ? tc.btnMuted(' Cancel ') : tc.muted.bold('Cancel')}</Text>
                     </Box>
                   </Box>
                   {/* Bottom prompt with dynamic Enter action and key hints (gray) */}
@@ -2073,9 +2098,9 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                   flexDirection="column"
                 >
                   <Text>
-                    {archiveFocus === 'confirm' ? 
-                      chalk.bgGreen.white.bold(` ${archiveTarget.isArchived ? 'Unarchive' : 'Archive'} `) : 
-                      chalk.bold[archiveTarget.isArchived ? 'green' : 'yellow'](archiveTarget.isArchived ? 'Unarchive' : 'Archive')
+                    {archiveFocus === 'confirm' ?
+                      chalk.bgGreen.white.bold(` ${archiveTarget.isArchived ? 'Unarchive' : 'Archive'} `) :
+                      (archiveTarget.isArchived ? tc.success : tc.warning).bold(archiveTarget.isArchived ? 'Unarchive' : 'Archive')
                     }
                   </Text>
                 </Box>
@@ -2089,15 +2114,12 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                   flexDirection="column"
                 >
                   <Text>
-                    {archiveFocus === 'cancel' ? 
-                      chalk.bgGray.white.bold(' Cancel ') : 
-                      chalk.gray.bold('Cancel')
-                    }
+                    {archiveFocus === 'cancel' ? tc.btnMuted(' Cancel ') : tc.muted.bold('Cancel')}
                   </Text>
                 </Box>
               </Box>
               <Box marginTop={1} flexDirection="row" justifyContent="center">
-                <Text color="gray">Press Enter to {archiveFocus === 'confirm' ? (archiveTarget.isArchived ? 'Unarchive' : 'Archive') : 'Cancel'} | Y to {archiveTarget.isArchived ? 'Unarchive' : 'Archive'} | C to Cancel</Text>
+                <Text color={theme.muted}>Press Enter to {archiveFocus === 'confirm' ? (archiveTarget.isArchived ? 'Unarchive' : 'Archive') : 'Cancel'} | Y to {archiveTarget.isArchived ? 'Unarchive' : 'Archive'} | C to Cancel</Text>
               </Box>
               <Box marginTop={1}>
                 <TextInput
@@ -2150,10 +2172,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                   flexDirection="column"
                 >
                   <Text>
-                    {syncFocus === 'confirm' ? 
-                      chalk.bgBlue.white.bold(' Sync ') : 
-                      chalk.blue.bold('Sync')
-                    }
+                    {syncFocus === 'confirm' ? tc.btnPrimary(' Sync ') : tc.primary.bold('Sync')}
                   </Text>
                 </Box>
                 <Box
@@ -2166,15 +2185,12 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                   flexDirection="column"
                 >
                   <Text>
-                    {syncFocus === 'cancel' ? 
-                      chalk.bgGray.white.bold(' Cancel ') : 
-                      chalk.gray.bold('Cancel')
-                    }
+                    {syncFocus === 'cancel' ? tc.btnMuted(' Cancel ') : tc.muted.bold('Cancel')}
                   </Text>
                 </Box>
               </Box>
               <Box marginTop={1} flexDirection="row" justifyContent="center">
-                <Text color="gray">Press Enter to {syncFocus === 'confirm' ? 'Sync' : 'Cancel'} | Y to Sync | C to Cancel</Text>
+                <Text color={theme.muted}>Press Enter to {syncFocus === 'confirm' ? 'Sync' : 'Cancel'} | Y to Sync | C to Cancel</Text>
               </Box>
               <Box marginTop={1}>
                 <TextInput
@@ -2191,25 +2207,25 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               </Box>
               {syncError && (
                 <Box marginTop={1}>
-                  <Text color="magenta">{syncError}</Text>
+                  <Text color={theme.error}>{syncError}</Text>
                 </Box>
               )}
               {syncing && (
                 <Box marginTop={1}>
-                  <Text color="yellow">Syncing...</Text>
+                  <Text color={theme.warning}>Syncing...</Text>
                 </Box>
               )}
             </Box>
           </Box>
         ) : logoutMode ? (
           <Box height={contentHeight} alignItems="center" justifyContent="center">
-            <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={3} paddingY={2} width={Math.min(terminalWidth - 8, 80)}>
+            <Box flexDirection="column" borderStyle="round" borderColor={theme.primary} paddingX={3} paddingY={2} width={Math.min(terminalWidth - 8, 80)}>
               <Text bold>Logout Confirmation</Text>
-              <Text color="cyan">Are you sure you want to log out?</Text>
+              <Text color={theme.primary}>Are you sure you want to log out?</Text>
               <Box marginTop={1} flexDirection="row" justifyContent="center" gap={6}>
                 <Box
                   borderStyle="round"
-                  borderColor="cyan"
+                  borderColor={theme.primary}
                   height={3}
                   width={20}
                   alignItems="center"
@@ -2217,15 +2233,12 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                   flexDirection="column"
                 >
                   <Text>
-                    {logoutFocus === 'confirm' ? 
-                      chalk.bgCyan.white.bold(' Logout ') : 
-                      chalk.cyan.bold('Logout')
-                    }
+                    {logoutFocus === 'confirm' ? tc.btnPrimary(' Logout ') : tc.primary.bold('Logout')}
                   </Text>
                 </Box>
                 <Box
                   borderStyle="round"
-                  borderColor={logoutFocus === 'cancel' ? 'white' : 'gray'}
+                  borderColor={logoutFocus === 'cancel' ? 'white' : theme.muted}
                   height={3}
                   width={20}
                   alignItems="center"
@@ -2233,15 +2246,12 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                   flexDirection="column"
                 >
                   <Text>
-                    {logoutFocus === 'cancel' ? 
-                      chalk.bgGray.white.bold(' Cancel ') : 
-                      chalk.gray.bold('Cancel')
-                    }
+                    {logoutFocus === 'cancel' ? tc.btnMuted(' Cancel ') : tc.muted.bold('Cancel')}
                   </Text>
                 </Box>
               </Box>
               <Box marginTop={1} flexDirection="row" justifyContent="center">
-                <Text color="gray">Press Enter to {logoutFocus === 'confirm' ? 'Logout' : 'Cancel'} | Y to Logout | C to Cancel</Text>
+                <Text color={theme.muted}>Press Enter to {logoutFocus === 'confirm' ? 'Logout' : 'Cancel'} | Y to Logout | C to Cancel</Text>
               </Box>
             </Box>
           </Box>
@@ -2258,33 +2268,33 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
           <Box height={contentHeight} alignItems="center" justifyContent="center">
             {(() => {
               const repo = infoRepo || visibleItems[cursor];
-              if (!repo) return <Text color="red">No repository selected.</Text>;
+              if (!repo) return <Text color={theme.error}>No repository selected.</Text>;
               const langName = repo.primaryLanguage?.name || 'N/A';
               const langColor = repo.primaryLanguage?.color || '#666666';
               return (
-                <Box flexDirection="column" borderStyle="round" borderColor="magenta" paddingX={3} paddingY={2} width={Math.min(terminalWidth - 8, 90)}>
-                  <Text bold>Repository Info {infoRepo ? chalk.dim('(cached)') : ''}</Text>
+                <Box flexDirection="column" borderStyle="round" borderColor={theme.internal} paddingX={3} paddingY={2} width={Math.min(terminalWidth - 8, 90)}>
+                  <Text bold>Repository Info {infoRepo ? tc.muted('(cached)') : ''}</Text>
                   <Box height={1}><Text> </Text></Box>
-                  <Text>{chalk.bold(repo.nameWithOwner)}</Text>
-                  {repo.description && <Text color="gray">{repo.description}</Text>}
+                  <Text>{tc.text.bold(repo.nameWithOwner)}</Text>
+                  {repo.description && <Text color={theme.muted}>{repo.description}</Text>}
                   <Box height={1}><Text> </Text></Box>
                   <Text>
-                    {repo.visibility === 'PRIVATE' ? chalk.yellow('Private') : 
-                     repo.visibility === 'INTERNAL' ? chalk.magenta('Internal') : 
-                     chalk.green('Public')}
-                    {repo.isArchived ? chalk.gray('  Archived') : ''}
-                    {repo.isFork ? chalk.blue('  Fork') : ''}
+                    {repo.visibility === 'PRIVATE' ? tc.private('Private') :
+                     repo.visibility === 'INTERNAL' ? tc.internal('Internal') :
+                     tc.success('Public')}
+                    {repo.isArchived ? tc.archived('  Archived') : ''}
+                    {repo.isFork ? tc.fork('  Fork') : ''}
                   </Text>
                   <Text>
-                    {chalk.gray(`★ ${repo.stargazerCount}  ⑂ ${repo.forkCount}`)}
+                    {tc.muted(`★ ${repo.stargazerCount}  ⑂ ${repo.forkCount}`)}
                   </Text>
                   <Text>
-                    {chalk.hex(langColor)(`● `)}{chalk.gray(`${langName}`)}
+                    {chalk.hex(langColor)(`● `)}{tc.muted(`${langName}`)}
                   </Text>
-                  <Text color="gray">Updated: {formatDate(repo.updatedAt)} • Pushed: {formatDate(repo.pushedAt)}</Text>
-                  <Text color="gray">Size: {repo.diskUsage} KB</Text>
+                  <Text color={theme.muted}>Updated: {formatDate(repo.updatedAt)} • Pushed: {formatDate(repo.pushedAt)}</Text>
+                  <Text color={theme.muted}>Size: {repo.diskUsage} KB</Text>
                   <Box height={1}><Text> </Text></Box>
-                  <Text color="gray">Press Esc or I to close</Text>
+                  <Text color={theme.muted}>Press Esc or I to close</Text>
                 </Box>
               );
             })()}
@@ -2300,6 +2310,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                 storeUIPrefs({ archiveFilter: filter });
               }}
               onCancel={() => setArchiveFilterMode(false)}
+              theme={theme}
             />
           </Box>
         ) : visibilityMode ? (
@@ -2314,6 +2325,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                 storeUIPrefs({ visibilityFilter: filter });
               }}
               onCancel={() => setVisibilityMode(false)}
+              theme={theme}
             />
           </Box>
         ) : sortMode ? (
@@ -2328,6 +2340,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                 // Will trigger refresh via useEffect
               }}
               onCancel={() => setSortMode(false)}
+              theme={theme}
             />
           </Box>
         ) : sortDirectionMode ? (
@@ -2343,6 +2356,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                 // Will trigger refresh via useEffect
               }}
               onCancel={() => setSortDirectionMode(false)}
+              theme={theme}
             />
           </Box>
         ) : changeVisibilityMode && changeVisibilityTarget ? (
@@ -2357,6 +2371,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               onClose={closeChangeVisibilityModal}
               changing={changingVisibility}
               error={changeVisibilityError}
+              theme={theme}
             />
           </Box>
         ) : renameMode && renameTarget ? (
@@ -2365,6 +2380,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               repo={renameTarget}
               onRename={executeRename}
               onCancel={closeRenameModal}
+              theme={theme}
             />
           </Box>
         ) : copyUrlMode ? (
@@ -2374,6 +2390,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               terminalWidth={terminalWidth}
               onClose={closeCopyUrlModal}
               onCopy={handleCopyUrl}
+              theme={theme}
             />
           </Box>
         ) : unstarMode && unstarTarget ? (
@@ -2385,6 +2402,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               onCancel={closeUnstarModal}
               isUnstarring={unstarring}
               error={unstarError}
+              theme={theme}
             />
           </Box>
         ) : starMode && starTarget ? (
@@ -2397,6 +2415,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               onCancel={closeStarModal}
               isStarring={starring}
               error={starError}
+              theme={theme}
             />
           </Box>
         ) : (
@@ -2414,6 +2433,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               archiveFilter={archiveFilter}
               isEnterprise={isEnterpriseOrg}
               starsMode={starsMode}
+              theme={theme}
             />
 
             {/* Filter input */}
@@ -2479,6 +2499,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                       spacingLines={spacingLines}
                       forkTracking={forkTracking}
                       starsMode={starsMode}
+                      theme={theme}
                     />
                   );
                 })
@@ -2528,20 +2549,20 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       <Box marginTop={1} paddingX={1} flexDirection="column">
         {/* Line 1: Basic navigation */}
         <Box width={terminalWidth} justifyContent="center">
-          <Text color="gray" dimColor={modalOpen ? true : undefined}>
+          <Text color={theme.muted} dimColor={modalOpen ? true : undefined}>
             ↑↓ Navigate • Ctrl+G Top • G Bottom • ⏎/O Open • R Refresh
           </Text>
         </Box>
         {/* Line 2: Search and filtering */}
         <Box width={terminalWidth} justifyContent="center">
-          <Text color="gray" dimColor={modalOpen ? true : undefined}>
-            / Search • S Sort • D Direction • T Density • A Archive Filter{!starsMode && ' • V Visibility Filter'}{ownerContext === 'personal' && ' • Shift+S Stars'}
+          <Text color={theme.muted} dimColor={modalOpen ? true : undefined}>
+            / Search • S Sort • D Direction • T Density • Shift+T Theme • A Archive Filter{!starsMode && ' • V Visibility Filter'}{ownerContext === 'personal' && ' • Shift+S Stars'}
           </Text>
         </Box>
         {/* Line 3: Repository actions */}
         <Box width={terminalWidth} justifyContent="center">
-          <Text color="gray" dimColor={modalOpen ? true : undefined}>
-            {starsMode ? 
+          <Text color={theme.muted} dimColor={modalOpen ? true : undefined}>
+            {starsMode ?
               'I Info • C Copy URL • U Unstar Repository' :
               'I Info • C Copy URL • Ctrl+S Un/Star • Ctrl+R Rename • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+F Sync Fork'
             }
@@ -2549,13 +2570,13 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         </Box>
         {/* Line 4: System controls */}
         <Box width={terminalWidth} justifyContent="center">
-          <Text color="gray" dimColor={modalOpen ? true : undefined}>
+          <Text color={theme.muted} dimColor={modalOpen ? true : undefined}>
             K Cache Info • W Org Switch • Del/Backspace Delete • Ctrl+L Logout • Q Quit
           </Text>
         </Box>
         {/* Line 5: Sponsorship */}
         <Box width={terminalWidth} justifyContent="center" marginTop={1}>
-          <Text color="yellow" dimColor={modalOpen ? true : undefined}>
+          <Text color={theme.warning} dimColor={modalOpen ? true : undefined}>
             💖 Sponsor on GitHub: github.com/sponsors/wiiiimm
           </Text>
         </Box>
@@ -2572,6 +2593,15 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               <Text key={i} color="gray">{msg}</Text>
             ))
           )}
+        </Box>
+      )}
+
+      {/* Theme toast notification */}
+      {themeToast && (
+        <Box marginTop={1} justifyContent="center">
+          <Box borderStyle="round" borderColor={theme.primary} paddingX={2} paddingY={0}>
+            <Text color={theme.primary}>{themeToast}</Text>
+          </Box>
         </Box>
       )}
 

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -1589,14 +1589,12 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
 
     // Cycle theme (Shift+T)
     if (key.shift && input === 'T') {
-      setThemeName((tn) => {
-        const next = nextTheme(tn);
-        storeUIPrefs({ theme: next });
-        if (themeToastTimerRef.current) clearTimeout(themeToastTimerRef.current);
-        setThemeToast(`Theme: ${getTheme(next).label}`);
-        themeToastTimerRef.current = setTimeout(() => setThemeToast(null), 2500);
-        return next;
-      });
+      const next = nextTheme(themeName);
+      setThemeName(next);
+      storeUIPrefs({ theme: next });
+      if (themeToastTimerRef.current) clearTimeout(themeToastTimerRef.current);
+      setThemeToast(`Theme: ${getTheme(next).label}`);
+      themeToastTimerRef.current = setTimeout(() => setThemeToast(null), 2500);
       return;
     }
 

--- a/tests/ui/RepoListHeader.test.tsx
+++ b/tests/ui/RepoListHeader.test.tsx
@@ -38,7 +38,7 @@ describe('RepoListHeader', () => {
     );
 
     const output = lastFrame() || '';
-    expect(output).toContain('Organization: My Organization');
+    expect(output).toContain('Organisation: My Organization');
     expect(output).toContain('Sort: name ↑');
     expect(output).toContain('Fork Status - Commits Behind: OFF');
     unmount();
@@ -58,7 +58,7 @@ describe('RepoListHeader', () => {
     );
 
     const output = lastFrame() || '';
-    expect(output).toContain('Organization: my-org');
+    expect(output).toContain('Organisation: my-org');
     unmount();
   });
 
@@ -188,7 +188,7 @@ describe('RepoListHeader', () => {
     const output = lastFrame() || '';
     // Should not show any context label when undefined
     expect(output).not.toContain('Personal Account');
-    expect(output).not.toContain('Organization:');
+    expect(output).not.toContain('Organisation:');
     // But should still show other elements
     expect(output).toContain('Sort: updated ↓');
     unmount();


### PR DESCRIPTION
Assignee: @wiiiimm ([William Li](https://linear.app/stealths/profiles/wiiiimm))

## Summary

- **`src/config/themes.ts`**: 4 built-in themes (Default, Ocean, Forest, Monochrome) with semantic colour slots (`primary`, `secondary`, `success`, `warning`, `error`, `muted`, `text`, `selected`, `private`, `archived`, `internal`, `fork`, `dim`)
- **`src/ui/hooks/useTheme.ts`**: memoised `useTheme(name)` hook returning `{ theme, c }` with pre-bound chalk helpers and background variants for modal arrow indicators
- **`UIPrefs`** extended with `theme?` and `archiveFilter?` fields in `src/config/config.ts`
- **`Shift+T`** cycles through themes with a 2.5 s toast notification; `T` (unshifted) still toggles density
- Theme is loaded from `getUIPrefs()` on mount and saved via `storeUIPrefs({ theme: next })`
- Theme colours threaded through: `RepoRow`, `RepoListHeader`, all 9 modal component files (Sort, SortDirection, ArchiveFilter, Visibility, ChangeVisibility, CopyUrl, Rename, Star, Unstar), and all inline modal renders in `RepoList.tsx` (delete, archive, sync, logout, info)
- Monochrome theme uses only white/whiteBright/gray — genuinely low-colour for accessibility
- `README.md`, `AGENTS.md`, and `CHANGELOG.md` updated with theme list and `Shift+T` keybinding docs

Closes [SWR-354](https://linear.app/stealths/issue/SWR-354/color-themes-with-cycle-keybinding-and-persisted-preference)

## Acceptance Criteria

- [x] At least the 4 themes available and visibly distinct
- [x] `Shift+T` cycles themes with a confirmation toast
- [x] Theme persists across restarts (UI prefs)
- [x] Theme colors applied consistently across list, rows, header, and all modals
- [x] Monochrome theme is genuinely low-color (accessibility-friendly)
- [x] README.md updated (theme list + `Shift+T` keybinding)
- [x] AGENTS.md updated
- [x] CHANGELOG updated

## Test plan

- [ ] Run `node dist/index.js`, press `Shift+T` repeatedly — toast shows theme name, UI colours change visibly
- [ ] Quit and relaunch — theme restored from prefs
- [ ] Press `T` — density still toggles (not theme)
- [ ] Cycle to Monochrome — verify no saturated colours remain in list, rows, and modals
- [ ] Open Sort, Visibility, ArchiveFilter modals — arrow indicator matches theme primary colour
- [ ] Open a repo Info panel — border and text colours match current theme

---
> **Tip:** I will respond to comments that @ mention @cyrus-mini-5 on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes plus a new optional UI pref field; no auth, API, or data-handling logic changes.
> 
> **Overview**
> Adds **persisted colour themes** with four palettes (Default, Ocean, Forest, Monochrome) defined in `src/config/themes.ts` and consumed via a new `useTheme` hook that exposes semantic chalk helpers.
> 
> **Shift+T** cycles themes (with a short toast); plain **T** still toggles density. The choice is stored in UI prefs (`theme` on `UIPrefs`, alongside `archiveFilter` typing in config).
> 
> Theme colours are wired through the main list (`RepoList.tsx` header, footer, inline delete/archive/sync/logout/info flows), `RepoRow`, `RepoListHeader`, and the sort/visibility/archive/copy/rename/star modals. Docs (`README.md`, `AGENTS.md`) document the keybinding; `AGENTS.md` also warns not to hand-edit `CHANGELOG.md`. Header tests expect British **Organisation** spelling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a41e0fe6a07cc6dc726d4bedc61fe2d6d4a81c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added four colour themes (Default, Ocean, Forest, Monochrome) cycled via Shift+T
  * Theme selection persists across restarts with visual feedback

* **Improvements**
  * Applied consistent theming across all modals, headers, and lists
  * Corrected "Organisation" spelling for regional consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->