### PR TITLE
feat: session usage summary shown on quit with operation tracking (SWR-19) [semantic pr title]

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -75,8 +75,12 @@ logger.info('Starting gh-manager-cli', {
 });
 
 // Graceful shutdown handlers
+// Signal-driven exits (Ctrl+C / kill) still exit with code 0, so flag them here
+// to suppress the end-of-session summary, which is meant only for a normal quit.
+let exitingViaSignal = false;
 const handleShutdown = (signal: string) => {
-  logger.info('Shutting down gh-manager-cli', { 
+  exitingViaSignal = true;
+  logger.info('Shutting down gh-manager-cli', {
     signal,
     uptime: process.uptime()
   });
@@ -103,12 +107,12 @@ process.on('exit', (code) => {
   // Only show sponsorship message on normal exit (code 0)
   // and not when there's an error or when using --version/--help
   const isNormalExit = code === 0;
-  const isInteractiveSession = !argv.includes('--version') && 
-                               !argv.includes('-v') && 
-                               !argv.includes('--help') && 
+  const isInteractiveSession = !argv.includes('--version') &&
+                               !argv.includes('-v') &&
+                               !argv.includes('--help') &&
                                !argv.includes('-h');
-  
-  if (isNormalExit && isInteractiveSession) {
+
+  if (isNormalExit && isInteractiveSession && !exitingViaSignal) {
     showSponsorshipMessage();
   }
   

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import pkg from '../package.json';
 import 'dotenv/config';
 import App from './ui/App';
 import { logger } from './lib/logger';
+import { formatSessionSummary } from './lib/session';
 
 // Basic CLI flags (handled before rendering Ink)
 const argv = process.argv.slice(2);
@@ -82,10 +83,10 @@ const handleShutdown = (signal: string) => {
   process.exit(0);
 };
 
-// Function to show sponsorship message
+// Function to show session summary and sponsorship message
 const showSponsorshipMessage = () => {
-  console.log('\n' + '─'.repeat(60));
-  console.log('\n💚 Thank you for using gh-manager-cli!\n');
+  process.stdout.write(formatSessionSummary());
+  console.log('💚 Thank you for using gh-manager-cli!\n');
   console.log('If this app saved you time, please consider supporting');
   console.log('the development of more open-source projects like this:\n');
   console.log('  💖 Sponsor on GitHub: https://github.com/sponsors/wiiiimm');

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -6,7 +6,8 @@ export type OperationType =
   | 'syncFork'
   | 'rename'
   | 'star'
-  | 'unstar';
+  | 'unstar'
+  | 'transfer';
 
 interface OperationCounts {
   delete: number;
@@ -17,6 +18,7 @@ interface OperationCounts {
   rename: number;
   star: number;
   unstar: number;
+  transfer: number;
 }
 
 const startTime = new Date();
@@ -29,6 +31,7 @@ const counts: OperationCounts = {
   rename: 0,
   star: 0,
   unstar: 0,
+  transfer: 0,
 };
 
 export function trackOperation(type: OperationType): void {
@@ -63,7 +66,18 @@ const OPERATION_LABELS: Record<OperationType, string> = {
   rename: 'renamed',
   star: 'starred',
   unstar: 'unstarred',
+  transfer: 'transferred',
 };
+
+// Map a bulk (multi-select) action to its session OperationType. Kept here so
+// both the single-repo handlers and the bulk loop record the same per-type
+// counts in the end-of-session summary. 'visibility' is the only name that
+// differs from its OperationType ('visibilityChange'); the rest are identical.
+export function bulkActionToOperation(
+  action: 'delete' | 'archive' | 'unarchive' | 'star' | 'unstar' | 'visibility' | 'transfer',
+): OperationType {
+  return action === 'visibility' ? 'visibilityChange' : action;
+}
 
 export function formatSessionSummary(): string {
   const durationMs = Date.now() - startTime.getTime();

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -43,7 +43,10 @@ export function getTotalOperations(): number {
 }
 
 function formatDuration(ms: number): string {
-  const totalSeconds = Math.floor(ms / 1000);
+  // Clamp to zero so a backward clock adjustment during the session can never
+  // produce a negative or non-finite duration in the summary.
+  const safeMs = Number.isFinite(ms) && ms > 0 ? ms : 0;
+  const totalSeconds = Math.floor(safeMs / 1000);
   const hours = Math.floor(totalSeconds / 3600);
   const minutes = Math.floor((totalSeconds % 3600) / 60);
   const seconds = totalSeconds % 60;

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,91 @@
+export type OperationType =
+  | 'delete'
+  | 'archive'
+  | 'unarchive'
+  | 'visibilityChange'
+  | 'syncFork'
+  | 'rename'
+  | 'star'
+  | 'unstar';
+
+interface OperationCounts {
+  delete: number;
+  archive: number;
+  unarchive: number;
+  visibilityChange: number;
+  syncFork: number;
+  rename: number;
+  star: number;
+  unstar: number;
+}
+
+const startTime = new Date();
+const counts: OperationCounts = {
+  delete: 0,
+  archive: 0,
+  unarchive: 0,
+  visibilityChange: 0,
+  syncFork: 0,
+  rename: 0,
+  star: 0,
+  unstar: 0,
+};
+
+export function trackOperation(type: OperationType): void {
+  counts[type]++;
+}
+
+export function getTotalOperations(): number {
+  return Object.values(counts).reduce((sum, n) => sum + n, 0);
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+  if (minutes > 0) {
+    return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  }
+  return `${seconds}s`;
+}
+
+const OPERATION_LABELS: Record<OperationType, string> = {
+  delete: 'deleted',
+  archive: 'archived',
+  unarchive: 'unarchived',
+  visibilityChange: 'visibility changed',
+  syncFork: 'fork synced',
+  rename: 'renamed',
+  star: 'starred',
+  unstar: 'unstarred',
+};
+
+export function formatSessionSummary(): string {
+  const durationMs = Date.now() - startTime.getTime();
+  const durationStr = formatDuration(durationMs);
+  const total = getTotalOperations();
+
+  const hr = '─'.repeat(60);
+  const lines: string[] = ['\n' + hr, ''];
+
+  if (total === 0) {
+    lines.push(`  Session: ${durationStr}  •  No changes made`);
+  } else {
+    lines.push(`  Session: ${durationStr}  •  ${total} operation${total === 1 ? '' : 's'} performed`);
+    lines.push('');
+    for (const [type, n] of Object.entries(counts) as [OperationType, number][]) {
+      if (n > 0) {
+        const noun = n === 1 ? 'repository' : 'repositories';
+        lines.push(`    • ${n} ${noun} ${OPERATION_LABELS[type]}`);
+      }
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -18,7 +18,7 @@ import { UnstarModal } from '../components/modals/UnstarModal';
 import { RepoRow, FilterInput, RepoListHeader } from '../components/repo';
 import { SlowSpinner } from '../components/common';
 import { truncate, formatDate, copyToClipboard, computeWindow } from '../../lib/utils';
-import { trackOperation } from '../../lib/session';
+import { trackOperation, bulkActionToOperation } from '../../lib/session';
 
 // Allow customizable repos per fetch via env var (1-50, default 15)
 const getPageSize = () => {
@@ -624,6 +624,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
           // processed — surface it as a failure instead of a silent no-op.
           throw new Error(`Missing required parameter for bulk ${action}`);
         }
+        trackOperation(bulkActionToOperation(action));
         trackSuccessfulOperation();
       } catch (e: any) {
         failed.push({ repo, error: e.message || 'Unknown error' });
@@ -843,6 +844,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     setTotalCount(c => Math.max(0, c - 1));
     setCursor(c => Math.max(0, Math.min(c, visibleItems.length - 2)));
 
+    trackOperation('transfer');
     trackSuccessfulOperation();
     closeTransferModal();
   }

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -17,6 +17,7 @@ import { UnstarModal } from '../components/modals/UnstarModal';
 import { RepoRow, FilterInput, RepoListHeader } from '../components/repo';
 import { SlowSpinner } from '../components/common';
 import { truncate, formatDate, copyToClipboard, computeWindow } from '../../lib/utils';
+import { trackOperation } from '../../lib/session';
 
 // Allow customizable repos per fetch via env var (1-50, default 15)
 const getPageSize = () => {
@@ -305,14 +306,15 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       const targetId = (unstarTarget as any).id;
       
       await unstarRepository(client, targetId);
-      
+
       // Remove from starred items list
       setStarredItems(prev => prev.filter((r: any) => r.id !== targetId));
       setStarredTotalCount(c => Math.max(0, c - 1));
-      
+
       // Adjust cursor if needed
       setCursor(c => Math.max(0, Math.min(c, starredItems.length - 2)));
-      
+
+      trackOperation('unstar');
       trackSuccessfulOperation();
       
       // Close modal
@@ -374,6 +376,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       
       setItems(prev => prev.map(updateRepo));
 
+      trackOperation(isStarred ? 'unstar' : 'star');
       trackSuccessfulOperation();
 
       // Close modal
@@ -448,6 +451,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         return r;
       };
       setItems(prev => prev.map(updateSyncedRepo));
+      trackOperation('syncFork');
+      trackSuccessfulOperation();
       closeSyncModal();
     } catch (e: any) {
       setSyncing(false);
@@ -477,7 +482,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       const updateRepo = (r: any) => (r.id === id ? { ...r, isArchived: !isArchived } : r);
       setItems(prev => prev.map(updateRepo));
 
-      trackSuccessfulOperation(); // Track the successful operation
+      trackOperation(isArchived ? 'unarchive' : 'archive');
+      trackSuccessfulOperation();
       closeArchiveModal();
     } catch (e) {
       setArchiving(false);
@@ -503,6 +509,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       const updateRepo = (r: any) => (r.id === id ? { ...r, name: newName, nameWithOwner: newNameWithOwner } : r);
       setItems(prev => prev.map(updateRepo));
 
+      trackOperation('rename');
+      trackSuccessfulOperation();
       closeRenameModal();
     } catch (error: any) {
       throw error; // Let the modal handle the error
@@ -592,6 +600,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         setItems(prev => prev.map(updateRepo));
       }
       
+      trackOperation('visibilityChange');
+      trackSuccessfulOperation();
       closeChangeVisibilityModal();
     } catch (e: any) {
       setChangingVisibility(false);
@@ -682,7 +692,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       // Update counts
       setTotalCount((c) => Math.max(0, c - 1));
       
-      trackSuccessfulOperation(); // Track the successful operation
+      trackOperation('delete');
+      trackSuccessfulOperation();
       setDeleteMode(false);
       setDeleteTarget(null);
       setTypedCode('');

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -608,7 +608,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
           // active visibility filter (both 'public' and 'private'), so they stay
           // available when the filter changes — never prune here.
           const updateRepo = (r: RepoNode) => r.id === repo.id
-            ? { ...r, visibility: visTarget, isPrivate: visTarget !== 'PUBLIC' }
+            ? { ...r, visibility: visTarget, isPrivate: visTarget === 'PRIVATE' }
             : r;
           setItems(prev => prev.map(updateRepo));
         } else if (action === 'transfer' && transferDest) {

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import {
+  trackOperation,
+  getTotalOperations,
+  formatSessionSummary,
+  bulkActionToOperation,
+} from '../src/lib/session';
+
+// The session tracker is a module-level singleton, so counts accumulate across
+// the whole process (i.e. across org/workspace switches) — exactly the
+// behaviour the end-of-session summary relies on. These tests run against that
+// shared state, so they assert on deltas rather than absolute counts.
+
+describe('bulkActionToOperation', () => {
+  it('maps visibility to visibilityChange and passes the rest through', () => {
+    expect(bulkActionToOperation('visibility')).toBe('visibilityChange');
+    expect(bulkActionToOperation('delete')).toBe('delete');
+    expect(bulkActionToOperation('archive')).toBe('archive');
+    expect(bulkActionToOperation('unarchive')).toBe('unarchive');
+    expect(bulkActionToOperation('star')).toBe('star');
+    expect(bulkActionToOperation('unstar')).toBe('unstar');
+    expect(bulkActionToOperation('transfer')).toBe('transfer');
+  });
+});
+
+describe('trackOperation / session summary', () => {
+  it('counts the new transfer operation type', () => {
+    const before = getTotalOperations();
+    trackOperation('transfer');
+    expect(getTotalOperations()).toBe(before + 1);
+    expect(formatSessionSummary()).toContain('repository transferred');
+  });
+
+  it('counts bulk-style operations via the mapping helper', () => {
+    const before = getTotalOperations();
+    trackOperation(bulkActionToOperation('delete'));
+    trackOperation(bulkActionToOperation('visibility'));
+    expect(getTotalOperations()).toBe(before + 2);
+    const summary = formatSessionSummary();
+    expect(summary).toContain('deleted');
+    expect(summary).toContain('visibility changed');
+  });
+});


### PR DESCRIPTION
Assignee: @wiiiimm ([William Li](https://linear.app/stealths/profiles/wiiiimm))

## Summary

- Adds `src/lib/session.ts` — a module-level singleton that records session start time and tracks operations by type (delete, archive, unarchive, visibilityChange, syncFork, rename, star, unstar)
- Wires `trackOperation()` into every destructive action handler in `RepoList.tsx`; also adds missing `trackSuccessfulOperation()` calls to `executeSync`, `executeRename`, and `handleVisibilityChange`
- Updates `index.tsx` exit handler to print a session summary (duration + per-type operation breakdown) before the donation prompt on normal quit

**Example output on quit:**
```
─────────────────────────────────────────────────────────────
  Session: 3m 47s  •  3 operations performed

    • 1 repository deleted
    • 1 repository archived
    • 1 repository visibility changed

💚 Thank you for using gh-manager-cli!
...
```

## Acceptance Criteria

- [x] Track time used (quit time − launch time) — `startTime` captured at module import in `session.ts`
- [x] Track operations performed (excluding search and listing) — all destructive actions instrumented: delete, archive/unarchive, visibility change, sync fork, rename, star, unstar

## Test plan

- [ ] Launch the CLI and quit immediately — confirm summary shows the session duration and "No changes made"
- [ ] Perform a mix of operations (archive, delete, visibility change) then quit — confirm correct per-type counts
- [ ] Quit via Ctrl+C (SIGINT) — no summary shown (handled by `handleShutdown` which doesn't call `showSponsorshipMessage`)

Closes [SWR-19](https://linear.app/stealths/issue/SWR-19/gh-manager-cli-show-usage-summary-at-the-end-of-each-session-along)

---
> **Tip:** I will respond to comments that @ mention @cyrus-mini-5 on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Instruments all destructive GitHub repo actions and changes quit/exit messaging; the bulk visibility `isPrivate` fix alters how INTERNAL repos appear in the list after bulk updates.
> 
> **Overview**
> Adds an end-of-session **usage summary** (duration plus per-type repo operation counts) printed on a normal interactive quit, before the existing sponsorship message.
> 
> A new **`session` module** holds process-wide start time and counters for destructive actions (delete, archive/unarchive, visibility, sync fork, rename, star/unstar, **transfer**), with **`bulkActionToOperation`** so bulk flows use the same labels as single-repo handlers. **`RepoList`** calls **`trackOperation`** after each successful mutation (including bulk), and fills in missing **`trackSuccessfulOperation`** on sync, rename, and visibility. **`index.tsx`** sets **`exitingViaSignal`** so Ctrl+C / SIGTERM still exit 0 but **skip** the summary and sponsorship block.
> 
> Also fixes bulk visibility UI state: **`isPrivate`** is set with **`visTarget === 'PRIVATE'`** instead of treating non-`PUBLIC` as private (so **INTERNAL** is not mislabeled). Vitest coverage for the session helpers is added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d465e33f68a9c2e953cfc85a75d865eba00cb81b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session summary now displays operations performed (such as deleted, archived, renamed, transferred, or visibility changes) upon exit.

* **Refactor**
  * Sponsorship message output sequence updated to include session summary first before thank-you message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->