### PR TITLE
feat: theme-aware selected-row highlight with improved contrast (SWR-364) [semantic pr title]

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ On first run, you'll be prompted to authenticate with GitHub (OAuth recommended)
 ### User Interface & Experience
 - **Keyboard Navigation**: Full keyboard control (arrow keys, PageUp/Down, `Ctrl+G`/`G`)
 - **Display Density**: Toggle between compact/cozy/comfy spacing (`T`)
-- **Colour Themes**: Four themes (Default, Ocean, Forest, Monochrome) cycled with `Shift+T`, persisted across restarts
+- **Colour Themes**: Four themes (Default, Ocean, Forest, Monochrome) cycled with `Shift+T`, persisted across restarts; the selected-row highlight is theme-aware and tuned per theme for readable contrast
 - **Visual Indicators**: Fork status, private/internal/archived badges, language colors, visibility status
 - **Enterprise Support**: Full support for GitHub Enterprise with Internal repository visibility
 - **Organization Context**: Switch between personal and organization accounts with ENT badge for enterprise orgs
@@ -272,7 +272,7 @@ Launch the app, then use the keys below:
   - Stars: Number of stars
 - **Sort Direction**: `D` to open sort direction modal (ascending/descending)
 - **Display Density**: `T` to toggle compact/cozy/comfy
-- **Colour Theme**: `Shift+T` to cycle themes (Default → Ocean → Forest → Monochrome); selection persists across restarts
+- **Colour Theme**: `Shift+T` to cycle themes (Default → Ocean → Forest → Monochrome); selection persists across restarts. Each theme defines its own selected-row highlight (a darker on-theme background) so the highlighted repository stays high-contrast
 - **Fork Status**: Always enabled — shows commits **ahead** and **behind** upstream once enrichment completes (see below)
 - **Visibility Filter**: `V` opens modal (All, Public, Private/Internal for enterprise)
 - **Archive Filter**: `A` toggles archive filter (All → Unarchived → Archived)

--- a/src/config/themes.ts
+++ b/src/config/themes.ts
@@ -11,6 +11,13 @@ export interface Theme {
   muted: string;
   text: string;
   selected: string;
+  /**
+   * Background colour for the highlighted/selected row. Deliberately darker
+   * than the foreground text so bright selected text stays high-contrast.
+   * Hex is used for precise per-theme tones; chalk/Ink downsamples it to the
+   * nearest ANSI colour on terminals without truecolour support.
+   */
+  selectedBg: string;
   private: string;
   archived: string;
   internal: string;
@@ -30,6 +37,7 @@ export const THEMES: Record<ThemeName, Theme> = {
     muted: 'gray',
     text: 'white',
     selected: 'cyan',
+    selectedBg: '#1f4a57', // dark teal — contrasts the cyan/white selected text
     private: 'yellow',
     archived: 'gray',
     internal: 'magenta',
@@ -47,6 +55,7 @@ export const THEMES: Record<ThemeName, Theme> = {
     muted: 'blue',
     text: 'whiteBright',
     selected: 'blueBright',
+    selectedBg: '#11294d', // deep blue — sits behind the bright blue/white text
     private: 'cyan',
     archived: 'blue',
     internal: 'magenta',
@@ -64,6 +73,7 @@ export const THEMES: Record<ThemeName, Theme> = {
     muted: 'gray',
     text: 'white',
     selected: 'green',
+    selectedBg: '#14391f', // deep forest green behind the green/white text
     private: 'yellow',
     archived: 'gray',
     internal: 'magenta',
@@ -81,6 +91,7 @@ export const THEMES: Record<ThemeName, Theme> = {
     muted: 'gray',
     text: 'white',
     selected: 'whiteBright',
+    selectedBg: '#333333', // neutral dark grey — darker than the old bright grey
     private: 'white',
     archived: 'gray',
     internal: 'white',

--- a/src/ui/components/repo/RepoRow.tsx
+++ b/src/ui/components/repo/RepoRow.tsx
@@ -94,7 +94,7 @@ export default function RepoRow({
   const spacingBelow = spacingLines - spacingAbove;
 
   return (
-    <Box flexDirection="column" backgroundColor={selected ? 'gray' : undefined}>
+    <Box flexDirection="column" backgroundColor={selected ? theme.selectedBg : undefined}>
       {spacingAbove > 0 && (
         <Box height={spacingAbove}>
           <Text> </Text>


### PR DESCRIPTION
## Summary

Follow-up to SWR-354 (colour themes). The selected/highlighted row background was hardcoded to `'gray'` in `RepoRow`, so:
- the highlight never changed with the active colour theme, and
- the bright grey gave **low contrast** against the (also bright) selected-row text.

## Change

- Add a per-theme `selectedBg` slot to the `Theme` type (`src/config/themes.ts`).
- Give each theme its own deliberately darker, on-theme highlight tuned for readable contrast:
  - **Default** → `#1f4a57` (dark teal)
  - **Ocean** → `#11294d` (deep blue)
  - **Forest** → `#14391f` (deep forest green)
  - **Monochrome** → `#333333` (neutral dark grey — darker than the old bright grey)
- `RepoRow` now uses `theme.selectedBg` for the selected row instead of the literal `'gray'`.

Hex keeps precise per-theme tones; chalk/Ink downsamples to the nearest ANSI colour on terminals without truecolour support, so it degrades gracefully.

## Acceptance criteria

- [x] Selected-row highlight changes when cycling themes (Shift+T)
- [x] Each theme has a distinct, deliberately-chosen highlight colour with good text contrast
- [x] No remaining hardcoded selection background in the active repo-row path (`RepoRow.tsx`)
- [x] Build passes; existing tests still green (189 pass; the 3 failures — sponsorship docs ×2, ArchiveModal ×1 — are pre-existing on `main`)

## Notes

- `src/ui/views/RepoList.main.tsx` still has a hardcoded `'gray'` highlight but is **dead code** (not imported anywhere; the active list is `RepoList.tsx` → `RepoRow.tsx`), so it was left untouched.
- AGENTS.md has no colour-slot enumeration to update; README theming notes were updated.

Linear: SWR-364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentation-only change to theme config and one row component; no auth, API, or data handling impact.
> 
> **Overview**
> **Theme-aware selected-row highlights** replace the fixed `'gray'` background on the active repository row so the selection follows the colour theme and stays readable against bright selected text.
> 
> Each theme in `themes.ts` gains a **`selectedBg`** hex tuned per palette (teal, deep blue, forest green, neutral grey for Monochrome). **`RepoRow`** applies `theme.selectedBg` when the row is selected. README notes that cycling themes (`Shift+T`) now changes the highlight and that terminals without truecolour still get a reasonable ANSI fallback via chalk/Ink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66f860dee2fdd2d12ae4d7a2eabe0adc57a3636d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->