### PR TITLE
feat: add repository creation (Ctrl+N) and transfer (Shift+M)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,7 @@ See the living roadmap in [TODOs.md](./TODOs.md) for the canonical, up-to-date l
 - `I`: repository info modal
 - `K`: cache inspection
 - `Ctrl+N`: create a new repository in the current context (prompts for name with the personal/org slug shown in front; `Tab` cycles visibility; GitHub errors surfaced inline). Disabled in starred mode.
-- `Ctrl+T`: transfer selected repo to another owner (prompts for destination owner, then a confirmation step; GitHub errors surfaced inline; transferred repo is removed from the list). Disabled in starred mode.
+- `Shift+M`: transfer (move) selected repo to another owner (prompts for destination owner, then a confirmation step; GitHub errors surfaced inline; transferred repo is removed from the list). Disabled in starred mode.
 - `Del` or `Backspace`: delete selected repo (two-stage confirmation)
 - `Ctrl+A`: archive/unarchive selected repo
 - `Ctrl+V`: change repository visibility

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ See the living roadmap in [TODOs.md](./TODOs.md) for the canonical, up-to-date l
 - `P`: on a fork — jump cursor to the parent repo if it is already loaded; otherwise fetches the parent repo and shows it in the Info modal
 - `I`: repository info modal
 - `K`: cache inspection
-- `Ctrl+N`: create a new repository in the current context (prompts for name with the personal/org slug shown in front; `Tab` cycles visibility; GitHub errors surfaced inline). Disabled in starred mode.
+- `Ctrl+N`: create a new repository in the current context (prompts for name with the personal/organisation slug shown in front; `Tab` cycles visibility; GitHub errors surfaced inline). Disabled in starred mode.
 - `Shift+M`: transfer (move) selected repo to another owner (prompts for destination owner, then a confirmation step; GitHub errors surfaced inline; transferred repo is removed from the list). Disabled in starred mode.
 - `Del` or `Backspace`: delete selected repo (two-stage confirmation)
 - `Ctrl+A`: archive/unarchive selected repo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,7 @@ See the living roadmap in [TODOs.md](./TODOs.md) for the canonical, up-to-date l
 - `I`: repository info modal
 - `K`: cache inspection
 - `Ctrl+N`: create a new repository in the current context (prompts for name with the personal/organisation slug shown in front; `Tab` cycles visibility; GitHub errors surfaced inline). Disabled in starred mode.
-- `Shift+M`: transfer (move) selected repo to another owner (prompts for destination owner, then a confirmation step; GitHub errors surfaced inline; transferred repo is removed from the list). Disabled in starred mode.
+- `Shift+M`: transfer (move) selected repo to another owner (prompts for destination owner, then requires typing a randomly generated verification code — like delete — followed by a final confirmation step; GitHub errors surfaced inline; transferred repo is removed from the list). Disabled in starred mode.
 - `Del` or `Backspace`: delete selected repo (two-stage confirmation)
 - `Ctrl+A`: archive/unarchive selected repo
 - `Ctrl+V`: change repository visibility

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,7 @@ See the living roadmap in [TODOs.md](./TODOs.md) for the canonical, up-to-date l
 - `P`: on a fork — jump cursor to the parent repo if it is already loaded; otherwise fetches the parent repo and shows it in the Info modal
 - `I`: repository info modal
 - `K`: cache inspection
+- `Ctrl+N`: create a new repository in the current context (prompts for name with the personal/org slug shown in front; `Tab` cycles visibility; GitHub errors surfaced inline). Disabled in starred mode.
 - `Del` or `Backspace`: delete selected repo (two-stage confirmation)
 - `Ctrl+A`: archive/unarchive selected repo
 - `Ctrl+V`: change repository visibility

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,7 @@ See the living roadmap in [TODOs.md](./TODOs.md) for the canonical, up-to-date l
 - `I`: repository info modal
 - `K`: cache inspection
 - `Ctrl+N`: create a new repository in the current context (prompts for name with the personal/org slug shown in front; `Tab` cycles visibility; GitHub errors surfaced inline). Disabled in starred mode.
+- `Ctrl+T`: transfer selected repo to another owner (prompts for destination owner, then a confirmation step; GitHub errors surfaced inline; transferred repo is removed from the list). Disabled in starred mode.
 - `Del` or `Backspace`: delete selected repo (two-stage confirmation)
 - `Ctrl+A`: archive/unarchive selected repo
 - `Ctrl+V`: change repository visibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-# [1.44.0](https://github.com/wiiiimm/gh-manager-cli/compare/v1.43.0...v1.44.0) (2026-06-05)
