### PR TITLE
fix(ui): ignore archive modal input immediately

### DIFF
--- a/src/ui/components/modals/ArchiveModal.tsx
+++ b/src/ui/components/modals/ArchiveModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import chalk from 'chalk';
 import type { RepoNode } from '../../../types';
@@ -12,12 +12,13 @@ interface ArchiveModalProps {
 
 export default function ArchiveModal({ repo, onArchive, onCancel }: ArchiveModalProps) {
   const [archiving, setArchiving] = useState(false);
+  const archivingRef = useRef(false);
   const [archiveError, setArchiveError] = useState<string | null>(null);
   const [archiveFocus, setArchiveFocus] = useState<'confirm' | 'cancel'>('confirm');
 
   // Handle keyboard input
   useInput((input, key) => {
-    if (archiving) return; // Ignore input while archiving
+    if (archivingRef.current) return; // Ignore input while archiving, even before React re-renders
     
     if (key.escape || input.toLowerCase() === 'c') {
       onCancel();
@@ -45,14 +46,16 @@ export default function ArchiveModal({ repo, onArchive, onCancel }: ArchiveModal
 
   // Handle the archive confirmation
   const handleArchiveConfirm = async () => {
-    if (!repo || archiving) return;
+    if (!repo || archivingRef.current) return;
     
     try {
+      archivingRef.current = true;
       setArchiving(true);
       setArchiveError(null);
       await onArchive(repo);
     } catch (e: any) {
       setArchiveError(e.message || `Failed to ${repo.isArchived ? 'unarchive' : 'archive'} repository`);
+      archivingRef.current = false;
       setArchiving(false);
     }
   };


### PR DESCRIPTION
## Summary
- Add an immediate in-progress guard for archive/unarchive confirmations so queued key input is ignored as soon as an archive starts.
- Keeps the existing loading state UI while preventing stale `useInput` callbacks from invoking cancel before React re-renders.

Fixes #63

## Test Plan
- [x] `pnpm -C /Users/clawuser/workspace/oss-repos/wiiiimm/gh-manager-cli exec vitest run tests/ui/ArchiveModal.test.tsx -t 'ignores input while archiving is in progress'`
- [x] `pnpm -C /Users/clawuser/workspace/oss-repos/wiiiimm/gh-manager-cli exec vitest run tests/ui/ArchiveModal.test.tsx`
- [x] `pnpm -C /Users/clawuser/workspace/oss-repos/wiiiimm/gh-manager-cli run build`
- [ ] `pnpm -C /Users/clawuser/workspace/oss-repos/wiiiimm/gh-manager-cli test` currently has a pre-existing sponsorship README expectation failure unrelated to this modal change (`tests/sponsorship.test.ts` expects `Ko-fi`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where repeatedly clicking the archive or unarchive button whilst an operation was in progress could cause duplicate submissions. The component now immediately prevents further input during processing, safeguarding against accidental duplicate archiving actions and ensuring all operations complete reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->