### PR TITLE
test: align sponsorship tests with Buy Me a Coffee-only docs (SWR-367) [semantic pr title]

### DIFF
--- a/tests/sponsorship.test.ts
+++ b/tests/sponsorship.test.ts
@@ -47,11 +47,14 @@ describe('GitHub Sponsorship Configuration', () => {
 
   it('should have comprehensive sponsorship documentation', () => {
     expect(existsSync(sponsorshipDocsPath)).toBe(true);
-    
+
+    // The guide was rewritten to focus solely on Buy Me a Coffee (SWR-367), so
+    // assert the current single-platform structure rather than the old
+    // multi-platform headings (Ko-fi / Custom URLs).
     const content = readFileSync(sponsorshipDocsPath, 'utf8');
-    expect(content).toContain('GitHub Sponsorship Platforms Guide');
-    expect(content).toContain('Ko-fi (Buy Me Coffee Alternative)');
-    expect(content).toContain('Custom URLs (Including Buy Me a Coffee)');
+    expect(content).toContain('GitHub Sponsorship Configuration Guide');
+    expect(content).toContain('Buy Me a Coffee');
+    expect(content).toContain('Why Support This Project?');
   });
 
   it('should have proper YAML structure', () => {
@@ -71,14 +74,15 @@ describe('GitHub Sponsorship Configuration', () => {
     expect(commentedPlatforms.length).toBeGreaterThan(0);
   });
 
-  it('should reference sponsorship documentation in README', () => {
+  it('should have a Support & Sponsorship section in README', () => {
     const readmePath = join(process.cwd(), 'README.md');
     const content = readFileSync(readmePath, 'utf8');
-    
+
+    // README sponsorship section was simplified to the active platforms only
+    // (SWR-367): GitHub Sponsors + Buy Me a Coffee. Ko-fi and the
+    // SPONSORSHIP_PLATFORMS.md link are no longer referenced here.
     expect(content).toContain('Support & Sponsorship');
     expect(content).toContain('GitHub Sponsors');
-    expect(content).toContain('Ko-fi');
     expect(content).toContain('Buy Me a Coffee');
-    expect(content).toContain('SPONSORSHIP_PLATFORMS.md');
   });
 });


### PR DESCRIPTION
## Summary

Fixes **SWR-367** — two pre-existing failures in `tests/sponsorship.test.ts` on `main`.

The sponsorship docs (`docs/SPONSORSHIP_PLATFORMS.md`) and the README were previously rewritten to focus **solely on Buy Me a Coffee**, but the tests still asserted the old **multi-platform** guide. So they failed against the current docs:

- `should have comprehensive sponsorship documentation` expected `GitHub Sponsorship Platforms Guide`, `Ko-fi (Buy Me Coffee Alternative)`, `Custom URLs (Including Buy Me a Coffee)` — none of which exist anymore.
- `should reference sponsorship documentation in README` expected `Ko-fi` and a `SPONSORSHIP_PLATFORMS.md` link — neither is in the README now.

## Fix

The docs simplification was intentional, so this aligns the **tests** to the current single-platform reality (no doc/README changes):

- Doc test now asserts the real headings: `GitHub Sponsorship Configuration Guide`, `Buy Me a Coffee`, `Why Support This Project?`.
- README test now asserts the active platforms (`Support & Sponsorship`, `GitHub Sponsors`, `Buy Me a Coffee`) and is renamed to **`should have a Support & Sponsorship section in README`** to reflect what it verifies.

The `FUNDING.yml` tests were already passing (Ko-fi/patreon/etc. still live as commented examples there) and are untouched.

## Verification

```
tests/sponsorship.test.ts  →  8/8 passing
full suite                 →  233/233 passing
```

Scoped to SWR-367 only — independent of the SWR-368 modal work in #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime, config, or documentation edits.
> 
> **Overview**
> Updates **`tests/sponsorship.test.ts`** so sponsorship checks match the current Buy Me a Coffee–focused docs and README (SWR-367), fixing two failing tests on `main` without changing product files.
> 
> The **documentation test** now expects headings from the rewritten guide (`GitHub Sponsorship Configuration Guide`, `Buy Me a Coffee`, `Why Support This Project?`) instead of the removed multi-platform titles (Ko-fi, custom URLs, etc.). The **README test** is renamed to **`should have a Support & Sponsorship section in README`** and only asserts GitHub Sponsors and Buy Me a Coffee—dropping Ko-fi and the `SPONSORSHIP_PLATFORMS.md` link. Comments in the test file document why expectations changed; **`FUNDING.yml`** assertions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c4be8d85662cd198ecb0304333130736146823. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->