-
-
-### Features
-
-* theme-aware selected-row highlight with better contrast (SWR-364) ([#59](https://github.com/wiiiimm/gh-manager-cli/issues/59)) ([1b71cb2](https://github.com/wiiiimm/gh-manager-cli/commit/1b71cb2144b0773bb0d9538e3f30141e53346890)), closes [#1f4a57](https://github.com/wiiiimm/gh-manager-cli/issues/1f4a57) [#11294d](https://github.com/wiiiimm/gh-manager-cli/issues/11294d) [#14391f](https://github.com/wiiiimm/gh-manager-cli/issues/14391f) [#333333](https://github.com/wiiiimm/gh-manager-cli/issues/333333)
-
 # [1.43.0](https://github.com/wiiiimm/gh-manager-cli/compare/v1.42.0...v1.43.0) (2026-06-05)
 
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ On first run, you'll be prompted to authenticate with GitHub (OAuth recommended)
   - View detailed info (`I`) - Shows repository metadata, language, size, and timestamps
   - Open in browser (Enter/`O`) — for forks a chooser lets you open this repo or the upstream
   - Jump to upstream (`P`) — moves cursor to the parent if loaded; otherwise fetches and shows it
+  - Create new repository (`Ctrl+N`) — prompts for a name (with the personal/org slug shown in front), choose visibility with `Tab`, and surfaces GitHub errors inline
   - Rename repository (`Ctrl+R`) with inline validation and automatic cache update
   - Copy repository URL to clipboard (`C`) with SSH/HTTPS options
   - Delete repository (`Del` or `Backspace`) with secure two-step confirmation
@@ -288,6 +289,10 @@ Launch the app, then use the keys below:
 - **Quit**: `Q`
 
 ### Repository Actions
+- **Create repository**: `Ctrl+N` to create a new repository in the current context (personal or org)
+  - Prompts for a name with the owner slug (`owner/`) shown in front
+  - `Tab` cycles visibility (Private/Public, plus Internal for enterprise orgs)
+  - Enter to create; GitHub errors (e.g. name already exists) are shown inline
 - **Repository info**: `I` to view detailed metadata (size, language, timestamps)
 - **Cache info**: `K` to inspect Apollo cache status
 - **Archive/Unarchive**: `Ctrl+A` with confirmation prompt

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ On first run, you'll be prompted to authenticate with GitHub (OAuth recommended)
   - Jump to upstream (`P`) — moves cursor to the parent if loaded; otherwise fetches and shows it
   - Create new repository (`Ctrl+N`) — prompts for a name (with the personal/org slug shown in front), choose visibility with `Tab`, and surfaces GitHub errors inline
   - Rename repository (`Ctrl+R`) with inline validation and automatic cache update
+  - Transfer repository to another owner (`Ctrl+T`) — prompts for the destination owner, shows a confirmation, and surfaces GitHub errors inline
   - Copy repository URL to clipboard (`C`) with SSH/HTTPS options
   - Delete repository (`Del` or `Backspace`) with secure two-step confirmation
   - Archive/unarchive repositories (`Ctrl+A`) with confirmation prompts
@@ -303,6 +304,10 @@ Launch the app, then use the keys below:
 - **Star/Unstar**: `Ctrl+S` to toggle star status for any repository
 - **Sync fork**: `Ctrl+F` (for forks only, shows ahead/behind counts and handles conflicts)
 - **Rename repository**: `Ctrl+R` with inline validation
+- **Transfer repository**: `Ctrl+T` to transfer ownership to another user or organisation
+  - Prompts for the destination owner (`new-owner/<repo>` preview)
+  - Two-step flow with a confirmation prompt before transferring
+  - GitHub errors (e.g. insufficient permissions) are shown inline
 - **Copy URL**: `C` to copy repository URL to clipboard (SSH/HTTPS options)
 
 ### General

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ On first run, you'll be prompted to authenticate with GitHub (OAuth recommended)
   - View detailed info (`I`) - Shows repository metadata, language, size, and timestamps
   - Open in browser (Enter/`O`) — for forks a chooser lets you open this repo or the upstream
   - Jump to upstream (`P`) — moves cursor to the parent if loaded; otherwise fetches and shows it
-  - Create new repository (`Ctrl+N`) — prompts for a name (with the personal/org slug shown in front), choose visibility with `Tab`, and surfaces GitHub errors inline
+  - Create new repository (`Ctrl+N`) — prompts for a name (with the personal/organisation slug shown in front), choose visibility with `Tab`, and surfaces GitHub errors inline
   - Rename repository (`Ctrl+R`) with inline validation and automatic cache update
   - Transfer repository to another owner (`Shift+M`) — prompts for the destination owner, shows a confirmation, and surfaces GitHub errors inline
   - Copy repository URL to clipboard (`C`) with SSH/HTTPS options
@@ -290,9 +290,9 @@ Launch the app, then use the keys below:
 - **Quit**: `Q`
 
 ### Repository Actions
-- **Create repository**: `Ctrl+N` to create a new repository in the current context (personal or org)
+- **Create repository**: `Ctrl+N` to create a new repository in the current context (personal or organisation)
   - Prompts for a name with the owner slug (`owner/`) shown in front
-  - `Tab` cycles visibility (Private/Public, plus Internal for enterprise orgs)
+  - `Tab` cycles visibility (Private/Public, plus Internal for enterprise organisations)
   - Enter to create; GitHub errors (e.g. name already exists) are shown inline
 - **Repository info**: `I` to view detailed metadata (size, language, timestamps)
 - **Cache info**: `K` to inspect Apollo cache status

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ On first run, you'll be prompted to authenticate with GitHub (OAuth recommended)
   - Jump to upstream (`P`) — moves cursor to the parent if loaded; otherwise fetches and shows it
   - Create new repository (`Ctrl+N`) — prompts for a name (with the personal/organisation slug shown in front), choose visibility with `Tab`, and surfaces GitHub errors inline
   - Rename repository (`Ctrl+R`) with inline validation and automatic cache update
-  - Transfer repository to another owner (`Shift+M`) — prompts for the destination owner, shows a confirmation, and surfaces GitHub errors inline
+  - Transfer repository to another owner (`Shift+M`) — prompts for the destination owner, requires a verification code, shows a final confirmation, and surfaces GitHub errors inline
   - Copy repository URL to clipboard (`C`) with SSH/HTTPS options
   - Delete repository (`Del` or `Backspace`) with secure two-step confirmation
   - Archive/unarchive repositories (`Ctrl+A`) with confirmation prompts
@@ -306,7 +306,7 @@ Launch the app, then use the keys below:
 - **Rename repository**: `Ctrl+R` with inline validation
 - **Transfer repository**: `Shift+M` (Move) to transfer ownership to another user or organisation
   - Prompts for the destination owner (`new-owner/<repo>` preview)
-  - Two-step flow with a confirmation prompt before transferring
+  - Requires typing a randomly generated verification code (like delete), then a final confirmation before transferring
   - GitHub errors (e.g. insufficient permissions) are shown inline
 - **Copy URL**: `C` to copy repository URL to clipboard (SSH/HTTPS options)
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ On first run, you'll be prompted to authenticate with GitHub (OAuth recommended)
   - Jump to upstream (`P`) — moves cursor to the parent if loaded; otherwise fetches and shows it
   - Create new repository (`Ctrl+N`) — prompts for a name (with the personal/org slug shown in front), choose visibility with `Tab`, and surfaces GitHub errors inline
   - Rename repository (`Ctrl+R`) with inline validation and automatic cache update
-  - Transfer repository to another owner (`Ctrl+T`) — prompts for the destination owner, shows a confirmation, and surfaces GitHub errors inline
+  - Transfer repository to another owner (`Shift+M`) — prompts for the destination owner, shows a confirmation, and surfaces GitHub errors inline
   - Copy repository URL to clipboard (`C`) with SSH/HTTPS options
   - Delete repository (`Del` or `Backspace`) with secure two-step confirmation
   - Archive/unarchive repositories (`Ctrl+A`) with confirmation prompts
@@ -304,7 +304,7 @@ Launch the app, then use the keys below:
 - **Star/Unstar**: `Ctrl+S` to toggle star status for any repository
 - **Sync fork**: `Ctrl+F` (for forks only, shows ahead/behind counts and handles conflicts)
 - **Rename repository**: `Ctrl+R` with inline validation
-- **Transfer repository**: `Ctrl+T` to transfer ownership to another user or organisation
+- **Transfer repository**: `Shift+M` (Move) to transfer ownership to another user or organisation
   - Prompts for the destination owner (`new-owner/<repo>` preview)
   - Two-step flow with a confirmation prompt before transferring
   - GitHub errors (e.g. insufficient permissions) are shown inline

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-manager-cli",
-  "version": "1.44.0",
+  "version": "1.43.0",
   "private": false,
   "description": "TUI terminal app to manage GitHub repos. Clean up your account in 5 minutes. Archive, delete, rename repos with keyboard shortcuts. Alternative to clicking through github.com",
   "license": "MIT",

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -754,16 +754,22 @@ export async function createRepositoryRest(
 
   logger.info('Creating repository', { name, visibility, org: org ?? null, url });
 
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Authorization': `token ${token}`,
-      'Accept': 'application/vnd.github+json',
-      'Content-Type': 'application/json',
-      'User-Agent': 'gh-manager-cli'
-    },
-    body: JSON.stringify(body)
-  } as any);
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `token ${token}`,
+        'Accept': 'application/vnd.github+json',
+        'Content-Type': 'application/json',
+        'User-Agent': 'gh-manager-cli'
+      },
+      body: JSON.stringify(body)
+    } as any);
+  } catch (networkError: any) {
+    logger.error('Network error during repository creation', { error: networkError.message, name, org: org ?? null });
+    throw new Error(`Network error whilst creating repository: ${networkError.message}`);
+  }
 
   if (res.status === 201) {
     const data = await res.json();
@@ -806,16 +812,22 @@ export async function transferRepositoryRest(
 
   logger.info('Transferring repository', { owner, repo, newOwner, url });
 
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Authorization': `token ${token}`,
-      'Accept': 'application/vnd.github+json',
-      'Content-Type': 'application/json',
-      'User-Agent': 'gh-manager-cli'
-    },
-    body: JSON.stringify({ new_owner: newOwner })
-  } as any);
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `token ${token}`,
+        'Accept': 'application/vnd.github+json',
+        'Content-Type': 'application/json',
+        'User-Agent': 'gh-manager-cli'
+      },
+      body: JSON.stringify({ new_owner: newOwner })
+    } as any);
+  } catch (networkError: any) {
+    logger.error('Network error during repository transfer', { error: networkError.message, owner, repo, newOwner });
+    throw new Error(`Network error whilst transferring repository: ${networkError.message}`);
+  }
 
   // 202 Accepted = transfer initiated. Some responses may also return 200.
   if (res.status === 202 || res.status === 200) {

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -727,6 +727,7 @@ export async function deleteRepositoryRest(
 // GitHub GraphQL does not support creating repos. Use REST:
 //   - Personal: POST /user/repos
 //   - Organisation: POST /orgs/{org}/repos
+/** Options describing the repository to create via {@link createRepositoryRest}. */
 export interface CreateRepositoryOptions {
   name: string;
   visibility: 'PUBLIC' | 'PRIVATE' | 'INTERNAL';
@@ -734,6 +735,18 @@ export interface CreateRepositoryOptions {
   org?: string; // when provided, create under the organisation instead of the viewer
 }
 
+/**
+ * Create a repository via the GitHub REST API.
+ *
+ * Posts to `/user/repos` for the viewer, or `/orgs/{org}/repos` when `options.org`
+ * is set. Maps the requested visibility to the REST body (`private` boolean, or
+ * `visibility: 'internal'` for enterprise organisations).
+ *
+ * @param token GitHub access token with repo-creation scope.
+ * @param options The new repository's name, visibility, optional description and org.
+ * @returns The created repository's `nameWithOwner` and web `url`.
+ * @throws Error with a GitHub-derived message on a non-201 response or network failure.
+ */
 export async function createRepositoryRest(
   token: string,
   options: CreateRepositoryOptions
@@ -802,6 +815,19 @@ export async function createRepositoryRest(
 // GitHub GraphQL does not support transferring repos. Use REST:
 //   POST /repos/{owner}/{repo}/transfer with { new_owner }
 // The transfer is asynchronous: GitHub returns 202 Accepted on success.
+/**
+ * Transfer a repository to another owner via the GitHub REST API.
+ *
+ * The transfer is asynchronous — GitHub returns `202 Accepted` to acknowledge the
+ * request and processes it in the background, so success here means *initiated*,
+ * not completed.
+ *
+ * @param token GitHub access token with admin rights on the repository.
+ * @param owner Current owner (user or organisation) of the repository.
+ * @param repo Repository name.
+ * @param newOwner Destination owner (username or organisation login).
+ * @throws Error with a GitHub-derived message on a non-202/200 response or network failure.
+ */
 export async function transferRepositoryRest(
   token: string,
   owner: string,

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -724,6 +724,75 @@ export async function deleteRepositoryRest(
   throw new Error(msg);
 }
 
+// GitHub GraphQL does not support creating repos. Use REST:
+//   - Personal: POST /user/repos
+//   - Organisation: POST /orgs/{org}/repos
+export interface CreateRepositoryOptions {
+  name: string;
+  visibility: 'PUBLIC' | 'PRIVATE' | 'INTERNAL';
+  description?: string;
+  org?: string; // when provided, create under the organisation instead of the viewer
+}
+
+export async function createRepositoryRest(
+  token: string,
+  options: CreateRepositoryOptions
+): Promise<{ nameWithOwner: string; url: string }> {
+  const { name, visibility, description, org } = options;
+  const url = org
+    ? `https://api.github.com/orgs/${org}/repos`
+    : `https://api.github.com/user/repos`;
+
+  const body: Record<string, any> = { name };
+  if (visibility === 'INTERNAL') {
+    // Internal visibility is only valid for org repos within an enterprise
+    body.visibility = 'internal';
+  } else {
+    body.private = visibility === 'PRIVATE';
+  }
+  if (description) body.description = description;
+
+  logger.info('Creating repository', { name, visibility, org: org ?? null, url });
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Authorization': `token ${token}`,
+      'Accept': 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+      'User-Agent': 'gh-manager-cli'
+    },
+    body: JSON.stringify(body)
+  } as any);
+
+  if (res.status === 201) {
+    const data = await res.json();
+    logger.info('Successfully created repository', {
+      nameWithOwner: data.full_name,
+      url: data.html_url
+    });
+    return { nameWithOwner: data.full_name, url: data.html_url };
+  }
+
+  let msg = `Failed to create repository (status ${res.status})`;
+  try {
+    const errBody = await res.json();
+    if (errBody?.message) msg = errBody.message;
+    if (Array.isArray(errBody?.errors) && errBody.errors.length > 0) {
+      const details = errBody.errors
+        .map((e: any) => e.message || (e.field ? `${e.field}: ${e.code}` : e.code))
+        .filter(Boolean)
+        .join('; ');
+      if (details) msg += ` (${details})`;
+    }
+  } catch {
+    // ignore body parse errors
+  }
+
+  logger.error('Failed to create repository', { status: res.status, error: msg, name, org: org ?? null });
+  throw new Error(msg);
+}
+
 // Fetch starred repositories
 export async function getStarredRepositories(
   client: ReturnType<typeof makeClient>,

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -727,6 +727,31 @@ export async function deleteRepositoryRest(
 // GitHub GraphQL does not support creating repos. Use REST:
 //   - Personal: POST /user/repos
 //   - Organisation: POST /orgs/{org}/repos
+/**
+ * Parse a failed GitHub REST response into a human-readable error message,
+ * combining the top-level `message` with any per-field `errors[]` details.
+ *
+ * @param res The non-OK fetch Response.
+ * @param defaultMessage Fallback message used when the body can't be parsed.
+ */
+async function parseGitHubRestError(res: Response, defaultMessage: string): Promise<string> {
+  let msg = defaultMessage;
+  try {
+    const errBody = await res.json();
+    if (errBody?.message) msg = errBody.message;
+    if (Array.isArray(errBody?.errors) && errBody.errors.length > 0) {
+      const details = errBody.errors
+        .map((e: any) => e.message || (e.field ? `${e.field}: ${e.code}` : e.code))
+        .filter(Boolean)
+        .join('; ');
+      if (details) msg += ` (${details})`;
+    }
+  } catch {
+    // ignore body parse errors
+  }
+  return msg;
+}
+
 /** Options describing the repository to create via {@link createRepositoryRest}. */
 export interface CreateRepositoryOptions {
   name: string;
@@ -793,20 +818,7 @@ export async function createRepositoryRest(
     return { nameWithOwner: data.full_name, url: data.html_url };
   }
 
-  let msg = `Failed to create repository (status ${res.status})`;
-  try {
-    const errBody = await res.json();
-    if (errBody?.message) msg = errBody.message;
-    if (Array.isArray(errBody?.errors) && errBody.errors.length > 0) {
-      const details = errBody.errors
-        .map((e: any) => e.message || (e.field ? `${e.field}: ${e.code}` : e.code))
-        .filter(Boolean)
-        .join('; ');
-      if (details) msg += ` (${details})`;
-    }
-  } catch {
-    // ignore body parse errors
-  }
+  const msg = await parseGitHubRestError(res, `Failed to create repository (status ${res.status})`);
 
   logger.error('Failed to create repository', { status: res.status, error: msg, name, org: org ?? null });
   throw new Error(msg);
@@ -861,20 +873,7 @@ export async function transferRepositoryRest(
     return;
   }
 
-  let msg = `Failed to transfer repository (status ${res.status})`;
-  try {
-    const errBody = await res.json();
-    if (errBody?.message) msg = errBody.message;
-    if (Array.isArray(errBody?.errors) && errBody.errors.length > 0) {
-      const details = errBody.errors
-        .map((e: any) => e.message || (e.field ? `${e.field}: ${e.code}` : e.code))
-        .filter(Boolean)
-        .join('; ');
-      if (details) msg += ` (${details})`;
-    }
-  } catch {
-    // ignore body parse errors
-  }
+  const msg = await parseGitHubRestError(res, `Failed to transfer repository (status ${res.status})`);
 
   logger.error('Failed to transfer repository', { status: res.status, error: msg, owner, repo, newOwner });
   throw new Error(msg);

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -793,6 +793,55 @@ export async function createRepositoryRest(
   throw new Error(msg);
 }
 
+// GitHub GraphQL does not support transferring repos. Use REST:
+//   POST /repos/{owner}/{repo}/transfer with { new_owner }
+// The transfer is asynchronous: GitHub returns 202 Accepted on success.
+export async function transferRepositoryRest(
+  token: string,
+  owner: string,
+  repo: string,
+  newOwner: string
+): Promise<void> {
+  const url = `https://api.github.com/repos/${owner}/${repo}/transfer`;
+
+  logger.info('Transferring repository', { owner, repo, newOwner, url });
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Authorization': `token ${token}`,
+      'Accept': 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+      'User-Agent': 'gh-manager-cli'
+    },
+    body: JSON.stringify({ new_owner: newOwner })
+  } as any);
+
+  // 202 Accepted = transfer initiated. Some responses may also return 200.
+  if (res.status === 202 || res.status === 200) {
+    logger.info('Successfully initiated repository transfer', { owner, repo, newOwner, status: res.status });
+    return;
+  }
+
+  let msg = `Failed to transfer repository (status ${res.status})`;
+  try {
+    const errBody = await res.json();
+    if (errBody?.message) msg = errBody.message;
+    if (Array.isArray(errBody?.errors) && errBody.errors.length > 0) {
+      const details = errBody.errors
+        .map((e: any) => e.message || (e.field ? `${e.field}: ${e.code}` : e.code))
+        .filter(Boolean)
+        .join('; ');
+      if (details) msg += ` (${details})`;
+    }
+  } catch {
+    // ignore body parse errors
+  }
+
+  logger.error('Failed to transfer repository', { status: res.status, error: msg, owner, repo, newOwner });
+  throw new Error(msg);
+}
+
 // Fetch starred repositories
 export async function getStarredRepositories(
   client: ReturnType<typeof makeClient>,

--- a/src/ui/components/modals/CreateRepoModal.tsx
+++ b/src/ui/components/modals/CreateRepoModal.tsx
@@ -1,0 +1,147 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import TextInput from 'ink-text-input';
+import type { Theme } from '../../../config/themes';
+import { useTheme } from '../../hooks/useTheme';
+import { SlowSpinner } from '../common';
+
+type Visibility = 'PUBLIC' | 'PRIVATE' | 'INTERNAL';
+
+interface CreateRepoModalProps {
+  /** Owner slug shown in front of the name input (viewer login or org login) */
+  ownerSlug: string;
+  /** Whether the current context is an organisation (vs. personal) */
+  isOrg?: boolean;
+  /** Whether the org belongs to an enterprise (enables Internal visibility) */
+  isEnterprise?: boolean;
+  onCreate: (name: string, visibility: Visibility) => Promise<void>;
+  onCancel: () => void;
+  theme?: Theme;
+}
+
+export default function CreateRepoModal({ ownerSlug, isOrg, isEnterprise, onCreate, onCancel, theme: themeProp }: CreateRepoModalProps) {
+  const { theme, c } = useTheme(themeProp?.name ?? 'default');
+  const [name, setName] = useState('');
+  const [visibility, setVisibility] = useState<Visibility>('PRIVATE');
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Internal visibility is only available for enterprise organisations
+  const visibilities: Visibility[] = (isOrg && isEnterprise)
+    ? ['PRIVATE', 'PUBLIC', 'INTERNAL']
+    : ['PRIVATE', 'PUBLIC'];
+
+  useInput((input, key) => {
+    if (creating) return;
+
+    if (key.escape) {
+      onCancel();
+      return;
+    }
+
+    // Tab cycles through the available visibility options
+    if (key.tab) {
+      setVisibility(v => {
+        const idx = visibilities.indexOf(v);
+        return visibilities[(idx + 1) % visibilities.length];
+      });
+      return;
+    }
+
+    if (key.return) {
+      if (name.trim()) handleCreateConfirm();
+      return;
+    }
+  });
+
+  const handleCreateConfirm = async () => {
+    if (!name.trim() || creating) return;
+    try {
+      setCreating(true);
+      setError(null);
+      await onCreate(name.trim(), visibility);
+    } catch (e: any) {
+      setError(e.message || 'Failed to create repository');
+      setCreating(false);
+    }
+  };
+
+  // GitHub repo names allow: alphanumeric, hyphen, underscore, period
+  const handleNameChange = (value: string) => {
+    setName(value.replace(/[^a-zA-Z0-9\-_.]/g, ''));
+  };
+
+  const visLabel = (v: Visibility) => (v === 'PUBLIC' ? 'Public' : v === 'PRIVATE' ? 'Private' : 'Internal');
+
+  const isDisabled = !name.trim();
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={theme.primary}
+      paddingX={3}
+      paddingY={2}
+      width={80}
+    >
+      <Text bold color={theme.primary}>Create New Repository</Text>
+      <Box height={1}><Text> </Text></Box>
+
+      <Text color={theme.muted}>Owner: {ownerSlug} {isOrg ? '(organisation)' : '(personal)'}</Text>
+      <Box height={1}><Text> </Text></Box>
+
+      <Text>Repository name:</Text>
+      <Box flexDirection="row" alignItems="center">
+        <Text>{ownerSlug}/</Text>
+        <TextInput
+          value={name}
+          onChange={handleNameChange}
+          placeholder="my-new-repo"
+          focus={!creating}
+        />
+      </Box>
+
+      <Box height={1}><Text> </Text></Box>
+      <Box flexDirection="row">
+        <Text>Visibility: </Text>
+        {visibilities.map((v, i) => (
+          <Text key={v}>
+            {v === visibility ? c.btnPrimary(` ${visLabel(v)} `) : c.muted(visLabel(v))}
+            {i < visibilities.length - 1 ? '  ' : ''}
+          </Text>
+        ))}
+      </Box>
+
+      {creating ? (
+        <Box marginTop={2} justifyContent="center">
+          <Box flexDirection="row">
+            <Box marginRight={1}>
+              <SlowSpinner />
+            </Box>
+            <Text color={theme.primary}>Creating repository...</Text>
+          </Box>
+        </Box>
+      ) : (
+        <>
+          <Box marginTop={2}>
+            <Text color={theme.muted}>
+              {isDisabled ?
+                'Enter a name to create the repository' :
+                `Press Enter to create "${ownerSlug}/${name}"`
+              }
+            </Text>
+          </Box>
+          <Box marginTop={1}>
+            <Text color={theme.muted}>Tab to change visibility • Esc to cancel</Text>
+          </Box>
+        </>
+      )}
+
+      {error && (
+        <Box marginTop={1}>
+          <Text color={theme.error}>{error}</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/ui/components/modals/CreateRepoModal.tsx
+++ b/src/ui/components/modals/CreateRepoModal.tsx
@@ -71,8 +71,8 @@ export default function CreateRepoModal({ ownerSlug, isOrg, isEnterprise, onCrea
       setCreating(true);
       setError(null);
       await onCreate(name.trim(), visibility);
-    } catch (e: any) {
-      setError(e.message || 'Failed to create repository');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to create repository');
     } finally {
       setCreating(false);
       submittingRef.current = false;

--- a/src/ui/components/modals/CreateRepoModal.tsx
+++ b/src/ui/components/modals/CreateRepoModal.tsx
@@ -73,14 +73,17 @@ export default function CreateRepoModal({ ownerSlug, isOrg, isEnterprise, onCrea
       await onCreate(name.trim(), visibility);
     } catch (e: any) {
       setError(e.message || 'Failed to create repository');
+    } finally {
       setCreating(false);
       submittingRef.current = false;
     }
   };
 
-  // GitHub repo names allow: alphanumeric, hyphen, underscore, period
+  // GitHub repo names allow alphanumerics, hyphen, underscore and period, but
+  // cannot start with a dot — strip disallowed chars and any leading dots so we
+  // don't make a doomed API round-trip for names like ".hidden" or "..".
   const handleNameChange = (value: string) => {
-    setName(value.replace(/[^a-zA-Z0-9\-_.]/g, ''));
+    setName(value.replace(/[^a-zA-Z0-9\-_.]/g, '').replace(/^\.+/, ''));
   };
 
   const visLabel = (v: Visibility) => (v === 'PUBLIC' ? 'Public' : v === 'PRIVATE' ? 'Private' : 'Internal');

--- a/src/ui/components/modals/CreateRepoModal.tsx
+++ b/src/ui/components/modals/CreateRepoModal.tsx
@@ -19,6 +19,13 @@ interface CreateRepoModalProps {
   theme?: Theme;
 }
 
+/**
+ * Modal for creating a new repository in the current (personal or organisation) context.
+ *
+ * Prompts for a sanitised repository name shown after the `ownerSlug/` prefix, lets the
+ * user cycle visibility with Tab (Private/Public, plus Internal for enterprise orgs), and
+ * surfaces GitHub errors inline. Enter creates, Esc cancels. Guards against double-submit.
+ */
 export default function CreateRepoModal({ ownerSlug, isOrg, isEnterprise, onCreate, onCancel, theme: themeProp }: CreateRepoModalProps) {
   const { theme, c } = useTheme(themeProp?.name ?? 'default');
   const [name, setName] = useState('');

--- a/src/ui/components/modals/CreateRepoModal.tsx
+++ b/src/ui/components/modals/CreateRepoModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { Box, Text, useInput } from 'ink';
 import TextInput from 'ink-text-input';
 import type { Theme } from '../../../config/themes';
@@ -25,6 +25,9 @@ export default function CreateRepoModal({ ownerSlug, isOrg, isEnterprise, onCrea
   const [visibility, setVisibility] = useState<Visibility>('PRIVATE');
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Synchronous guard: `creating` state updates asynchronously, so two quick
+  // Enter presses could fire two create requests before the state is observed.
+  const submittingRef = useRef(false);
 
   // Internal visibility is only available for enterprise organisations
   const visibilities: Visibility[] = (isOrg && isEnterprise)
@@ -55,7 +58,8 @@ export default function CreateRepoModal({ ownerSlug, isOrg, isEnterprise, onCrea
   });
 
   const handleCreateConfirm = async () => {
-    if (!name.trim() || creating) return;
+    if (!name.trim() || creating || submittingRef.current) return;
+    submittingRef.current = true;
     try {
       setCreating(true);
       setError(null);
@@ -63,6 +67,7 @@ export default function CreateRepoModal({ ownerSlug, isOrg, isEnterprise, onCrea
     } catch (e: any) {
       setError(e.message || 'Failed to create repository');
       setCreating(false);
+      submittingRef.current = false;
     }
   };
 

--- a/src/ui/components/modals/DeleteModal.tsx
+++ b/src/ui/components/modals/DeleteModal.tsx
@@ -19,12 +19,13 @@ export default function DeleteModal({ repo, onDelete, onCancel }: DeleteModalPro
   const [deleteConfirmStage, setDeleteConfirmStage] = useState(false); // true after code verified
   const [confirmFocus, setConfirmFocus] = useState<'delete' | 'cancel'>('delete');
 
-  // Generate a random 6-character code when the modal opens
+  // Generate a random 4-character code when the modal opens.
+  // Code is uppercase-only (and matched case-insensitively) — see handleCodeSubmit.
   useEffect(() => {
     if (repo) {
       const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // Omit similar-looking chars
       let code = '';
-      for (let i = 0; i < 6; i++) {
+      for (let i = 0; i < 4; i++) {
         code += chars.charAt(Math.floor(Math.random() * chars.length));
       }
       setDeleteCode(code);
@@ -77,7 +78,18 @@ export default function DeleteModal({ repo, onDelete, onCancel }: DeleteModalPro
     }
   };
 
-  // Handle the verification code submission
+  // Uppercase as the user types and auto-advance the moment the full code
+  // matches — no Enter required.
+  const handleCodeChange = (value: string) => {
+    const up = value.toUpperCase();
+    setTypedCode(up);
+    if (up === deleteCode) {
+      setDeleteError(null);
+      setDeleteConfirmStage(true);
+    }
+  };
+
+  // Enter fallback: advance on a correct code, otherwise surface the error
   const handleCodeSubmit = () => {
     if (typedCode.toUpperCase() === deleteCode) {
       setDeleteConfirmStage(true);
@@ -114,7 +126,7 @@ export default function DeleteModal({ repo, onDelete, onCancel }: DeleteModalPro
             <Text>Verification code: </Text>
             <TextInput
               value={typedCode}
-              onChange={setTypedCode}
+              onChange={handleCodeChange}
               onSubmit={handleCodeSubmit}
             />
           </Box>

--- a/src/ui/components/modals/TransferModal.tsx
+++ b/src/ui/components/modals/TransferModal.tsx
@@ -80,17 +80,20 @@ export default function TransferModal({ repo, onTransfer, onCancel, theme: theme
       setTransferring(true);
       setError(null);
       await onTransfer(repo, newOwner.trim());
-    } catch (e: any) {
-      setError(e.message || 'Failed to transfer repository');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to transfer repository');
     } finally {
       setTransferring(false);
       submittingRef.current = false;
     }
   };
 
-  // GitHub owner logins allow alphanumeric characters and single hyphens
+  // GitHub owner logins allow alphanumeric characters and single hyphens, and
+  // cannot start with a hyphen — strip invalid chars and any leading hyphens.
+  // (We intentionally don't strip trailing hyphens here: doing so on every
+  // keystroke would prevent typing hyphenated names like "my-org".)
   const handleOwnerChange = (value: string) => {
-    setNewOwner(value.replace(/[^a-zA-Z0-9-]/g, ''));
+    setNewOwner(value.replace(/[^a-zA-Z0-9-]/g, '').replace(/^-+/, ''));
   };
 
   const isInputDisabled = !newOwner.trim() || newOwner.trim().toLowerCase() === owner.toLowerCase();

--- a/src/ui/components/modals/TransferModal.tsx
+++ b/src/ui/components/modals/TransferModal.tsx
@@ -202,7 +202,7 @@ export default function TransferModal({ repo, onTransfer, onCancel, theme: theme
             Transfer {c.text.bold(repo.nameWithOwner)} {'→'} {c.warning.bold(`${newOwner}/${repo.name}`)}
           </Text>
           <Box height={1}><Text> </Text></Box>
-          <Text>To confirm, please type <Text color={theme.warning} bold>{transferCode}</Text> below:</Text>
+          <Text>{`To confirm, please type ${c.warning.bold(transferCode)} below:`}</Text>
           <Box marginTop={1} flexDirection="row" alignItems="center">
             <Text>Verification code: </Text>
             <TextInput

--- a/src/ui/components/modals/TransferModal.tsx
+++ b/src/ui/components/modals/TransferModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { Box, Text, useInput } from 'ink';
 import TextInput from 'ink-text-input';
 import type { RepoNode } from '../../../types';
@@ -21,6 +21,8 @@ export default function TransferModal({ repo, onTransfer, onCancel, theme: theme
   const [focus, setFocus] = useState<'transfer' | 'cancel'>('cancel');
   const [transferring, setTransferring] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Synchronous guard against double-submission (state updates are async)
+  const submittingRef = useRef(false);
 
   const owner = repo ? repo.nameWithOwner.split('/')[0] : '';
 
@@ -65,7 +67,8 @@ export default function TransferModal({ repo, onTransfer, onCancel, theme: theme
   });
 
   const handleTransferConfirm = async () => {
-    if (transferring || !repo || !newOwner.trim()) return;
+    if (transferring || submittingRef.current || !repo || !newOwner.trim()) return;
+    submittingRef.current = true;
     try {
       setTransferring(true);
       setError(null);
@@ -73,6 +76,7 @@ export default function TransferModal({ repo, onTransfer, onCancel, theme: theme
     } catch (e: any) {
       setError(e.message || 'Failed to transfer repository');
       setTransferring(false);
+      submittingRef.current = false;
     }
   };
 

--- a/src/ui/components/modals/TransferModal.tsx
+++ b/src/ui/components/modals/TransferModal.tsx
@@ -1,0 +1,191 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import TextInput from 'ink-text-input';
+import type { RepoNode } from '../../../types';
+import type { Theme } from '../../../config/themes';
+import { useTheme } from '../../hooks/useTheme';
+import { SlowSpinner } from '../common';
+
+interface TransferModalProps {
+  repo: RepoNode | null;
+  onTransfer: (repo: RepoNode, newOwner: string) => Promise<void>;
+  onCancel: () => void;
+  theme?: Theme;
+}
+
+export default function TransferModal({ repo, onTransfer, onCancel, theme: themeProp }: TransferModalProps) {
+  const { theme, c } = useTheme(themeProp?.name ?? 'default');
+  const [newOwner, setNewOwner] = useState('');
+  const [stage, setStage] = useState<'input' | 'confirm'>('input');
+  // Default focus on Cancel for safety on the confirmation stage
+  const [focus, setFocus] = useState<'transfer' | 'cancel'>('cancel');
+  const [transferring, setTransferring] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const owner = repo ? repo.nameWithOwner.split('/')[0] : '';
+
+  useInput((input, key) => {
+    if (transferring || !repo) return;
+
+    if (key.escape) {
+      onCancel();
+      return;
+    }
+
+    if (stage === 'input') {
+      if (key.return) {
+        const target = newOwner.trim();
+        if (target && target.toLowerCase() !== owner.toLowerCase()) {
+          setError(null);
+          setStage('confirm');
+          setFocus('cancel');
+        }
+      }
+      return;
+    }
+
+    // Confirmation stage
+    if (key.leftArrow || key.rightArrow || key.tab) {
+      setFocus(f => (f === 'transfer' ? 'cancel' : 'transfer'));
+      return;
+    }
+    if (input === 'y' || input === 'Y') {
+      handleTransferConfirm();
+      return;
+    }
+    if (input === 'c' || input === 'C') {
+      onCancel();
+      return;
+    }
+    if (key.return) {
+      if (focus === 'transfer') handleTransferConfirm();
+      else onCancel();
+      return;
+    }
+  });
+
+  const handleTransferConfirm = async () => {
+    if (transferring || !repo || !newOwner.trim()) return;
+    try {
+      setTransferring(true);
+      setError(null);
+      await onTransfer(repo, newOwner.trim());
+    } catch (e: any) {
+      setError(e.message || 'Failed to transfer repository');
+      setTransferring(false);
+    }
+  };
+
+  // GitHub owner logins allow alphanumeric characters and single hyphens
+  const handleOwnerChange = (value: string) => {
+    setNewOwner(value.replace(/[^a-zA-Z0-9-]/g, ''));
+  };
+
+  const isInputDisabled = !newOwner.trim() || newOwner.trim().toLowerCase() === owner.toLowerCase();
+
+  if (!repo) return null;
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={theme.warning}
+      paddingX={3}
+      paddingY={2}
+      width={80}
+    >
+      <Text bold color={theme.warning}>Transfer Repository</Text>
+      <Box height={1}><Text> </Text></Box>
+
+      <Text color={theme.muted}>Repository: {repo.nameWithOwner}</Text>
+
+      {stage === 'input' ? (
+        <>
+          <Box height={1}><Text> </Text></Box>
+          <Text>New owner (username or organisation):</Text>
+          <Box flexDirection="row" alignItems="center">
+            <TextInput
+              value={newOwner}
+              onChange={handleOwnerChange}
+              placeholder="new-owner"
+              focus={!transferring}
+            />
+            <Text>/{repo.name}</Text>
+          </Box>
+
+          <Box marginTop={2}>
+            <Text color={theme.muted}>
+              {isInputDisabled ?
+                'Enter a different owner to continue' :
+                `Press Enter to review the transfer to "${newOwner}/${repo.name}"`
+              }
+            </Text>
+          </Box>
+          <Box marginTop={1}>
+            <Text color={theme.muted}>Press Esc to cancel</Text>
+          </Box>
+        </>
+      ) : (
+        <>
+          <Box height={1}><Text> </Text></Box>
+          <Text>
+            Transfer {c.text.bold(repo.nameWithOwner)} {'→'} {c.warning.bold(`${newOwner}/${repo.name}`)}
+          </Text>
+          <Box marginTop={1}>
+            <Text color={theme.warning}>
+              ⚠️  This hands ownership to {newOwner}. You may lose admin access, and only the
+              new owner can transfer it back.
+            </Text>
+          </Box>
+
+          {transferring ? (
+            <Box marginTop={2} justifyContent="center">
+              <Box flexDirection="row">
+                <Box marginRight={1}>
+                  <SlowSpinner />
+                </Box>
+                <Text color={theme.warning}>Transferring repository...</Text>
+              </Box>
+            </Box>
+          ) : (
+            <>
+              <Box marginTop={1} flexDirection="row" justifyContent="center" gap={6}>
+                <Box
+                  borderStyle="round"
+                  borderColor={focus === 'transfer' ? theme.warning : theme.muted}
+                  height={3}
+                  width={20}
+                  alignItems="center"
+                  justifyContent="center"
+                  flexDirection="column"
+                >
+                  <Text>{focus === 'transfer' ? c.btnPrimary(' Transfer ') : c.warning.bold('Transfer')}</Text>
+                </Box>
+                <Box
+                  borderStyle="round"
+                  borderColor={focus === 'cancel' ? 'white' : theme.muted}
+                  height={3}
+                  width={20}
+                  alignItems="center"
+                  justifyContent="center"
+                  flexDirection="column"
+                >
+                  <Text>{focus === 'cancel' ? c.btnMuted(' Cancel ') : c.muted.bold('Cancel')}</Text>
+                </Box>
+              </Box>
+              <Box marginTop={1} flexDirection="row" justifyContent="center">
+                <Text color={theme.muted}>←/→ Focus • Enter to {focus === 'transfer' ? 'Transfer' : 'Cancel'} • Y Transfer • C/Esc Cancel</Text>
+              </Box>
+            </>
+          )}
+        </>
+      )}
+
+      {error && (
+        <Box marginTop={1}>
+          <Text color={theme.error}>{error}</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/ui/components/modals/TransferModal.tsx
+++ b/src/ui/components/modals/TransferModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import TextInput from 'ink-text-input';
 import type { RepoNode } from '../../../types';
@@ -14,24 +14,46 @@ interface TransferModalProps {
 }
 
 /**
- * Two-stage modal for transferring a repository to another owner.
+ * Three-stage modal for transferring a repository to another owner.
  *
  * Stage one collects a sanitised destination owner (username or organisation); stage two
- * shows a confirmation (Cancel focused by default) before initiating the transfer. GitHub
- * errors are surfaced inline. Esc cancels at any point. Guards against double-submit.
+ * requires the user to type a randomly generated verification code (mirroring the delete
+ * flow) to guard against accidental transfers; stage three shows a final confirmation
+ * (Cancel focused by default) before initiating the transfer. GitHub errors are surfaced
+ * inline. Esc cancels at any point. Guards against double-submit.
  */
 export default function TransferModal({ repo, onTransfer, onCancel, theme: themeProp }: TransferModalProps) {
   const { theme, c } = useTheme(themeProp?.name ?? 'default');
   const [newOwner, setNewOwner] = useState('');
-  const [stage, setStage] = useState<'input' | 'confirm'>('input');
+  const [stage, setStage] = useState<'input' | 'code' | 'confirm'>('input');
   // Default focus on Cancel for safety on the confirmation stage
   const [focus, setFocus] = useState<'transfer' | 'cancel'>('cancel');
   const [transferring, setTransferring] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Verification code the user must retype to reach the final confirmation stage
+  const [transferCode, setTransferCode] = useState('');
+  const [typedCode, setTypedCode] = useState('');
   // Synchronous guard against double-submission (state updates are async)
   const submittingRef = useRef(false);
 
   const owner = repo ? repo.nameWithOwner.split('/')[0] : '';
+
+  // Generate a fresh 4-character verification code whenever the modal opens.
+  // Code is uppercase-only (and matched case-insensitively) — see handleCodeSubmit.
+  useEffect(() => {
+    if (repo) {
+      const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // Omit similar-looking chars
+      let code = '';
+      for (let i = 0; i < 4; i++) {
+        code += chars.charAt(Math.floor(Math.random() * chars.length));
+      }
+      setTransferCode(code);
+      setTypedCode('');
+      setStage('input');
+      setFocus('cancel');
+      setError(null);
+    }
+  }, [repo]);
 
   useInput((input, key) => {
     if (transferring || !repo) return;
@@ -46,10 +68,16 @@ export default function TransferModal({ repo, onTransfer, onCancel, theme: theme
         const target = newOwner.trim();
         if (target && target.toLowerCase() !== owner.toLowerCase()) {
           setError(null);
-          setStage('confirm');
-          setFocus('cancel');
+          setTypedCode('');
+          setStage('code');
         }
       }
+      return;
+    }
+
+    // Code stage: let TextInput handle character entry and Enter (via onSubmit);
+    // we only intercept Esc here (handled above).
+    if (stage === 'code') {
       return;
     }
 
@@ -72,6 +100,31 @@ export default function TransferModal({ repo, onTransfer, onCancel, theme: theme
       return;
     }
   });
+
+  // Advance to the final confirmation stage once the code matches
+  const advanceToConfirm = () => {
+    setError(null);
+    setStage('confirm');
+    setFocus('cancel');
+  };
+
+  // Uppercase as the user types and auto-advance the moment the full code
+  // matches — no Enter required (mirrors the delete flow).
+  const handleCodeChange = (value: string) => {
+    const up = value.toUpperCase();
+    setTypedCode(up);
+    if (up === transferCode) advanceToConfirm();
+  };
+
+  // Enter fallback: advance on a correct code, otherwise surface the error
+  const handleCodeSubmit = () => {
+    if (typedCode.toUpperCase() === transferCode) {
+      advanceToConfirm();
+    } else {
+      setError('Incorrect verification code. Please try again.');
+      setTypedCode('');
+    }
+  };
 
   const handleTransferConfirm = async () => {
     if (transferring || submittingRef.current || !repo || !newOwner.trim()) return;
@@ -114,7 +167,7 @@ export default function TransferModal({ repo, onTransfer, onCancel, theme: theme
 
       <Text color={theme.muted}>Repository: {repo.nameWithOwner}</Text>
 
-      {stage === 'input' ? (
+      {stage === 'input' && (
         <>
           <Box height={1}><Text> </Text></Box>
           <Text>New owner (username or organisation):</Text>
@@ -140,7 +193,32 @@ export default function TransferModal({ repo, onTransfer, onCancel, theme: theme
             <Text color={theme.muted}>Press Esc to cancel</Text>
           </Box>
         </>
-      ) : (
+      )}
+
+      {stage === 'code' && (
+        <>
+          <Box height={1}><Text> </Text></Box>
+          <Text>
+            Transfer {c.text.bold(repo.nameWithOwner)} {'→'} {c.warning.bold(`${newOwner}/${repo.name}`)}
+          </Text>
+          <Box height={1}><Text> </Text></Box>
+          <Text>To confirm, please type <Text color={theme.warning} bold>{transferCode}</Text> below:</Text>
+          <Box marginTop={1} flexDirection="row" alignItems="center">
+            <Text>Verification code: </Text>
+            <TextInput
+              value={typedCode}
+              onChange={handleCodeChange}
+              onSubmit={handleCodeSubmit}
+              focus={!transferring}
+            />
+          </Box>
+          <Box marginTop={1}>
+            <Text color={theme.muted}>Type the code to continue • Esc to cancel</Text>
+          </Box>
+        </>
+      )}
+
+      {stage === 'confirm' && (
         <>
           <Box height={1}><Text> </Text></Box>
           <Text>

--- a/src/ui/components/modals/TransferModal.tsx
+++ b/src/ui/components/modals/TransferModal.tsx
@@ -13,6 +13,13 @@ interface TransferModalProps {
   theme?: Theme;
 }
 
+/**
+ * Two-stage modal for transferring a repository to another owner.
+ *
+ * Stage one collects a sanitised destination owner (username or organisation); stage two
+ * shows a confirmation (Cancel focused by default) before initiating the transfer. GitHub
+ * errors are surfaced inline. Esc cancels at any point. Guards against double-submit.
+ */
 export default function TransferModal({ repo, onTransfer, onCancel, theme: themeProp }: TransferModalProps) {
   const { theme, c } = useTheme(themeProp?.name ?? 'default');
   const [newOwner, setNewOwner] = useState('');

--- a/src/ui/components/modals/TransferModal.tsx
+++ b/src/ui/components/modals/TransferModal.tsx
@@ -82,6 +82,7 @@ export default function TransferModal({ repo, onTransfer, onCancel, theme: theme
       await onTransfer(repo, newOwner.trim());
     } catch (e: any) {
       setError(e.message || 'Failed to transfer repository');
+    } finally {
       setTransferring(false);
       submittingRef.current = false;
     }

--- a/src/ui/components/modals/index.ts
+++ b/src/ui/components/modals/index.ts
@@ -13,4 +13,5 @@ export { default as RenameModal } from './RenameModal';
 export { StarModal } from './StarModal';
 export { default as OpenInBrowserModal } from './OpenInBrowserModal';
 export { default as CreateRepoModal } from './CreateRepoModal';
+export { default as TransferModal } from './TransferModal';
 

--- a/src/ui/components/modals/index.ts
+++ b/src/ui/components/modals/index.ts
@@ -12,4 +12,5 @@ export { default as CopyUrlModal } from './CopyUrlModal';
 export { default as RenameModal } from './RenameModal';
 export { StarModal } from './StarModal';
 export { default as OpenInBrowserModal } from './OpenInBrowserModal';
+export { default as CreateRepoModal } from './CreateRepoModal';
 

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -536,14 +536,15 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     setCreateMode(false);
 
     // The list refresh sends the active visibility filter to the API as a
-    // privacy parameter. If the new repo's visibility wouldn't pass that
-    // filter (e.g. a private repo while the Public filter is on), it would be
-    // omitted from the refreshed data and creation would look like it failed.
-    // Reset the filter to 'all' in that case so the new repo is visible.
+    // privacy parameter. If the new repo's visibility wouldn't be returned
+    // under that filter, it would be omitted from the refreshed data and
+    // creation would look like it failed. Note INTERNAL repos are NOT returned
+    // by the API's privacy: PRIVATE filter (even though the client 'private'
+    // filter shows them), so INTERNAL only passes when the filter is 'all'.
     const passesVisibilityFilter =
       visibilityFilter === 'all' ||
       (visibilityFilter === 'public' && visibility === 'PUBLIC') ||
-      (visibilityFilter === 'private' && (visibility === 'PRIVATE' || visibility === 'INTERNAL'));
+      (visibilityFilter === 'private' && visibility === 'PRIVATE');
 
     // Refresh from the network so the new repository shows up in the list
     setCursor(0);
@@ -552,10 +553,14 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     try { await purgeApolloCacheFiles(); } catch {}
 
     if (!passesVisibilityFilter) {
-      // Changing the filter triggers the visibilityFilter effect to refetch
-      // from the network (with privacy cleared), so avoid a duplicate fetch here.
+      // Reset the filter to 'all' so the new repo is visible, and fetch with an
+      // explicit 'all' privacy override. We refetch directly (rather than relying
+      // on the visibilityFilter effect, which no-ops when items is empty) and
+      // pre-sync previousVisibilityFilter so that effect doesn't double-fetch.
+      previousVisibilityFilter.current = 'all';
       storeUIPrefs({ visibilityFilter: 'all' });
       setVisibilityFilter('all');
+      fetchPage(null, true, true, undefined, 'network-only', 'all');
     } else {
       fetchPage(null, true, true, undefined, 'network-only');
     }
@@ -911,7 +916,10 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     reset = false,
     isSortChange = false,
     overrideForkTracking?: boolean,
-    policy?: 'cache-first' | 'network-only'
+    policy?: 'cache-first' | 'network-only',
+    // Force the API privacy parameter instead of deriving it from
+    // visibilityFilter. 'all' clears it (returns every visibility).
+    privacyOverride?: 'PUBLIC' | 'PRIVATE' | 'all'
   ) => {
     logger.info('fetchPage called', {
       after,
@@ -942,7 +950,9 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       
       // Map visibility filter to API privacy parameter
       let privacy: 'PUBLIC' | 'PRIVATE' | undefined;
-      if (visibilityFilter === 'public') privacy = 'PUBLIC';
+      if (privacyOverride !== undefined) {
+        privacy = privacyOverride === 'all' ? undefined : privacyOverride;
+      } else if (visibilityFilter === 'public') privacy = 'PUBLIC';
       else if (visibilityFilter === 'private') privacy = 'PRIVATE';
       // Note: GitHub API doesn't support filtering by INTERNAL at the API level
       

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -535,12 +535,30 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
 
     setCreateMode(false);
 
+    // The list refresh sends the active visibility filter to the API as a
+    // privacy parameter. If the new repo's visibility wouldn't pass that
+    // filter (e.g. a private repo while the Public filter is on), it would be
+    // omitted from the refreshed data and creation would look like it failed.
+    // Reset the filter to 'all' in that case so the new repo is visible.
+    const passesVisibilityFilter =
+      visibilityFilter === 'all' ||
+      (visibilityFilter === 'public' && visibility === 'PUBLIC') ||
+      (visibilityFilter === 'private' && (visibility === 'PRIVATE' || visibility === 'INTERNAL'));
+
     // Refresh from the network so the new repository shows up in the list
     setCursor(0);
     setRefreshing(true);
     setSortingLoading(true);
     try { await purgeApolloCacheFiles(); } catch {}
-    fetchPage(null, true, true, undefined, 'network-only');
+
+    if (!passesVisibilityFilter) {
+      // Changing the filter triggers the visibilityFilter effect to refetch
+      // from the network (with privacy cleared), so avoid a duplicate fetch here.
+      storeUIPrefs({ visibilityFilter: 'all' });
+      setVisibilityFilter('all');
+    } else {
+      fetchPage(null, true, true, undefined, 'network-only');
+    }
   }
 
   function closeTransferModal() {
@@ -2641,7 +2659,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         {/* Line 4: System controls */}
         <Box width={terminalWidth} justifyContent="center">
           <Text color={theme.muted} dimColor={modalOpen ? true : undefined}>
-            K Cache Info • W Org Switch • Ctrl+N New Repo • Del/Backspace Delete • Ctrl+L Logout • Q Quit
+            K Cache Info • W Org Switch{!starsMode ? ' • Ctrl+N New Repo' : ''} • Del/Backspace Delete • Ctrl+L Logout • Q Quit
           </Text>
         </Box>
         {/* Line 5: Sponsorship */}

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -568,9 +568,14 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     }
 
     // Fetch the freshly created repo node and insert it so it's visible right
-    // away. If the lookup fails, fall back to a full network refresh.
+    // away. A just-created repo can briefly be missing from GraphQL (replication
+    // lag), so retry once before falling back to a full network refresh.
     const [owner, repoName] = (nameWithOwner || '').split('/');
-    const created = await fetchRepositoryByOwnerAndName(client, owner, repoName);
+    let created = await fetchRepositoryByOwnerAndName(client, owner, repoName);
+    if (!created) {
+      await new Promise(resolve => setTimeout(resolve, 600));
+      created = await fetchRepositoryByOwnerAndName(client, owner, repoName);
+    }
 
     setCreateMode(false);
     // Queue the new repo for cursor focus. Its index in the visible list depends

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -920,10 +920,14 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   async function jumpToUpstreamRepo(parentNameWithOwner: string) {
     const [parentOwner, parentName] = parentNameWithOwner.split('/');
     if (!parentOwner || !parentName) return;
-    const repo = await fetchRepositoryByOwnerAndName(client, parentOwner, parentName);
-    if (repo) {
-      setInfoRepo(repo);
-      setInfoMode(true);
+    try {
+      const repo = await fetchRepositoryByOwnerAndName(client, parentOwner, parentName);
+      if (repo) {
+        setInfoRepo(repo);
+        setInfoMode(true);
+      }
+    } catch (err: any) {
+      logger.error('Failed to fetch upstream repository', { error: err?.message, parentNameWithOwner });
     }
   }
 

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState, useRef, useCallback } from 'react'
 import { Box, Text, useApp, useInput, useStdout, Spacer, Newline } from 'ink';
 import TextInput from 'ink-text-input';
 import chalk from 'chalk';
-import { makeClient, fetchViewerReposPageUnified, deleteRepositoryRest, archiveRepositoryById, unarchiveRepositoryById, changeRepositoryVisibility, syncForkWithUpstream, getRepositoryFromCache, purgeApolloCacheFiles, inspectCacheStatus, updateCacheAfterDelete, updateCacheAfterArchive, updateCacheAfterVisibilityChange, updateCacheWithRepository, checkOrganizationIsEnterprise, OwnerAffiliation, fetchViewerOrganizations, fetchRestRateLimits, renameRepositoryById, updateCacheAfterRename, getStarredRepositories, starRepository, unstarRepository, enrichForksWithAheadBehind, fetchRepositoryByOwnerAndName } from '../../services/github';
+import { makeClient, fetchViewerReposPageUnified, deleteRepositoryRest, archiveRepositoryById, unarchiveRepositoryById, changeRepositoryVisibility, syncForkWithUpstream, getRepositoryFromCache, purgeApolloCacheFiles, inspectCacheStatus, updateCacheAfterDelete, updateCacheAfterArchive, updateCacheAfterVisibilityChange, updateCacheWithRepository, checkOrganizationIsEnterprise, OwnerAffiliation, fetchViewerOrganizations, fetchRestRateLimits, renameRepositoryById, updateCacheAfterRename, getStarredRepositories, starRepository, unstarRepository, enrichForksWithAheadBehind, fetchRepositoryByOwnerAndName, createRepositoryRest } from '../../services/github';
 import { getUIPrefs, storeUIPrefs, OwnerContext } from '../../config/config';
 import { type ThemeName, nextTheme, getTheme } from '../../config/themes';
 import { useTheme } from '../hooks/useTheme';
@@ -12,7 +12,7 @@ import type { RepoNode, RateLimitInfo, RestRateLimitInfo } from '../../types';
 import { exec } from 'child_process';
 import OrgSwitcher from '../OrgSwitcher';
 import { logger } from '../../lib/logger';
-import { ArchiveFilterModal, DeleteModal, ArchiveModal, SyncModal, InfoModal, LogoutModal, VisibilityModal, SortModal, SortDirectionModal, ChangeVisibilityModal, CopyUrlModal, RenameModal, StarModal, OpenInBrowserModal } from '../components/modals';
+import { ArchiveFilterModal, DeleteModal, ArchiveModal, SyncModal, InfoModal, LogoutModal, VisibilityModal, SortModal, SortDirectionModal, ChangeVisibilityModal, CopyUrlModal, RenameModal, StarModal, OpenInBrowserModal, CreateRepoModal } from '../components/modals';
 import { UnstarModal } from '../components/modals/UnstarModal';
 import { RepoRow, FilterInput, RepoListHeader } from '../components/repo';
 import { SlowSpinner } from '../components/common';
@@ -134,6 +134,9 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   // Rename modal state
   const [renameMode, setRenameMode] = useState(false);
   const [renameTarget, setRenameTarget] = useState<RepoNode | null>(null);
+
+  // Create repository modal state
+  const [createMode, setCreateMode] = useState(false);
 
   // Copy URL modal state
   const [copyUrlMode, setCopyUrlMode] = useState(false);
@@ -515,6 +518,25 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     } catch (error: any) {
       throw error; // Let the modal handle the error
     }
+  }
+
+  // Shared create-repository execution function
+  async function executeCreate(name: string, visibility: 'PUBLIC' | 'PRIVATE' | 'INTERNAL') {
+    if (!name.trim()) return;
+
+    const org = ownerContext !== 'personal' ? ownerContext.login : undefined;
+
+    // Throws on failure so the modal can surface the GitHub error message
+    await createRepositoryRest(token, { name: name.trim(), visibility, org });
+
+    setCreateMode(false);
+
+    // Refresh from the network so the new repository shows up in the list
+    setCursor(0);
+    setRefreshing(true);
+    setSortingLoading(true);
+    try { await purgeApolloCacheFiles(); } catch {}
+    fetchPage(null, true, true, undefined, 'network-only');
   }
 
   // Timer ref for copy toast
@@ -1238,6 +1260,11 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return; // RenameModal component handles its own keyboard input
     }
 
+    // When create repository modal is open, trap inputs for modal
+    if (createMode) {
+      return; // CreateRepoModal component handles its own keyboard input
+    }
+
     // When open-in-browser modal is open, trap inputs for modal
     if (openInBrowserMode) {
       return; // OpenInBrowserModal component handles its own keyboard input
@@ -1473,6 +1500,14 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       if (repo) {
         setRenameMode(true);
         setRenameTarget(repo);
+      }
+      return;
+    }
+
+    // Create repository modal (Ctrl+N) - not available in stars mode
+    if (key.ctrl && (input === 'n' || input === 'N')) {
+      if (!starsMode) {
+        setCreateMode(true);
       }
       return;
     }
@@ -1760,7 +1795,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
 
   const lowRate = (rateLimit && rateLimit.remaining <= Math.ceil(rateLimit.limit * 0.1)) || 
                    (restRateLimit && restRateLimit.core.remaining <= Math.ceil(restRateLimit.core.limit * 0.1));
-  const modalOpen = deleteMode || archiveMode || syncMode || logoutMode || infoMode || visibilityMode || archiveFilterMode || sortMode || sortDirectionMode || changeVisibilityMode || copyUrlMode || renameMode || openInBrowserMode;
+  const modalOpen = deleteMode || archiveMode || syncMode || logoutMode || infoMode || visibilityMode || archiveFilterMode || sortMode || sortDirectionMode || changeVisibilityMode || copyUrlMode || renameMode || openInBrowserMode || createMode;
 
   // Memoize header to prevent re-renders - must be before any returns
   const headerBar = useMemo(() => (
@@ -2361,6 +2396,17 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               theme={theme}
             />
           </Box>
+        ) : createMode ? (
+          <Box height={contentHeight} alignItems="center" justifyContent="center">
+            <CreateRepoModal
+              ownerSlug={ownerContext === 'personal' ? (viewerLogin || 'me') : ownerContext.login}
+              isOrg={ownerContext !== 'personal'}
+              isEnterprise={isEnterpriseOrg}
+              onCreate={executeCreate}
+              onCancel={() => setCreateMode(false)}
+              theme={theme}
+            />
+          </Box>
         ) : copyUrlMode ? (
           <Box height={contentHeight} alignItems="center" justifyContent="center">
             <CopyUrlModal
@@ -2540,7 +2586,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         {/* Line 4: System controls */}
         <Box width={terminalWidth} justifyContent="center">
           <Text color={theme.muted} dimColor={modalOpen ? true : undefined}>
-            K Cache Info • W Org Switch • Del/Backspace Delete • Ctrl+L Logout • Q Quit
+            K Cache Info • W Org Switch • Ctrl+N New Repo • Del/Backspace Delete • Ctrl+L Logout • Q Quit
           </Text>
         </Box>
         {/* Line 5: Sponsorship */}

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -1546,8 +1546,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return;
     }
 
-    // Transfer repository modal (Ctrl+T) - not available in stars mode
-    if (key.ctrl && (input === 't' || input === 'T')) {
+    // Transfer repository modal (Shift+M for Move) - not available in stars mode
+    if (key.shift && input === 'M') {
       if (!starsMode) {
         const repo = visibleItems[cursor];
         if (repo) {
@@ -2634,7 +2634,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
           <Text color={theme.muted} dimColor={modalOpen ? true : undefined}>
             {starsMode ?
               'Shift+S My Repos • I Info • C Copy URL • U Unstar Repository' :
-              `${ownerContext === 'personal' ? 'Shift+S Starred • ' : ''}I Info • C Copy URL • Ctrl+S Un/Star • Ctrl+R Rename • Ctrl+T Transfer • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+F Sync Fork • P Jump to upstream`
+              `${ownerContext === 'personal' ? 'Shift+S Starred • ' : ''}I Info • C Copy URL • Ctrl+S Un/Star • Ctrl+R Rename • Shift+M Transfer • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+F Sync Fork • P Jump to upstream`
             }
           </Text>
         </Box>

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState, useRef, useCallback } from 'react'
 import { Box, Text, useApp, useInput, useStdout, Spacer, Newline } from 'ink';
 import TextInput from 'ink-text-input';
 import chalk from 'chalk';
-import { makeClient, fetchViewerReposPageUnified, deleteRepositoryRest, archiveRepositoryById, unarchiveRepositoryById, changeRepositoryVisibility, syncForkWithUpstream, getRepositoryFromCache, purgeApolloCacheFiles, inspectCacheStatus, updateCacheAfterDelete, updateCacheAfterArchive, updateCacheAfterVisibilityChange, updateCacheWithRepository, checkOrganizationIsEnterprise, OwnerAffiliation, fetchViewerOrganizations, fetchRestRateLimits, renameRepositoryById, updateCacheAfterRename, getStarredRepositories, starRepository, unstarRepository, enrichForksWithAheadBehind, fetchRepositoryByOwnerAndName, createRepositoryRest } from '../../services/github';
+import { makeClient, fetchViewerReposPageUnified, deleteRepositoryRest, archiveRepositoryById, unarchiveRepositoryById, changeRepositoryVisibility, syncForkWithUpstream, getRepositoryFromCache, purgeApolloCacheFiles, inspectCacheStatus, updateCacheAfterDelete, updateCacheAfterArchive, updateCacheAfterVisibilityChange, updateCacheWithRepository, checkOrganizationIsEnterprise, OwnerAffiliation, fetchViewerOrganizations, fetchRestRateLimits, renameRepositoryById, updateCacheAfterRename, getStarredRepositories, starRepository, unstarRepository, enrichForksWithAheadBehind, fetchRepositoryByOwnerAndName, createRepositoryRest, transferRepositoryRest } from '../../services/github';
 import { getUIPrefs, storeUIPrefs, OwnerContext } from '../../config/config';
 import { type ThemeName, nextTheme, getTheme } from '../../config/themes';
 import { useTheme } from '../hooks/useTheme';
@@ -12,7 +12,7 @@ import type { RepoNode, RateLimitInfo, RestRateLimitInfo } from '../../types';
 import { exec } from 'child_process';
 import OrgSwitcher from '../OrgSwitcher';
 import { logger } from '../../lib/logger';
-import { ArchiveFilterModal, DeleteModal, ArchiveModal, SyncModal, InfoModal, LogoutModal, VisibilityModal, SortModal, SortDirectionModal, ChangeVisibilityModal, CopyUrlModal, RenameModal, StarModal, OpenInBrowserModal, CreateRepoModal } from '../components/modals';
+import { ArchiveFilterModal, DeleteModal, ArchiveModal, SyncModal, InfoModal, LogoutModal, VisibilityModal, SortModal, SortDirectionModal, ChangeVisibilityModal, CopyUrlModal, RenameModal, StarModal, OpenInBrowserModal, CreateRepoModal, TransferModal } from '../components/modals';
 import { UnstarModal } from '../components/modals/UnstarModal';
 import { RepoRow, FilterInput, RepoListHeader } from '../components/repo';
 import { SlowSpinner } from '../components/common';
@@ -137,6 +137,10 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
 
   // Create repository modal state
   const [createMode, setCreateMode] = useState(false);
+
+  // Transfer repository modal state
+  const [transferMode, setTransferMode] = useState(false);
+  const [transferTarget, setTransferTarget] = useState<RepoNode | null>(null);
 
   // Copy URL modal state
   const [copyUrlMode, setCopyUrlMode] = useState(false);
@@ -537,6 +541,31 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     setSortingLoading(true);
     try { await purgeApolloCacheFiles(); } catch {}
     fetchPage(null, true, true, undefined, 'network-only');
+  }
+
+  function closeTransferModal() {
+    setTransferMode(false);
+    setTransferTarget(null);
+  }
+
+  // Shared transfer-repository execution function
+  async function executeTransfer(repo: RepoNode, newOwner: string) {
+    if (!repo || !newOwner.trim()) return;
+
+    const [owner, name] = (repo.nameWithOwner || '').split('/');
+    const targetId = (repo as any).id;
+
+    // Throws on failure so the modal can surface the GitHub error message
+    await transferRepositoryRest(token, owner, name, newOwner.trim());
+
+    // The repo no longer belongs to the current owner — drop it from the list
+    await updateCacheAfterDelete(token, targetId);
+    setItems(prev => prev.filter((r: any) => r.id !== targetId));
+    setTotalCount(c => Math.max(0, c - 1));
+    setCursor(c => Math.max(0, Math.min(c, visibleItems.length - 2)));
+
+    trackSuccessfulOperation();
+    closeTransferModal();
   }
 
   // Timer ref for copy toast
@@ -1265,6 +1294,11 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return; // CreateRepoModal component handles its own keyboard input
     }
 
+    // When transfer repository modal is open, trap inputs for modal
+    if (transferMode) {
+      return; // TransferModal component handles its own keyboard input
+    }
+
     // When open-in-browser modal is open, trap inputs for modal
     if (openInBrowserMode) {
       return; // OpenInBrowserModal component handles its own keyboard input
@@ -1508,6 +1542,18 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     if (key.ctrl && (input === 'n' || input === 'N')) {
       if (!starsMode) {
         setCreateMode(true);
+      }
+      return;
+    }
+
+    // Transfer repository modal (Ctrl+T) - not available in stars mode
+    if (key.ctrl && (input === 't' || input === 'T')) {
+      if (!starsMode) {
+        const repo = visibleItems[cursor];
+        if (repo) {
+          setTransferTarget(repo);
+          setTransferMode(true);
+        }
       }
       return;
     }
@@ -1795,7 +1841,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
 
   const lowRate = (rateLimit && rateLimit.remaining <= Math.ceil(rateLimit.limit * 0.1)) || 
                    (restRateLimit && restRateLimit.core.remaining <= Math.ceil(restRateLimit.core.limit * 0.1));
-  const modalOpen = deleteMode || archiveMode || syncMode || logoutMode || infoMode || visibilityMode || archiveFilterMode || sortMode || sortDirectionMode || changeVisibilityMode || copyUrlMode || renameMode || openInBrowserMode || createMode;
+  const modalOpen = deleteMode || archiveMode || syncMode || logoutMode || infoMode || visibilityMode || archiveFilterMode || sortMode || sortDirectionMode || changeVisibilityMode || copyUrlMode || renameMode || openInBrowserMode || createMode || transferMode;
 
   // Memoize header to prevent re-renders - must be before any returns
   const headerBar = useMemo(() => (
@@ -2407,6 +2453,15 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               theme={theme}
             />
           </Box>
+        ) : transferMode && transferTarget ? (
+          <Box height={contentHeight} alignItems="center" justifyContent="center">
+            <TransferModal
+              repo={transferTarget}
+              onTransfer={executeTransfer}
+              onCancel={closeTransferModal}
+              theme={theme}
+            />
+          </Box>
         ) : copyUrlMode ? (
           <Box height={contentHeight} alignItems="center" justifyContent="center">
             <CopyUrlModal
@@ -2579,7 +2634,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
           <Text color={theme.muted} dimColor={modalOpen ? true : undefined}>
             {starsMode ?
               'Shift+S My Repos • I Info • C Copy URL • U Unstar Repository' :
-              `${ownerContext === 'personal' ? 'Shift+S Starred • ' : ''}I Info • C Copy URL • Ctrl+S Un/Star • Ctrl+R Rename • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+F Sync Fork • P Jump to upstream`
+              `${ownerContext === 'personal' ? 'Shift+S Starred • ' : ''}I Info • C Copy URL • Ctrl+S Un/Star • Ctrl+R Rename • Ctrl+T Transfer • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+F Sync Fork • P Jump to upstream`
             }
           </Text>
         </Box>

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -535,6 +535,17 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
 
     setCreateMode(false);
 
+    // Clear any client-side filters that could hide the newly created repo from
+    // the refreshed list: an active fuzzy search (the query likely won't match
+    // the new name) and an archived-only filter (a new repo is always
+    // unarchived). The visibility filter is reconciled separately below.
+    setFilter('');
+    setFilterMode(false);
+    if (archiveFilter === 'archived') {
+      storeUIPrefs({ archiveFilter: 'all' });
+      setArchiveFilter('all');
+    }
+
     // The list refresh sends the active visibility filter to the API as a
     // privacy parameter. If the new repo's visibility wouldn't be returned
     // under that filter, it would be omitted from the refreshed data and
@@ -581,7 +592,11 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     // Throws on failure so the modal can surface the GitHub error message
     await transferRepositoryRest(token, owner, name, newOwner.trim());
 
-    // The repo no longer belongs to the current owner — drop it from the list
+    // GitHub transfers are asynchronous (202 Accepted = queued), so we optimistically
+    // drop the repo from the list for immediate feedback, consistent with the delete
+    // flow. We deliberately do NOT auto-refresh afterwards: a network refetch during
+    // the brief processing window could still return the repo under the current owner
+    // and make it flicker back. It stays removed until the user manually refreshes.
     await updateCacheAfterDelete(token, targetId);
     setItems(prev => prev.filter((r: any) => r.id !== targetId));
     setTotalCount(c => Math.max(0, c - 1));

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -1607,12 +1607,6 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       }
       return;
     }
-    
-    // Organization switcher (W for Workspace/Who)
-    if (input && input.toUpperCase() === 'W') {
-      setOrgSwitcherOpen(true);
-      return;
-    }
 
     // Sort modal: show sort options (S key when not in stars mode).
     // Disabled while a fuzzy search is active — results are ranked by match

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -524,7 +524,11 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     }
   }
 
-  // Shared create-repository execution function
+  /**
+   * Create a repository in the current context, then refresh the list so it appears.
+   * Clears any client-side filters (search, archived-only, mismatched visibility) that
+   * would otherwise hide the new repo. Throws on failure so the modal can show the error.
+   */
   async function executeCreate(name: string, visibility: 'PUBLIC' | 'PRIVATE' | 'INTERNAL') {
     if (!name.trim()) return;
 
@@ -582,7 +586,10 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     setTransferTarget(null);
   }
 
-  // Shared transfer-repository execution function
+  /**
+   * Transfer a repository to another owner, then optimistically remove it from the list
+   * and evict it from the cache. Throws on failure so the modal can show the error.
+   */
   async function executeTransfer(repo: RepoNode, newOwner: string) {
     if (!repo || !newOwner.trim()) return;
 

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -554,12 +554,13 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     }
 
     // If the new repo's visibility wouldn't pass the active visibility filter,
-    // reset to 'all' so it isn't filtered out of the list. Note INTERNAL is not
-    // matched by the 'private' filter for API purposes.
+    // reset to 'all' so it isn't filtered out of the list. The client-side
+    // 'private' filter includes both PRIVATE and INTERNAL (matching GitHub and
+    // executeVisibilityChange), so an INTERNAL repo passes it.
     const passesVisibilityFilter =
       visibilityFilter === 'all' ||
       (visibilityFilter === 'public' && visibility === 'PUBLIC') ||
-      (visibilityFilter === 'private' && visibility === 'PRIVATE');
+      (visibilityFilter === 'private' && (visibility === 'PRIVATE' || visibility === 'INTERNAL'));
     if (!passesVisibilityFilter) {
       previousVisibilityFilter.current = 'all';
       storeUIPrefs({ visibilityFilter: 'all' });
@@ -571,8 +572,11 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     const [owner, repoName] = (nameWithOwner || '').split('/');
     const created = await fetchRepositoryByOwnerAndName(client, owner, repoName);
 
-    setCursor(0);
     setCreateMode(false);
+    // Queue the new repo for cursor focus. Its index in the visible list depends
+    // on the active sort/filter, so it isn't necessarily at the top — an effect
+    // resolves the actual position once the repo appears (see pendingFocusRef).
+    pendingFocusRef.current = nameWithOwner;
 
     if (created) {
       await updateCacheWithRepository(token, created);
@@ -927,6 +931,10 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   type VisibilityFilter = 'all' | 'public' | 'private';
   const [visibilityFilter, setVisibilityFilter] = useState<VisibilityFilter>('all');
   const previousVisibilityFilter = useRef<VisibilityFilter>('all');
+  // nameWithOwner of a repo queued to receive cursor focus once it appears in
+  // the (re-sorted/filtered) visible list — e.g. a freshly created repo, whose
+  // position depends on the active sort rather than always being at the top.
+  const pendingFocusRef = useRef<string | null>(null);
 
   // Archive filter - 'all' | 'unarchived' | 'archived'
   type ArchiveFilter = 'all' | 'unarchived' | 'archived';
@@ -1840,6 +1848,19 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   useEffect(() => {
     setCursor(c => Math.min(c, Math.max(0, visibleItems.length - 1)));
   }, [filterActive, items.length, visibleItems.length]);
+
+  // Move the cursor to a repo queued for focus (e.g. just created) once it
+  // appears in the visible list. Its position depends on the active sort/filter,
+  // so we resolve the real index here rather than assuming the top.
+  useEffect(() => {
+    const target = pendingFocusRef.current;
+    if (!target) return;
+    const idx = visibleItems.findIndex(r => r.nameWithOwner === target);
+    if (idx >= 0) {
+      setCursor(idx);
+      pendingFocusRef.current = null;
+    }
+  }, [visibleItems]);
 
   // Calculate fixed heights for layout sections and list area
   const headerHeight = 2; // Header bar + margin

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -525,9 +525,14 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   }
 
   /**
-   * Create a repository in the current context, then refresh the list so it appears.
-   * Clears any client-side filters (search, archived-only, mismatched visibility) that
-   * would otherwise hide the new repo. Throws on failure so the modal can show the error.
+   * Create a repository in the current context, then make it appear in the list.
+   *
+   * The new repo's node is fetched and inserted directly into `items` (and the
+   * cache) so it shows immediately — independent of sort/pagination and of whether
+   * any background refresh succeeds. `filteredAndSorted` re-sorts client-side, so
+   * it lands in the right position even when it wouldn't be on the first server
+   * page. Client-side filters that would hide it are cleared/reconciled first.
+   * Throws on failure so the modal can show the error.
    */
   async function executeCreate(name: string, visibility: 'PUBLIC' | 'PRIVATE' | 'INTERNAL') {
     if (!name.trim()) return;
@@ -535,14 +540,12 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     const org = ownerContext !== 'personal' ? ownerContext.login : undefined;
 
     // Throws on failure so the modal can surface the GitHub error message
-    await createRepositoryRest(token, { name: name.trim(), visibility, org });
+    const { nameWithOwner } = await createRepositoryRest(token, { name: name.trim(), visibility, org });
 
-    setCreateMode(false);
-
-    // Clear any client-side filters that could hide the newly created repo from
-    // the refreshed list: an active fuzzy search (the query likely won't match
-    // the new name) and an archived-only filter (a new repo is always
-    // unarchived). The visibility filter is reconciled separately below.
+    // Clear any client-side filters that could hide the newly created repo:
+    // an active fuzzy search (the query likely won't match the new name) and an
+    // archived-only filter (a new repo is always unarchived). Visibility filter
+    // is reconciled below.
     setFilter('');
     setFilterMode(false);
     if (archiveFilter === 'archived') {
@@ -550,34 +553,38 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       setArchiveFilter('all');
     }
 
-    // The list refresh sends the active visibility filter to the API as a
-    // privacy parameter. If the new repo's visibility wouldn't be returned
-    // under that filter, it would be omitted from the refreshed data and
-    // creation would look like it failed. Note INTERNAL repos are NOT returned
-    // by the API's privacy: PRIVATE filter (even though the client 'private'
-    // filter shows them), so INTERNAL only passes when the filter is 'all'.
+    // If the new repo's visibility wouldn't pass the active visibility filter,
+    // reset to 'all' so it isn't filtered out of the list. Note INTERNAL is not
+    // matched by the 'private' filter for API purposes.
     const passesVisibilityFilter =
       visibilityFilter === 'all' ||
       (visibilityFilter === 'public' && visibility === 'PUBLIC') ||
       (visibilityFilter === 'private' && visibility === 'PRIVATE');
-
-    // Refresh from the network so the new repository shows up in the list
-    setCursor(0);
-    setRefreshing(true);
-    setSortingLoading(true);
-    try { await purgeApolloCacheFiles(); } catch {}
-
     if (!passesVisibilityFilter) {
-      // Reset the filter to 'all' so the new repo is visible, and fetch with an
-      // explicit 'all' privacy override. We refetch directly (rather than relying
-      // on the visibilityFilter effect, which no-ops when items is empty) and
-      // pre-sync previousVisibilityFilter so that effect doesn't double-fetch.
       previousVisibilityFilter.current = 'all';
       storeUIPrefs({ visibilityFilter: 'all' });
       setVisibilityFilter('all');
-      fetchPage(null, true, true, undefined, 'network-only', 'all');
+    }
+
+    // Fetch the freshly created repo node and insert it so it's visible right
+    // away. If the lookup fails, fall back to a full network refresh.
+    const [owner, repoName] = (nameWithOwner || '').split('/');
+    const created = await fetchRepositoryByOwnerAndName(client, owner, repoName);
+
+    setCursor(0);
+    setCreateMode(false);
+
+    if (created) {
+      await updateCacheWithRepository(token, created);
+      const createdId = (created as any).id;
+      setItems(prev => (prev.some((r: any) => r.id === createdId) ? prev : [created, ...prev]));
+      setTotalCount(c => c + 1);
     } else {
-      fetchPage(null, true, true, undefined, 'network-only');
+      // Couldn't resolve the new node — refresh from the network so it still appears.
+      setRefreshing(true);
+      setSortingLoading(true);
+      try { await purgeApolloCacheFiles(); } catch {}
+      fetchPage(null, true, true, undefined, 'network-only', passesVisibilityFilter ? undefined : 'all');
     }
   }
 

--- a/tests/ui/DeleteModal.test.tsx
+++ b/tests/ui/DeleteModal.test.tsx
@@ -17,16 +17,16 @@ const repoStub: RepoNode = {
 } as any;
 
 describe('DeleteModal Logic', () => {
-  it('generates a 6-character verification code', () => {
+  it('generates a 4-character verification code', () => {
     // This tests the logic that would generate the code
     const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
     let code = '';
-    for (let i = 0; i < 6; i++) {
+    for (let i = 0; i < 4; i++) {
       code += chars.charAt(Math.floor(Math.random() * chars.length));
     }
-    
-    expect(code).toHaveLength(6);
-    expect(code).toMatch(/^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{6}$/);
+
+    expect(code).toHaveLength(4);
+    expect(code).toMatch(/^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{4}$/);
   });
 
   it('verification code excludes similar-looking characters', () => {

--- a/tests/ui/TransferModal.test.tsx
+++ b/tests/ui/TransferModal.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from 'ink-testing-library';
+import TransferModal from '../../src/ui/components/modals/TransferModal';
+import type { RepoNode } from '../../src/types';
+
+// Mock the useInput hook to avoid stdin.ref issues and to drive key events.
+// Note: this also stubs the useInput used internally by ink-text-input, so the
+// destination-owner / verification-code TextInputs cannot receive typed
+// characters in this harness. Tests therefore exercise the drivable surface
+// (rendering, Esc-to-cancel, guards) plus the code logic directly.
+vi.mock('ink', async () => {
+  const actual = await vi.importActual('ink');
+  return {
+    ...actual,
+    useInput: vi.fn()
+  };
+});
+
+// ink-text-input internally calls the real ink useInput (which enables raw mode
+// and throws `stdin.ref is not a function` under the test stdin). Stub it to a
+// no-op so the surrounding modal can render; typed input isn't exercised here.
+vi.mock('ink-text-input', () => ({
+  default: () => null
+}));
+
+describe('TransferModal', () => {
+  let mockUseInput: any;
+
+  const mockRepo: RepoNode = {
+    id: 'repo-123',
+    name: 'test-repo',
+    nameWithOwner: 'user/test-repo',
+    description: 'Test repository',
+    isArchived: false,
+    isPrivate: false,
+    isFork: false,
+    stargazerCount: 10,
+    forkCount: 5,
+    primaryLanguage: { name: 'TypeScript', color: '#3178c6' },
+    updatedAt: '2024-01-01T00:00:00Z',
+    pushedAt: '2024-01-01T00:00:00Z',
+    diskUsage: 1024,
+    visibility: 'PUBLIC'
+  } as any;
+
+  beforeEach(async () => {
+    const ink = await import('ink');
+    mockUseInput = (ink as any).useInput;
+    mockUseInput.mockReset();
+  });
+
+  it('renders the destination-owner input stage', () => {
+    mockUseInput.mockImplementation(() => {});
+
+    const { lastFrame, unmount } = render(
+      <TransferModal repo={mockRepo} onTransfer={async () => {}} onCancel={() => {}} />
+    );
+
+    const output = lastFrame() || '';
+    expect(output).toContain('Transfer Repository');
+    expect(output).toContain('user/test-repo');
+    expect(output).toContain('New owner');
+    unmount();
+  });
+
+  it('renders nothing when repo is null', () => {
+    mockUseInput.mockImplementation(() => {});
+
+    const { lastFrame, unmount } = render(
+      <TransferModal repo={null} onTransfer={async () => {}} onCancel={() => {}} />
+    );
+
+    expect((lastFrame() || '').trim()).toBe('');
+    unmount();
+  });
+
+  it('cancels on Esc', () => {
+    const onCancel = vi.fn();
+    let inputCallback: any;
+    mockUseInput.mockImplementation((cb: any) => { inputCallback = cb; });
+
+    const { unmount } = render(
+      <TransferModal repo={mockRepo} onTransfer={async () => {}} onCancel={onCancel} />
+    );
+
+    inputCallback('', { escape: true });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('does not advance past the owner stage when no owner has been entered', () => {
+    const onTransfer = vi.fn(async () => {});
+    const onCancel = vi.fn();
+    let inputCallback: any;
+    mockUseInput.mockImplementation((cb: any) => { inputCallback = cb; });
+
+    const { lastFrame, unmount } = render(
+      <TransferModal repo={mockRepo} onTransfer={onTransfer} onCancel={onCancel} />
+    );
+
+    // Pressing Enter with an empty owner must not move to the code stage…
+    inputCallback('', { return: true });
+
+    const output = lastFrame() || '';
+    expect(output).toContain('New owner');           // still on input stage
+    expect(output).not.toContain('Verification code');
+    expect(onTransfer).not.toHaveBeenCalled();        // …and never starts a transfer
+    unmount();
+  });
+
+  // The verification code is a 4-char uppercase string excluding ambiguous chars.
+  it('generates a 4-character code excluding ambiguous characters', () => {
+    const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+    let code = '';
+    for (let i = 0; i < 4; i++) {
+      code += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    expect(code).toMatch(/^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{4}$/);
+    expect(chars).not.toContain('I');
+    expect(chars).not.toContain('O');
+    expect(chars).not.toContain('0');
+    expect(chars).not.toContain('1');
+  });
+
+  it('verifies the typed code case-insensitively', () => {
+    const code = 'AB23';
+    expect('ab23'.toUpperCase() === code).toBe(true);
+    expect('AB23'.toUpperCase() === code).toBe(true);
+    expect('zzzz'.toUpperCase() === code).toBe(false);
+  });
+});

--- a/tests/ui/TransferModal.test.tsx
+++ b/tests/ui/TransferModal.test.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { render } from 'ink-testing-library';
+import type { Key } from 'ink';
 import TransferModal from '../../src/ui/components/modals/TransferModal';
 import type { RepoNode } from '../../src/types';
+
+// Signature of the callback Ink passes to useInput
+type InkInputHandler = (input: string, key: Partial<Key>) => void;
 
 // Mock the useInput hook to avoid stdin.ref issues and to drive key events.
 // Note: this also stubs the useInput used internally by ink-text-input, so the
@@ -25,7 +29,7 @@ vi.mock('ink-text-input', () => ({
 }));
 
 describe('TransferModal', () => {
-  let mockUseInput: any;
+  let mockUseInput: Mock;
 
   const mockRepo: RepoNode = {
     id: 'repo-123',
@@ -42,11 +46,11 @@ describe('TransferModal', () => {
     pushedAt: '2024-01-01T00:00:00Z',
     diskUsage: 1024,
     visibility: 'PUBLIC'
-  } as any;
+  } as RepoNode;
 
   beforeEach(async () => {
     const ink = await import('ink');
-    mockUseInput = (ink as any).useInput;
+    mockUseInput = (ink as unknown as { useInput: Mock }).useInput;
     mockUseInput.mockReset();
   });
 
@@ -77,8 +81,8 @@ describe('TransferModal', () => {
 
   it('cancels on Esc', () => {
     const onCancel = vi.fn();
-    let inputCallback: any;
-    mockUseInput.mockImplementation((cb: any) => { inputCallback = cb; });
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
 
     const { unmount } = render(
       <TransferModal repo={mockRepo} onTransfer={async () => {}} onCancel={onCancel} />
@@ -92,8 +96,8 @@ describe('TransferModal', () => {
   it('does not advance past the owner stage when no owner has been entered', () => {
     const onTransfer = vi.fn(async () => {});
     const onCancel = vi.fn();
-    let inputCallback: any;
-    mockUseInput.mockImplementation((cb: any) => { inputCallback = cb; });
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
 
     const { lastFrame, unmount } = render(
       <TransferModal repo={mockRepo} onTransfer={onTransfer} onCancel={onCancel} />

--- a/wiki/Usage.md
+++ b/wiki/Usage.md
@@ -47,9 +47,9 @@ Launch the app, then use the keys below to navigate and interact with your repos
 
 ## Repository Actions
 
-- **Create repository**: `Ctrl+N` to create a new repository in the current context (personal or org)
+- **Create repository**: `Ctrl+N` to create a new repository in the current context (personal or organisation)
   - Prompts for a name with the owner slug (`owner/`) shown in front
-  - `Tab` cycles visibility (Private/Public, plus Internal for enterprise orgs)
+  - `Tab` cycles visibility (Private/Public, plus Internal for enterprise organisations)
   - Enter to create; GitHub errors (e.g. name already exists) are shown inline
 - **Repository info**: `I` to view detailed metadata (size, language, timestamps)
 - **Cache info**: `K` to inspect Apollo cache status

--- a/wiki/Usage.md
+++ b/wiki/Usage.md
@@ -61,6 +61,9 @@ Launch the app, then use the keys below to navigate and interact with your repos
 - **Star/Unstar**: `Ctrl+S` to toggle star status for any repository
 - **Sync fork**: `Ctrl+F` (for forks only, shows commit status and handles conflicts)
 - **Rename repository**: `Ctrl+R` with inline validation
+- **Transfer repository**: `Ctrl+T` to transfer ownership to another user or organisation
+  - Prompts for the destination owner, then a confirmation step before transferring
+  - GitHub errors (e.g. insufficient permissions) are shown inline
 - **Copy URL**: `C` to copy repository URL to clipboard (SSH/HTTPS options)
 
 ## General

--- a/wiki/Usage.md
+++ b/wiki/Usage.md
@@ -62,7 +62,7 @@ Launch the app, then use the keys below to navigate and interact with your repos
 - **Sync fork**: `Ctrl+F` (for forks only, shows commit status and handles conflicts)
 - **Rename repository**: `Ctrl+R` with inline validation
 - **Transfer repository**: `Shift+M` (Move) to transfer ownership to another user or organisation
-  - Prompts for the destination owner, then a confirmation step before transferring
+  - Prompts for the destination owner, then requires typing a randomly generated verification code (like delete), followed by a final confirmation before transferring
   - GitHub errors (e.g. insufficient permissions) are shown inline
 - **Copy URL**: `C` to copy repository URL to clipboard (SSH/HTTPS options)
 

--- a/wiki/Usage.md
+++ b/wiki/Usage.md
@@ -47,6 +47,10 @@ Launch the app, then use the keys below to navigate and interact with your repos
 
 ## Repository Actions
 
+- **Create repository**: `Ctrl+N` to create a new repository in the current context (personal or org)
+  - Prompts for a name with the owner slug (`owner/`) shown in front
+  - `Tab` cycles visibility (Private/Public, plus Internal for enterprise orgs)
+  - Enter to create; GitHub errors (e.g. name already exists) are shown inline
 - **Repository info**: `I` to view detailed metadata (size, language, timestamps)
 - **Cache info**: `K` to inspect Apollo cache status
 - **Archive/Unarchive**: `Ctrl+A` with confirmation prompt

--- a/wiki/Usage.md
+++ b/wiki/Usage.md
@@ -64,6 +64,7 @@ Launch the app, then use the keys below to navigate and interact with your repos
 - **Transfer repository**: `Shift+M` (Move) to transfer ownership to another user or organisation
   - Prompts for the destination owner, then requires typing a randomly generated verification code (like delete), followed by a final confirmation before transferring
   - GitHub errors (e.g. insufficient permissions) are shown inline
+  - Transferred repository is removed from the list
 - **Copy URL**: `C` to copy repository URL to clipboard (SSH/HTTPS options)
 
 ## General

--- a/wiki/Usage.md
+++ b/wiki/Usage.md
@@ -61,7 +61,7 @@ Launch the app, then use the keys below to navigate and interact with your repos
 - **Star/Unstar**: `Ctrl+S` to toggle star status for any repository
 - **Sync fork**: `Ctrl+F` (for forks only, shows commit status and handles conflicts)
 - **Rename repository**: `Ctrl+R` with inline validation
-- **Transfer repository**: `Ctrl+T` to transfer ownership to another user or organisation
+- **Transfer repository**: `Shift+M` (Move) to transfer ownership to another user or organisation
   - Prompts for the destination owner, then a confirmation step before transferring
   - GitHub errors (e.g. insufficient permissions) are shown inline
 - **Copy URL**: `C` to copy repository URL to clipboard (SSH/HTTPS options)


### PR DESCRIPTION
Add a Create Repository modal triggered by Ctrl+N (case-insensitive) in
both personal and organisation contexts. The modal prompts for a name
with the owner slug shown in front, lets the user cycle visibility with
Tab (Private/Public, plus Internal for enterprise orgs), and surfaces
GitHub API errors inline. On success the list refreshes from the network
so the new repo appears. Disabled in starred mode.

Backed by a new createRepositoryRest helper (POST /user/repos or
POST /orgs/{org}/repos) that returns structured GitHub error messages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Creates repos and initiates ownership transfers via REST with optimistic UI removal; mistakes or permission gaps have real GitHub-side impact despite verification steps.
> 
> **Overview**
> Adds **create** and **transfer** repository flows from the repo list, wired through new REST helpers and Ink modals (both disabled in starred mode).
> 
> **`Ctrl+N`** opens `CreateRepoModal` (owner prefix, `Tab` for visibility including Internal on enterprise orgs, inline GitHub errors). Creation uses `createRepositoryRest` (`POST /user/repos` or `/orgs/{org}/repos`) with shared `parseGitHubRestError`. On success, `executeCreate` clears filters that would hide the new repo, fetches the node (with a short retry for GraphQL lag), updates cache/list/count, and focuses the row via `pendingFocusRef` instead of only refreshing.
> 
> **`Shift+M`** opens a three-step `TransferModal` (destination owner → 4-character verification code → final confirm, Cancel focused by default). `transferRepositoryRest` posts to the transfer endpoint; success **optimistically** removes the repo from the list and cache (no auto-refresh, to avoid flicker while GitHub processes the async transfer).
> 
> **Delete** confirmation now uses a **4-character** code and **auto-advances** when the typed code matches (same pattern as transfer). Docs/footer hints (`AGENTS.md`, README, wiki) and tests are updated; `package.json`/`CHANGELOG` show a version rollback (1.44.0 entry removed) that looks like release-branch housekeeping rather than feature logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c7208e5d1a229fd38c38359497e63c41dc221d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ctrl+N: create a new repository in-context — owner/slug prompt, Tab to cycle visibility (Private/Public/Internal), modal UI and inline GitHub errors; disabled in starred mode.
  * Shift+M: transfer a repository — destination prompt, verification-code step and final confirmation, modal UI and inline GitHub errors; disabled in starred mode.

* **Bug Fixes / Improvements**
  * Delete confirmation now uses a 4‑character code and auto-advances on correct entry.

* **Documentation**
  * README, help footer and usage/wiki updated to describe flows and keyboard hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->