### PR TITLE
feat: bulk transfer (move) repos to another owner/org — Bulk Select action (SWR-369) [semantic pr title]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 - ✅ Fork synchronization with upstream
 - ✅ Semantic release automation and CI/CD workflows
 - ✅ Automated changelog generation and PR title management
-- ✅ Bulk Select mode with bulk star, archive/unarchive, visibility, and delete operations
+- ✅ Bulk Select mode with bulk star, archive/unarchive, visibility, delete, and transfer operations
 - 🔧 Automated test suite expansion (ongoing)
 - 🔧 Cross-terminal rendering optimization
 
@@ -154,6 +154,7 @@ See the living roadmap in [TODOs.md](./TODOs.md) for the canonical, up-to-date l
 - `Ctrl+S`: bulk star/unstar the selected repos
 - `Ctrl+A`: bulk archive/unarchive the selected repos
 - `Ctrl+V`: bulk visibility update for the selected repos
+- `Shift+M`: bulk transfer (move) the selected repos to another owner/org
 - `Del` / `Backspace`: bulk delete the selected repos
 - Navigation (arrows, PageUp/Down, `Ctrl+G`, `G`) still works
 
@@ -164,11 +165,12 @@ Bulk actions reuse the same global shortcuts as single-repo mode and require at 
 0. Intent/target (only when needed):
    - Star and archive are toggles. If all selected repos share the same state, the opposite state is applied directly. If the selection is mixed, an intent modal asks the explicit target (e.g. "Archive all" vs "Unarchive all", "Star all" vs "Unstar all").
    - Visibility always shows a target picker (Public / Private / Internal — Internal only for enterprise orgs).
+   - Transfer always prompts for a destination owner/org (must differ from the current owner).
 1. Review list (Confirmation 1) — scrollable list of all selected repos; `Space` to unselect; Tab/Enter to proceed. Dismisses on Esc/Cancel or when the list empties.
 2. Count prompt (Confirmation 2) — "About to {action} {N} repos"; Cancel/Proceed, Esc cancels.
-3. Delete only — a separate verification-code modal (type a 4-character code).
+3. Delete and Transfer only — a separate verification-code modal (type a 4-character code).
 4. Sequential execution with per-repo progress; partial-failure reporting at the end.
-5. Selection cleared and bulk select mode exits on completion.
+5. Selection cleared and bulk select mode exits on completion. Transferred repos are removed from the list.
 
 **Persistence:** Selections survive search and filter/sort changes (stored as full node objects by id). Cleared on org/scope switch and stars mode toggle.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,15 +162,15 @@ Bulk actions reuse the same global shortcuts as single-repo mode and require at 
 
 **Bulk operation flow:**
 
-0. Intent/target (only when needed):
+0. Intent/target (only when needed, before review):
    - Star and archive are toggles. If all selected repos share the same state, the opposite state is applied directly. If the selection is mixed, an intent modal asks the explicit target (e.g. "Archive all" vs "Unarchive all", "Star all" vs "Unstar all").
    - Visibility always shows a target picker (Public / Private / Internal — Internal only for enterprise orgs).
-   - Transfer always prompts for a destination owner/org (must differ from the current owner).
 1. Review list (Confirmation 1) — scrollable list of all selected repos; `Space` to unselect; Tab/Enter to proceed. Dismisses on Esc/Cancel or when the list empties.
-2. Count prompt (Confirmation 2) — "About to {action} {N} repos"; Cancel/Proceed, Esc cancels.
-3. Delete and Transfer only — a separate verification-code modal (type a 4-character code).
-4. Sequential execution with per-repo progress; partial-failure reporting at the end.
-5. Selection cleared and bulk select mode exits on completion. Transferred repos are removed from the list.
+2. Destination owner (Transfer only) — after review, prompts for a destination owner/org (must differ from the current owner).
+3. Count prompt (Confirmation 2) — "About to {action} {N} repos" (transfer also shows "to {owner}"); Cancel/Proceed, Esc cancels.
+4. Delete and Transfer only — a separate verification-code modal (type a 4-character code).
+5. Sequential execution with per-repo progress; partial-failure reporting at the end.
+6. Selection cleared and bulk select mode exits on completion. Transferred repos are removed from the list.
 
 **Persistence:** Selections survive search and filter/sort changes (stored as full node objects by id). Cleared on org/scope switch and stars mode toggle.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [Unreleased]
+
+### Added
+
+- Bulk transfer (move) repositories to another owner/org from Bulk Select mode (`Shift+M`): destination prompt → review → count confirm → 4-char verification code → sequential execution with per-repo progress and partial-failure reporting ([SWR-369](https://linear.app/stealths/issue/SWR-369/bulk-transfer-move-repos-to-another-ownerorg-bulk-select-action))
+- Shared `BulkCodeModal` component — generic verification-code step now reused by both bulk delete and bulk transfer
+
 # [1.46.0](https://github.com/wiiiimm/gh-manager-cli/compare/v1.45.1...v1.46.0) (2026-06-07)
 
 

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Launch the app, then use the keys below:
   - Requires typing a randomly generated verification code (like delete), then a final confirmation before transferring
   - GitHub errors (e.g. insufficient permissions) are shown inline
 - **Bulk Transfer (Bulk Select mode)**: `Shift+M` within Bulk Select mode to move multiple repos at once
-  - Flow: destination owner prompt → review list (unselect) → count prompt → 4-character verification code → sequential execution with per-repo progress
+  - Flow: review list (unselect) → destination owner prompt → count prompt → 4-character verification code → sequential execution with per-repo progress
   - Transferred repos are removed from the current list; partial-failure report shown at completion
 - **Copy URL**: `C` to copy repository URL to clipboard (SSH/HTTPS options)
 

--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ On first run, you'll be prompted to authenticate with GitHub (OAuth recommended)
   - Sync forks with upstream (`Ctrl+F`) with ahead/behind counts and automatic conflict detection
 - **Bulk Operations** (`B` to enter Bulk Select mode):
   - Select multiple repositories with `Space`; `X` unselects all (while every other shortcut is disabled in bulk mode)
-  - Bulk actions reuse the global shortcuts: `Ctrl+S` star/unstar, `Ctrl+A` archive/unarchive, `Ctrl+V` visibility, `Del` delete
-  - Star and archive auto-detect a safe toggle; if the selection is mixed, an intent modal asks the explicit target. Visibility always prompts for the destination (Public / Private / Internal for enterprise orgs)
+  - Bulk actions reuse the global shortcuts: `Ctrl+S` star/unstar, `Ctrl+A` archive/unarchive, `Ctrl+V` visibility, `Del` delete, `Shift+M` transfer (move) to another owner/org
+  - Star and archive auto-detect a safe toggle; if the selection is mixed, an intent modal asks the explicit target. Visibility always prompts for the destination (Public / Private / Internal for enterprise orgs). Transfer always prompts for a destination owner
   - Selections persist across search, filter, and sort changes (select from different searches, then bulk-act)
-  - Confirmation flow: review list with ability to unselect → count prompt → (delete only) a 4-character verification code
-  - Per-repo progress reporting with partial-failure summary
+  - Confirmation flow: review list with ability to unselect → count prompt → (delete and transfer) a 4-character verification code
+  - Per-repo progress reporting with partial-failure summary; transferred repos are removed from the current list
 
 ### User Interface & Experience
 - **Keyboard Navigation**: Full keyboard control (arrow keys, PageUp/Down, `Ctrl+G`/`G`)
@@ -315,6 +315,9 @@ Launch the app, then use the keys below:
   - Prompts for the destination owner (`new-owner/<repo>` preview)
   - Requires typing a randomly generated verification code (like delete), then a final confirmation before transferring
   - GitHub errors (e.g. insufficient permissions) are shown inline
+- **Bulk Transfer (Bulk Select mode)**: `Shift+M` within Bulk Select mode to move multiple repos at once
+  - Flow: destination owner prompt → review list (unselect) → count prompt → 4-character verification code → sequential execution with per-repo progress
+  - Transferred repos are removed from the current list; partial-failure report shown at completion
 - **Copy URL**: `C` to copy repository URL to clipboard (SSH/HTTPS options)
 
 ### General

--- a/src/ui/components/modals/BulkCodeModal.tsx
+++ b/src/ui/components/modals/BulkCodeModal.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import TextInput from 'ink-text-input';
+
+interface BulkCodeModalProps {
+  /** Number of repos affected — shown in the header line. */
+  count: number;
+  /** Title shown at the top, e.g. "Confirm Bulk Delete". */
+  title: string;
+  /** Border / accent colour. */
+  borderColor: 'red' | 'yellow';
+  /** Body text rendered above the code prompt (plain JSX). */
+  body: React.ReactNode;
+  onConfirm: () => void;
+  onCancel: () => void;
+  terminalWidth?: number;
+}
+
+/**
+ * Generic verification-code modal shared by bulk delete and bulk transfer.
+ * Generates a random 4-character code; auto-advances once the user types it
+ * correctly. Mirrors the single-repo delete / transfer code steps.
+ */
+export default function BulkCodeModal({
+  title,
+  borderColor,
+  body,
+  onConfirm,
+  onCancel,
+  terminalWidth = 80,
+}: BulkCodeModalProps) {
+  const [code] = useState(() => {
+    const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+    return Array.from({ length: 4 }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
+  });
+  const [typedCode, setTypedCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useInput((_input, key) => {
+    if (key.escape) { onCancel(); return; }
+  });
+
+  const modalWidth = Math.min(terminalWidth - 4, 68);
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={borderColor}
+      paddingX={2}
+      paddingY={1}
+      width={modalWidth}
+    >
+      <Text bold color={borderColor}>⚠️  {title}</Text>
+      <Box height={1}><Text> </Text></Box>
+      {body}
+      <Box height={1}><Text> </Text></Box>
+      <Text>
+        To confirm, type <Text bold color="yellow">{code}</Text>:
+      </Text>
+      <Box marginTop={1}>
+        <Text>Verification code: </Text>
+        <TextInput
+          value={typedCode}
+          onChange={(v) => {
+            const up = v.toUpperCase().slice(0, 4);
+            setTypedCode(up);
+            setError(null);
+            if (up.length === 4) {
+              if (up === code) {
+                onConfirm();
+              } else {
+                setError('Code does not match. Try again.');
+                setTypedCode('');
+              }
+            }
+          }}
+          onSubmit={() => { /* completion handled in onChange */ }}
+          placeholder={code}
+        />
+      </Box>
+      {error && (
+        <Box marginTop={1}>
+          <Text color="red">{error}</Text>
+        </Box>
+      )}
+      <Box marginTop={1}>
+        <Text color="gray">Press Esc to cancel</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/components/modals/BulkConfirmModal.tsx
+++ b/src/ui/components/modals/BulkConfirmModal.tsx
@@ -9,6 +9,8 @@ interface BulkConfirmModalProps {
   actionColor: BulkActionColor;
   /** Lower-case verb phrase used inline, e.g. "delete", "make private". */
   actionVerb: string;
+  /** Optional destination owner, shown for transfer ("… to {destination}"). */
+  destination?: string;
   onConfirm: () => void;
   onCancel: () => void;
   terminalWidth?: number;
@@ -19,6 +21,7 @@ export default function BulkConfirmModal({
   actionLabel,
   actionColor,
   actionVerb,
+  destination,
   onConfirm,
   onCancel,
   terminalWidth = 80,
@@ -69,7 +72,14 @@ export default function BulkConfirmModal({
         {' '}
         <Text bold>{count}</Text>
         {' '}
-        repositor{count === 1 ? 'y' : 'ies'}.
+        repositor{count === 1 ? 'y' : 'ies'}
+        {destination ? (
+          <Text>
+            {' to '}
+            <Text bold color={actionColor}>{destination}</Text>
+          </Text>
+        ) : null}
+        .
       </Text>
 
       <Box height={1}><Text> </Text></Box>

--- a/src/ui/components/modals/BulkDeleteCodeModal.tsx
+++ b/src/ui/components/modals/BulkDeleteCodeModal.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
-import { Box, Text, useInput } from 'ink';
-import TextInput from 'ink-text-input';
+import React from 'react';
+import { Text } from 'ink';
+import BulkCodeModal from './BulkCodeModal';
 
 interface BulkDeleteCodeModalProps {
   count: number;
@@ -10,8 +10,8 @@ interface BulkDeleteCodeModalProps {
 }
 
 /**
- * Final delete confirmation for bulk delete: requires typing a 4-character
- * verification code, mirroring the single-repo delete confirmation.
+ * Final delete confirmation for bulk delete — wraps the shared BulkCodeModal
+ * with delete-specific title and body text.
  */
 export default function BulkDeleteCodeModal({
   count,
@@ -19,68 +19,23 @@ export default function BulkDeleteCodeModal({
   onCancel,
   terminalWidth = 80,
 }: BulkDeleteCodeModalProps) {
-  const [code] = useState(() => {
-    const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
-    return Array.from({ length: 4 }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
-  });
-  const [typedCode, setTypedCode] = useState('');
-  const [error, setError] = useState<string | null>(null);
-
-  useInput((_input, key) => {
-    if (key.escape) { onCancel(); return; }
-  });
-
-  const modalWidth = Math.min(terminalWidth - 4, 68);
-
   return (
-    <Box
-      flexDirection="column"
-      borderStyle="round"
+    <BulkCodeModal
+      count={count}
+      title="Confirm Bulk Delete"
       borderColor="red"
-      paddingX={2}
-      paddingY={1}
-      width={modalWidth}
-    >
-      <Text bold color="red">⚠️ Confirm Bulk Delete</Text>
-      <Box height={1}><Text> </Text></Box>
-      <Text>
-        You are about to <Text bold color="red">permanently delete</Text>{' '}
-        <Text bold>{count}</Text> repositor{count === 1 ? 'y' : 'ies'}.
-      </Text>
-      <Text color="red">This action <Text bold>CANNOT</Text> be undone.</Text>
-      <Box height={1}><Text> </Text></Box>
-      <Text>
-        To confirm, type <Text bold color="yellow">{code}</Text>:
-      </Text>
-      <Box marginTop={1}>
-        <Text>Verification code: </Text>
-        <TextInput
-          value={typedCode}
-          onChange={(v) => {
-            const up = v.toUpperCase().slice(0, 4);
-            setTypedCode(up);
-            setError(null);
-            if (up.length === 4) {
-              if (up === code) {
-                onConfirm();
-              } else {
-                setError('Code does not match. Try again.');
-                setTypedCode('');
-              }
-            }
-          }}
-          onSubmit={() => { /* completion handled in onChange */ }}
-          placeholder={code}
-        />
-      </Box>
-      {error && (
-        <Box marginTop={1}>
-          <Text color="red">{error}</Text>
-        </Box>
-      )}
-      <Box marginTop={1}>
-        <Text color="gray">Press Esc to cancel</Text>
-      </Box>
-    </Box>
+      body={
+        <>
+          <Text>
+            You are about to <Text bold color="red">permanently delete</Text>{' '}
+            <Text bold>{count}</Text> repositor{count === 1 ? 'y' : 'ies'}.
+          </Text>
+          <Text color="red">This action <Text bold>CANNOT</Text> be undone.</Text>
+        </>
+      }
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+      terminalWidth={terminalWidth}
+    />
   );
 }

--- a/src/ui/components/modals/BulkTransferCodeModal.tsx
+++ b/src/ui/components/modals/BulkTransferCodeModal.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Text } from 'ink';
+import BulkCodeModal from './BulkCodeModal';
+
+interface BulkTransferCodeModalProps {
+  count: number;
+  destination: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  terminalWidth?: number;
+}
+
+/**
+ * Verification-code step for bulk transfer — wraps the shared BulkCodeModal
+ * with transfer-specific title and body text.
+ */
+export default function BulkTransferCodeModal({
+  count,
+  destination,
+  onConfirm,
+  onCancel,
+  terminalWidth = 80,
+}: BulkTransferCodeModalProps) {
+  return (
+    <BulkCodeModal
+      count={count}
+      title="Confirm Bulk Transfer"
+      borderColor="yellow"
+      body={
+        <>
+          <Text>
+            You are about to <Text bold color="yellow">transfer</Text>{' '}
+            <Text bold>{count}</Text> repositor{count === 1 ? 'y' : 'ies'}{' '}
+            to <Text bold color="yellow">{destination}</Text>.
+          </Text>
+          <Text color="yellow">Transferred repos are removed from your current list.</Text>
+        </>
+      }
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+      terminalWidth={terminalWidth}
+    />
+  );
+}

--- a/src/ui/components/modals/BulkTransferDestinationModal.tsx
+++ b/src/ui/components/modals/BulkTransferDestinationModal.tsx
@@ -1,0 +1,98 @@
+import React, { useState, useRef } from 'react';
+import { Box, Text, useInput } from 'ink';
+import TextInput from 'ink-text-input';
+
+interface BulkTransferDestinationModalProps {
+  count: number;
+  /** Login of the current context owner — destination must differ. */
+  currentOwner: string;
+  onChoose: (destination: string) => void;
+  onCancel: () => void;
+  terminalWidth?: number;
+}
+
+/**
+ * Step 0 of the bulk transfer flow: collects and validates the destination
+ * owner/org. Input is sanitised to alphanumeric + hyphens; the destination
+ * must differ from the current owner. Modelled on single-repo TransferModal
+ * stage 1 and BulkVisibilityModal.
+ */
+export default function BulkTransferDestinationModal({
+  count,
+  currentOwner,
+  onChoose,
+  onCancel,
+  terminalWidth = 80,
+}: BulkTransferDestinationModalProps) {
+  const [destination, setDestination] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const submittingRef = useRef(false);
+
+  useInput((_input, key) => {
+    if (submittingRef.current) return;
+    if (key.escape) { onCancel(); return; }
+    if (key.return) {
+      const dest = destination.trim();
+      if (!dest) {
+        setError('Please enter a destination owner.');
+        return;
+      }
+      if (dest.toLowerCase() === currentOwner.toLowerCase()) {
+        setError(`Destination must differ from the current owner (${currentOwner}).`);
+        return;
+      }
+      submittingRef.current = true;
+      onChoose(dest);
+    }
+  });
+
+  const handleChange = (value: string) => {
+    // Strip invalid chars and leading hyphens (matches single-repo TransferModal)
+    setDestination(value.replace(/[^a-zA-Z0-9-]/g, '').replace(/^-+/, ''));
+    setError(null);
+  };
+
+  const isValid = destination.trim() && destination.trim().toLowerCase() !== currentOwner.toLowerCase();
+  const modalWidth = Math.min(terminalWidth - 4, 72);
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="yellow"
+      paddingX={2}
+      paddingY={1}
+      width={modalWidth}
+    >
+      <Text bold color="yellow">Bulk Transfer Repositories</Text>
+      <Box height={1}><Text> </Text></Box>
+      <Text>
+        Move <Text bold>{count}</Text> repositor{count === 1 ? 'y' : 'ies'} to a new owner.
+      </Text>
+      <Box height={1}><Text> </Text></Box>
+      <Text>Destination owner (username or organisation):</Text>
+      <Box marginTop={1} flexDirection="row" alignItems="center">
+        <TextInput
+          value={destination}
+          onChange={handleChange}
+          placeholder="new-owner"
+        />
+      </Box>
+      {error && (
+        <Box marginTop={1}>
+          <Text color="red">{error}</Text>
+        </Box>
+      )}
+      <Box marginTop={1}>
+        <Text color={isValid ? 'gray' : 'gray'}>
+          {isValid
+            ? `Press Enter to continue → ${destination}`
+            : 'Enter a different owner to continue'}
+        </Text>
+      </Box>
+      <Box marginTop={1}>
+        <Text color="gray">Press Esc to cancel</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/components/modals/bulkActions.ts
+++ b/src/ui/components/modals/bulkActions.ts
@@ -6,7 +6,8 @@ export type BulkAction =
   | 'unarchive'
   | 'star'
   | 'unstar'
-  | 'visibility';
+  | 'visibility'
+  | 'transfer';
 
 export type BulkVisibilityTarget = 'PUBLIC' | 'PRIVATE' | 'INTERNAL';
 
@@ -50,5 +51,7 @@ export function bulkActionMeta(action: BulkAction, visibilityTarget?: BulkVisibi
       const color: BulkActionColor = target === 'PUBLIC' ? 'green' : target === 'PRIVATE' ? 'yellow' : 'cyan';
       return { label: `Make ${name}`, gerund: `Making ${name}`, color, pastVerb: `made ${name.toLowerCase()}` };
     }
+    case 'transfer':
+      return { label: 'Transfer', gerund: 'Transferring', color: 'yellow', pastVerb: 'transferred' };
   }
 }

--- a/src/ui/components/modals/index.ts
+++ b/src/ui/components/modals/index.ts
@@ -14,6 +14,8 @@ export { StarModal } from './StarModal';
 export { default as BulkReviewModal } from './BulkReviewModal';
 export { default as BulkConfirmModal } from './BulkConfirmModal';
 export { default as BulkDeleteCodeModal } from './BulkDeleteCodeModal';
+export { default as BulkTransferCodeModal } from './BulkTransferCodeModal';
+export { default as BulkTransferDestinationModal } from './BulkTransferDestinationModal';
 export { default as BulkIntentModal } from './BulkIntentModal';
 export { default as BulkVisibilityModal } from './BulkVisibilityModal';
 export { default as BulkProgressModal } from './BulkProgressModal';

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -695,7 +695,10 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     // contain repos owned by others). Mirror the single-repo guard, which is
     // disabled in starred mode.
     if (starsMode) return;
-    setBulkTransferDestinationOpen(true); // step 0: collect destination
+    // Step 1: review/unselect the selection first (mirrors the other bulk
+    // actions). The destination prompt comes after review — see the
+    // BulkReviewModal onConfirm transfer branch.
+    beginBulkReview('transfer');
   }
 
   // Shared rename execution function
@@ -2944,7 +2947,13 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                 setSelectedRepos(finalSelection);
                 setBulkFinalSelection(finalSelection);
                 setBulkReviewOpen(false);
-                setBulkConfirmOpen(true);
+                if (bulkAction === 'transfer') {
+                  // Transfer collects the destination owner after review,
+                  // before the count/code confirmation.
+                  setBulkTransferDestinationOpen(true);
+                } else {
+                  setBulkConfirmOpen(true);
+                }
               }}
               onCancel={resetBulkFlow}
             />
@@ -2966,13 +2975,15 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         ) : bulkTransferDestinationOpen ? (
           <Box height={contentHeight} alignItems="center" justifyContent="center">
             <BulkTransferDestinationModal
-              count={selectedRepos.size}
+              count={bulkFinalSelection.size}
               currentOwner={ownerContext !== 'personal' ? ownerContext.login : (viewerLogin ?? '')}
               terminalWidth={terminalWidth}
               onChoose={(dest) => {
                 setBulkTransferDest(dest);
                 setBulkTransferDestinationOpen(false);
-                beginBulkReview('transfer');
+                // Review already ran (it precedes the destination prompt for
+                // transfer); proceed to the count confirmation.
+                setBulkConfirmOpen(true);
               }}
               onCancel={resetBulkFlow}
             />

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -1393,6 +1393,16 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return; // BulkDeleteCodeModal handles its own input
     }
 
+    // Bulk transfer destination prompt (transfer only)
+    if (bulkTransferDestinationOpen) {
+      return; // BulkTransferDestinationModal handles its own input
+    }
+
+    // Bulk transfer verification-code modal (Confirmation 3, transfer only)
+    if (bulkTransferCodeOpen) {
+      return; // BulkTransferCodeModal handles its own input
+    }
+
     // Handle input when in error state
     if (error) {
       // Quit on 'Q'
@@ -1693,7 +1703,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         // Ctrl+V: bulk visibility update
         if (key.ctrl && (input === 'v' || input === 'V')) { startBulkVisibility(); return; }
         // Shift+M: bulk transfer (move) to another owner
-        if (!key.ctrl && input === 'M') { startBulkTransfer(); return; }
+        // Match the single-repo transfer binding (key.shift && 'M') for consistency
+        if (key.shift && input === 'M') { startBulkTransfer(); return; }
         // Del/Backspace: bulk delete
         if (key.delete || key.backspace) { startBulkDelete(); return; }
       }
@@ -2192,7 +2203,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
 
   const lowRate = (rateLimit && rateLimit.remaining <= Math.ceil(rateLimit.limit * 0.1)) || 
                    (restRateLimit && restRateLimit.core.remaining <= Math.ceil(restRateLimit.core.limit * 0.1));
-  const modalOpen = deleteMode || archiveMode || syncMode || logoutMode || infoMode || visibilityMode || archiveFilterMode || sortMode || sortDirectionMode || changeVisibilityMode || copyUrlMode || renameMode || bulkIntentKind !== null || bulkVisibilityOpen || bulkReviewOpen || bulkConfirmOpen || bulkDeleteCodeOpen || bulkProgressOpen || openInBrowserMode || createMode || transferMode;
+  const modalOpen = deleteMode || archiveMode || syncMode || logoutMode || infoMode || visibilityMode || archiveFilterMode || sortMode || sortDirectionMode || changeVisibilityMode || copyUrlMode || renameMode || bulkIntentKind !== null || bulkVisibilityOpen || bulkReviewOpen || bulkConfirmOpen || bulkDeleteCodeOpen || bulkTransferDestinationOpen || bulkTransferCodeOpen || bulkProgressOpen || openInBrowserMode || createMode || transferMode;
 
   // Display metadata for the in-flight bulk action (label/colour/verbs).
   const bulkMeta = bulkAction ? bulkActionMeta(bulkAction, bulkVisibilityTarget ?? undefined) : null;

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -612,6 +612,11 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
           await updateCacheAfterDelete(token, repo.id);
           setItems(prev => prev.filter(r => r.id !== repo.id));
           setTotalCount(c => Math.max(0, c - 1));
+        } else {
+          // No branch matched (e.g. visibility without a target, or transfer
+          // without a destination). Never mark such a repo as successfully
+          // processed — surface it as a failure instead of a silent no-op.
+          throw new Error(`Missing required parameter for bulk ${action}`);
         }
         trackSuccessfulOperation();
       } catch (e: any) {
@@ -2909,6 +2914,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               actionLabel={bulkMeta.label}
               actionColor={bulkMeta.color}
               actionVerb={bulkMeta.label.toLowerCase()}
+              destination={bulkAction === 'transfer' ? bulkTransferDest : undefined}
               terminalWidth={terminalWidth}
               onConfirm={() => {
                 setBulkConfirmOpen(false);

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -686,6 +686,10 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
 
   function startBulkTransfer() {
     if (selectedRepos.size === 0) return;
+    // Transfer is owner-scoped and meaningless in starred mode (selection may
+    // contain repos owned by others). Mirror the single-repo guard, which is
+    // disabled in starred mode.
+    if (starsMode) return;
     setBulkTransferDestinationOpen(true); // step 0: collect destination
   }
 
@@ -3021,7 +3025,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                 </Text>
                 <Text color="gray">
                   {selectedRepos.size > 0
-                    ? 'Space select · X unselect all · Ctrl+S star · Ctrl+A archive · Ctrl+V visibility · Del delete · B/Esc exit'
+                    ? `Space select · X unselect all · Ctrl+S star · Ctrl+A archive · Ctrl+V visibility${starsMode ? '' : ' · Shift+M transfer'} · Del delete · B/Esc exit`
                     : 'Space select · B/Esc exit'}
                 </Text>
               </Box>
@@ -3155,7 +3159,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
             <Text color={multiSelectMode ? 'cyan' : 'gray'} dimColor={!multiSelectMode}>
               {multiSelectMode
                 ? (selectedRepos.size > 0
-                    ? `Space select • X unselect all • Ctrl+S star • Ctrl+A archive • Ctrl+V visibility • Del delete • B/Esc exit (${selectedRepos.size} selected)`
+                    ? `Space select • X unselect all • Ctrl+S star • Ctrl+A archive • Ctrl+V visibility${starsMode ? '' : ' • Shift+M transfer'} • Del delete • B/Esc exit (${selectedRepos.size} selected)`
                     : 'B/Esc exit bulk select • Space select (no selection)')
                 : 'B Bulk Select mode (star/archive/visibility/delete)'
               }

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -12,7 +12,7 @@ import type { RepoNode, RateLimitInfo, RestRateLimitInfo } from '../../types';
 import { exec } from 'child_process';
 import OrgSwitcher from '../OrgSwitcher';
 import { logger } from '../../lib/logger';
-import { ArchiveFilterModal, DeleteModal, ArchiveModal, SyncModal, InfoModal, LogoutModal, VisibilityModal, SortModal, SortDirectionModal, ChangeVisibilityModal, CopyUrlModal, RenameModal, StarModal, BulkReviewModal, BulkConfirmModal, BulkDeleteCodeModal, BulkIntentModal, BulkVisibilityModal, BulkProgressModal, OpenInBrowserModal, CreateRepoModal, TransferModal, bulkActionMeta } from '../components/modals';
+import { ArchiveFilterModal, DeleteModal, ArchiveModal, SyncModal, InfoModal, LogoutModal, VisibilityModal, SortModal, SortDirectionModal, ChangeVisibilityModal, CopyUrlModal, RenameModal, StarModal, BulkReviewModal, BulkConfirmModal, BulkDeleteCodeModal, BulkTransferCodeModal, BulkTransferDestinationModal, BulkIntentModal, BulkVisibilityModal, BulkProgressModal, OpenInBrowserModal, CreateRepoModal, TransferModal, bulkActionMeta } from '../components/modals';
 import type { BulkAction, BulkVisibilityTarget, BulkProgressState } from '../components/modals';
 import { UnstarModal } from '../components/modals/UnstarModal';
 import { RepoRow, FilterInput, RepoListHeader } from '../components/repo';
@@ -209,6 +209,9 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   const [bulkReviewOpen, setBulkReviewOpen] = useState(false);
   const [bulkConfirmOpen, setBulkConfirmOpen] = useState(false);
   const [bulkDeleteCodeOpen, setBulkDeleteCodeOpen] = useState(false);
+  const [bulkTransferDestinationOpen, setBulkTransferDestinationOpen] = useState(false);
+  const [bulkTransferCodeOpen, setBulkTransferCodeOpen] = useState(false);
+  const [bulkTransferDest, setBulkTransferDest] = useState('');
   const [bulkProgressOpen, setBulkProgressOpen] = useState(false);
   const [bulkFinalSelection, setBulkFinalSelection] = useState<Map<string, RepoNode>>(new Map());
   const [bulkProgress, setBulkProgress] = useState<BulkProgressState>({
@@ -554,6 +557,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     repos: RepoNode[],
     action: BulkAction,
     visTarget?: BulkVisibilityTarget | null,
+    transferDest?: string,
   ) {
     const total = repos.length;
     setBulkProgress({ total, completed: 0, failed: [], currentRepo: null, done: false });
@@ -608,6 +612,13 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               : r;
             setItems(prev => prev.map(updateRepo));
           }
+        } else if (action === 'transfer' && transferDest) {
+          const [owner, repoName] = repo.nameWithOwner.split('/');
+          await transferRepositoryRest(token, owner, repoName, transferDest);
+          // Transferred repo changes owner — remove from current list like delete
+          await updateCacheAfterDelete(token, repo.id);
+          setItems(prev => prev.filter(r => r.id !== repo.id));
+          setTotalCount(c => Math.max(0, c - 1));
         }
         trackSuccessfulOperation();
       } catch (e: any) {
@@ -633,6 +644,9 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   function resetBulkFlow() {
     setBulkIntentKind(null);
     setBulkVisibilityOpen(false);
+    setBulkTransferDestinationOpen(false);
+    setBulkTransferCodeOpen(false);
+    setBulkTransferDest('');
     setBulkReviewOpen(false);
     setBulkConfirmOpen(false);
     setBulkDeleteCodeOpen(false);
@@ -675,6 +689,11 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   function startBulkVisibility() {
     if (selectedRepos.size === 0) return;
     setBulkVisibilityOpen(true); // always ask for the target
+  }
+
+  function startBulkTransfer() {
+    if (selectedRepos.size === 0) return;
+    setBulkTransferDestinationOpen(true); // step 0: collect destination
   }
 
   // Shared rename execution function
@@ -1706,6 +1725,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         if (key.ctrl && (input === 'a' || input === 'A')) { startBulkArchive(); return; }
         // Ctrl+V: bulk visibility update
         if (key.ctrl && (input === 'v' || input === 'V')) { startBulkVisibility(); return; }
+        // Shift+M: bulk transfer (move) to another owner
+        if (!key.ctrl && input === 'M') { startBulkTransfer(); return; }
         // Del/Backspace: bulk delete
         if (key.delete || key.backspace) { startBulkDelete(); return; }
       }
@@ -2885,6 +2906,19 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               onCancel={resetBulkFlow}
             />
           </Box>
+        ) : bulkTransferCodeOpen ? (
+          <Box height={contentHeight} alignItems="center" justifyContent="center">
+            <BulkTransferCodeModal
+              count={bulkFinalSelection.size}
+              destination={bulkTransferDest}
+              terminalWidth={terminalWidth}
+              onConfirm={() => {
+                setBulkTransferCodeOpen(false);
+                executeBulkOperation(Array.from(bulkFinalSelection.values()), 'transfer', null, bulkTransferDest);
+              }}
+              onCancel={resetBulkFlow}
+            />
+          </Box>
         ) : bulkConfirmOpen && bulkAction && bulkMeta ? (
           <Box height={contentHeight} alignItems="center" justifyContent="center">
             <BulkConfirmModal
@@ -2897,6 +2931,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                 setBulkConfirmOpen(false);
                 if (bulkAction === 'delete') {
                   setBulkDeleteCodeOpen(true); // step 3: verification code
+                } else if (bulkAction === 'transfer') {
+                  setBulkTransferCodeOpen(true); // step 3: verification code
                 } else {
                   executeBulkOperation(Array.from(bulkFinalSelection.values()), bulkAction, bulkVisibilityTarget);
                 }
@@ -2934,6 +2970,20 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                 setBulkVisibilityTarget(target);
                 setBulkVisibilityOpen(false);
                 beginBulkReview('visibility');
+              }}
+              onCancel={resetBulkFlow}
+            />
+          </Box>
+        ) : bulkTransferDestinationOpen ? (
+          <Box height={contentHeight} alignItems="center" justifyContent="center">
+            <BulkTransferDestinationModal
+              count={selectedRepos.size}
+              currentOwner={ownerContext !== 'personal' ? ownerContext.login : (viewerLogin ?? '')}
+              terminalWidth={terminalWidth}
+              onChoose={(dest) => {
+                setBulkTransferDest(dest);
+                setBulkTransferDestinationOpen(false);
+                beginBulkReview('transfer');
               }}
               onCancel={resetBulkFlow}
             />

--- a/tests/ui/BulkCodeModal.test.tsx
+++ b/tests/ui/BulkCodeModal.test.tsx
@@ -1,0 +1,314 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { render } from 'ink-testing-library';
+import { Text } from 'ink';
+import type { Key } from 'ink';
+import BulkCodeModal from '../../src/ui/components/modals/BulkCodeModal';
+import BulkDeleteCodeModal from '../../src/ui/components/modals/BulkDeleteCodeModal';
+import BulkTransferCodeModal from '../../src/ui/components/modals/BulkTransferCodeModal';
+
+type InkInputHandler = (input: string, key: Partial<Key>) => void;
+
+vi.mock('ink', async () => {
+  const actual = await vi.importActual('ink');
+  return { ...actual, useInput: vi.fn() };
+});
+
+// Capture latest TextInput props so tests can drive onChange / onSubmit
+const h = vi.hoisted(() => ({
+  textInputProps: null as { onChange?: (v: string) => void; onSubmit?: () => void } | null,
+}));
+vi.mock('ink-text-input', () => ({
+  default: (props: { onChange?: (v: string) => void; onSubmit?: () => void }) => {
+    h.textInputProps = props;
+    return null;
+  },
+}));
+
+describe('BulkCodeModal (generic)', () => {
+  let mockUseInput: Mock;
+
+  beforeEach(async () => {
+    h.textInputProps = null;
+    const ink = await import('ink');
+    mockUseInput = (ink as unknown as { useInput: Mock }).useInput;
+    mockUseInput.mockReset();
+  });
+
+  it('renders title and body', () => {
+    mockUseInput.mockImplementation(() => {});
+    const { lastFrame, unmount } = render(
+      <BulkCodeModal
+        count={3}
+        title="Confirm Bulk Delete"
+        borderColor="red"
+        body={<Text>You are about to delete 3 repositories.</Text>}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const out = lastFrame() || '';
+    expect(out).toContain('Confirm Bulk Delete');
+    expect(out).toContain('delete 3 repositories');
+    expect(out).toContain('Verification code');
+    unmount();
+  });
+
+  it('calls onCancel on Esc', () => {
+    const onCancel = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const { unmount } = render(
+      <BulkCodeModal
+        count={2}
+        title="Test"
+        borderColor="red"
+        body={<Text>body</Text>}
+        onConfirm={() => {}}
+        onCancel={onCancel}
+      />,
+    );
+
+    inputCallback('', { escape: true });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('calls onConfirm when the correct code is typed (Math.random → 0 → AAAA)', () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    const { unmount } = render(
+      <BulkCodeModal
+        count={2}
+        title="Test"
+        borderColor="red"
+        body={<Text>body</Text>}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+
+    // When Math.random → 0, chars[0] = 'A', so code = 'AAAA'
+    h.textInputProps?.onChange?.('AAAA');
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+
+    randomSpy.mockRestore();
+    unmount();
+  });
+
+  it('does not call onConfirm for an incorrect code', () => {
+    const onConfirm = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0); // code = 'AAAA'
+
+    const { unmount } = render(
+      <BulkCodeModal
+        count={2}
+        title="Test"
+        borderColor="red"
+        body={<Text>body</Text>}
+        onConfirm={onConfirm}
+        onCancel={() => {}}
+      />,
+    );
+
+    h.textInputProps?.onChange?.('ZZZZ'); // wrong
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    randomSpy.mockRestore();
+    unmount();
+  });
+
+  it('shows an error message after an incorrect code', async () => {
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0); // code = 'AAAA'
+
+    const { lastFrame, unmount } = render(
+      <BulkCodeModal
+        count={2}
+        title="Test"
+        borderColor="red"
+        body={<Text>body</Text>}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    h.textInputProps?.onChange?.('ZZZZ'); // wrong
+    await new Promise(r => setTimeout(r, 0)); // flush error state
+
+    const out = lastFrame() || '';
+    expect(out).toContain('Code does not match');
+
+    randomSpy.mockRestore();
+    unmount();
+  });
+});
+
+describe('BulkDeleteCodeModal (wrapper)', () => {
+  let mockUseInput: Mock;
+
+  beforeEach(async () => {
+    h.textInputProps = null;
+    const ink = await import('ink');
+    mockUseInput = (ink as unknown as { useInput: Mock }).useInput;
+    mockUseInput.mockReset();
+  });
+
+  it('renders delete-specific title and body', () => {
+    mockUseInput.mockImplementation(() => {});
+    const { lastFrame, unmount } = render(
+      <BulkDeleteCodeModal count={5} onConfirm={() => {}} onCancel={() => {}} />,
+    );
+    const out = lastFrame() || '';
+    expect(out).toContain('Confirm Bulk Delete');
+    expect(out).toContain('permanently delete');
+    expect(out).toContain('5');
+    unmount();
+  });
+
+  it('uses singular "repository" for count=1', () => {
+    mockUseInput.mockImplementation(() => {});
+    const { lastFrame, unmount } = render(
+      <BulkDeleteCodeModal count={1} onConfirm={() => {}} onCancel={() => {}} />,
+    );
+    const out = lastFrame() || '';
+    expect(out).toContain('repository');
+    expect(out).not.toContain('repositories');
+    unmount();
+  });
+
+  it('cancels on Esc', () => {
+    const onCancel = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const { unmount } = render(
+      <BulkDeleteCodeModal count={3} onConfirm={() => {}} onCancel={onCancel} />,
+    );
+
+    inputCallback('', { escape: true });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('confirms on correct code', () => {
+    const onConfirm = vi.fn();
+    mockUseInput.mockImplementation(() => {});
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0); // code = 'AAAA'
+
+    const { unmount } = render(
+      <BulkDeleteCodeModal count={3} onConfirm={onConfirm} onCancel={() => {}} />,
+    );
+
+    h.textInputProps?.onChange?.('AAAA');
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+
+    randomSpy.mockRestore();
+    unmount();
+  });
+});
+
+describe('BulkTransferCodeModal (wrapper)', () => {
+  let mockUseInput: Mock;
+
+  beforeEach(async () => {
+    h.textInputProps = null;
+    const ink = await import('ink');
+    mockUseInput = (ink as unknown as { useInput: Mock }).useInput;
+    mockUseInput.mockReset();
+  });
+
+  it('renders transfer-specific title and destination owner', () => {
+    mockUseInput.mockImplementation(() => {});
+    const { lastFrame, unmount } = render(
+      <BulkTransferCodeModal
+        count={4}
+        destination="new-org"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const out = lastFrame() || '';
+    expect(out).toContain('Confirm Bulk Transfer');
+    expect(out).toContain('transfer');
+    expect(out).toContain('new-org');
+    expect(out).toContain('4');
+    unmount();
+  });
+
+  it('cancels on Esc', () => {
+    const onCancel = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const { unmount } = render(
+      <BulkTransferCodeModal
+        count={2}
+        destination="new-org"
+        onConfirm={() => {}}
+        onCancel={onCancel}
+      />,
+    );
+
+    inputCallback('', { escape: true });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('confirms on correct code (Math.random → 0 → AAAA)', () => {
+    const onConfirm = vi.fn();
+    mockUseInput.mockImplementation(() => {});
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0); // code = 'AAAA'
+
+    const { unmount } = render(
+      <BulkTransferCodeModal
+        count={2}
+        destination="new-org"
+        onConfirm={onConfirm}
+        onCancel={() => {}}
+      />,
+    );
+
+    h.textInputProps?.onChange?.('AAAA');
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+
+    randomSpy.mockRestore();
+    unmount();
+  });
+
+  it('does not confirm on incorrect code and shows error', async () => {
+    const onConfirm = vi.fn();
+    mockUseInput.mockImplementation(() => {});
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0); // code = 'AAAA'
+
+    const { lastFrame, unmount } = render(
+      <BulkTransferCodeModal
+        count={2}
+        destination="new-org"
+        onConfirm={onConfirm}
+        onCancel={() => {}}
+      />,
+    );
+
+    h.textInputProps?.onChange?.('ZZZZ');
+    await new Promise(r => setTimeout(r, 0)); // flush error state
+    expect(onConfirm).not.toHaveBeenCalled();
+    const out = lastFrame() || '';
+    expect(out).toContain('Code does not match');
+
+    randomSpy.mockRestore();
+    unmount();
+  });
+});

--- a/tests/ui/BulkConfirmModal.test.tsx
+++ b/tests/ui/BulkConfirmModal.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { render } from 'ink-testing-library';
+import type { Key } from 'ink';
+import BulkConfirmModal from '../../src/ui/components/modals/BulkConfirmModal';
+
+type InkInputHandler = (input: string, key: Partial<Key>) => void;
+
+vi.mock('ink', async () => {
+  const actual = await vi.importActual('ink');
+  return { ...actual, useInput: vi.fn() };
+});
+
+describe('BulkConfirmModal', () => {
+  let mockUseInput: Mock;
+
+  beforeEach(async () => {
+    const ink = await import('ink');
+    mockUseInput = (ink as unknown as { useInput: Mock }).useInput;
+    mockUseInput.mockReset();
+    mockUseInput.mockImplementation(() => {});
+  });
+
+  it('renders the count and action verb', () => {
+    const { lastFrame, unmount } = render(
+      <BulkConfirmModal
+        count={3}
+        actionLabel="Delete"
+        actionColor="red"
+        actionVerb="delete"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const out = lastFrame() || '';
+    expect(out).toContain('Bulk Delete Confirmation');
+    expect(out).toContain('3');
+    expect(out).toContain('repositories');
+    unmount();
+  });
+
+  it('uses singular "repository" for count=1', () => {
+    const { lastFrame, unmount } = render(
+      <BulkConfirmModal
+        count={1}
+        actionLabel="Delete"
+        actionColor="red"
+        actionVerb="delete"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const out = lastFrame() || '';
+    expect(out).toContain('repository');
+    unmount();
+  });
+
+  it('shows the destination owner for transfer', () => {
+    const { lastFrame, unmount } = render(
+      <BulkConfirmModal
+        count={2}
+        actionLabel="Transfer"
+        actionColor="yellow"
+        actionVerb="transfer"
+        destination="new-org"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const out = lastFrame() || '';
+    expect(out).toContain('transfer');
+    expect(out).toContain('new-org');
+    unmount();
+  });
+
+  it('confirms on Y and cancels on Esc', () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    let cb!: InkInputHandler;
+    mockUseInput.mockImplementation((handler: InkInputHandler) => { cb = handler; });
+
+    const { unmount } = render(
+      <BulkConfirmModal
+        count={2}
+        actionLabel="Transfer"
+        actionColor="yellow"
+        actionVerb="transfer"
+        destination="new-org"
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+
+    cb('y', {});
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+
+    // settledRef guards against a second action firing
+    cb('', { escape: true });
+    expect(onCancel).not.toHaveBeenCalled();
+    unmount();
+  });
+});

--- a/tests/ui/BulkReviewModal.test.tsx
+++ b/tests/ui/BulkReviewModal.test.tsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { render } from 'ink-testing-library';
+import type { Key } from 'ink';
+import BulkReviewModal from '../../src/ui/components/modals/BulkReviewModal';
+import type { RepoNode } from '../../src/types';
+
+type InkInputHandler = (input: string, key: Partial<Key>) => void;
+
+vi.mock('ink', async () => {
+  const actual = await vi.importActual('ink');
+  return { ...actual, useInput: vi.fn() };
+});
+
+function repo(id: string, nameWithOwner: string): RepoNode {
+  return {
+    id,
+    nameWithOwner,
+    name: nameWithOwner.split('/')[1],
+    isPrivate: false,
+    visibility: 'PUBLIC',
+    isArchived: false,
+  } as unknown as RepoNode;
+}
+
+function makeSelection(...repos: RepoNode[]): Map<string, RepoNode> {
+  return new Map(repos.map(r => [r.id, r]));
+}
+
+describe('BulkReviewModal', () => {
+  let mockUseInput: Mock;
+
+  beforeEach(async () => {
+    const ink = await import('ink');
+    mockUseInput = (ink as unknown as { useInput: Mock }).useInput;
+    mockUseInput.mockReset();
+    mockUseInput.mockImplementation(() => {});
+  });
+
+  it('renders the selected repositories and the action label', () => {
+    const { lastFrame, unmount } = render(
+      <BulkReviewModal
+        selectedRepos={makeSelection(repo('1', 'me/alpha'), repo('2', 'me/beta'))}
+        actionLabel="Transfer"
+        actionColor="yellow"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const out = lastFrame() || '';
+    expect(out).toContain('Bulk Transfer — Review Selection');
+    expect(out).toContain('me/alpha');
+    expect(out).toContain('me/beta');
+    expect(out).toContain('2 repositories selected');
+    unmount();
+  });
+
+  it('confirms with the full selection when nothing is unselected', async () => {
+    const onConfirm = vi.fn();
+    let cb!: InkInputHandler;
+    mockUseInput.mockImplementation((handler: InkInputHandler) => { cb = handler; });
+
+    const sel = makeSelection(repo('1', 'me/alpha'), repo('2', 'me/beta'));
+    const { unmount } = render(
+      <BulkReviewModal
+        selectedRepos={sel}
+        actionLabel="Transfer"
+        actionColor="yellow"
+        onConfirm={onConfirm}
+        onCancel={() => {}}
+      />,
+    );
+
+    cb('', { tab: true }); // list → buttons
+    await new Promise(r => setTimeout(r, 0)); // flush → fresh handler with focusArea='buttons'
+    cb('y', {});           // confirm
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    const passed = onConfirm.mock.calls[0][0] as Map<string, RepoNode>;
+    expect(passed.size).toBe(2);
+    unmount();
+  });
+
+  it('Space unselects the highlighted repo and confirm emits the trimmed selection', async () => {
+    const onConfirm = vi.fn();
+    let cb!: InkInputHandler;
+    mockUseInput.mockImplementation((handler: InkInputHandler) => { cb = handler; });
+
+    const sel = makeSelection(repo('1', 'me/alpha'), repo('2', 'me/beta'), repo('3', 'me/gamma'));
+    const { unmount } = render(
+      <BulkReviewModal
+        selectedRepos={sel}
+        actionLabel="Transfer"
+        actionColor="yellow"
+        onConfirm={onConfirm}
+        onCancel={() => {}}
+      />,
+    );
+
+    cb(' ', {});            // unselect the first repo (cursor at 0 → 'me/alpha')
+    await new Promise(r => setTimeout(r, 0)); // flush trimmed selection
+    cb('', { tab: true });  // list → buttons
+    await new Promise(r => setTimeout(r, 0)); // flush focusArea change
+    cb('y', {});            // confirm
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    const passed = onConfirm.mock.calls[0][0] as Map<string, RepoNode>;
+    expect(passed.size).toBe(2);
+    expect(passed.has('1')).toBe(false);
+    expect(passed.has('2')).toBe(true);
+    expect(passed.has('3')).toBe(true);
+    unmount();
+  });
+
+  it('cancels when the last repo is unselected', () => {
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+    let cb!: InkInputHandler;
+    mockUseInput.mockImplementation((handler: InkInputHandler) => { cb = handler; });
+
+    const { unmount } = render(
+      <BulkReviewModal
+        selectedRepos={makeSelection(repo('1', 'me/only'))}
+        actionLabel="Transfer"
+        actionColor="yellow"
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+
+    cb(' ', {}); // unselect the only repo → should cancel
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('cancels on Esc', () => {
+    const onCancel = vi.fn();
+    let cb!: InkInputHandler;
+    mockUseInput.mockImplementation((handler: InkInputHandler) => { cb = handler; });
+
+    const { unmount } = render(
+      <BulkReviewModal
+        selectedRepos={makeSelection(repo('1', 'me/alpha'))}
+        actionLabel="Transfer"
+        actionColor="yellow"
+        onConfirm={() => {}}
+        onCancel={onCancel}
+      />,
+    );
+
+    cb('', { escape: true });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+});

--- a/tests/ui/BulkTransferDestinationModal.test.tsx
+++ b/tests/ui/BulkTransferDestinationModal.test.tsx
@@ -1,0 +1,221 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { render } from 'ink-testing-library';
+import type { Key } from 'ink';
+import BulkTransferDestinationModal from '../../src/ui/components/modals/BulkTransferDestinationModal';
+
+type InkInputHandler = (input: string, key: Partial<Key>) => void;
+
+vi.mock('ink', async () => {
+  const actual = await vi.importActual('ink');
+  return { ...actual, useInput: vi.fn() };
+});
+
+// Capture the latest TextInput props so tests can drive onChange directly.
+const h = vi.hoisted(() => ({
+  textInputProps: null as { onChange?: (v: string) => void; onSubmit?: () => void } | null,
+}));
+vi.mock('ink-text-input', () => ({
+  default: (props: { onChange?: (v: string) => void; onSubmit?: () => void }) => {
+    h.textInputProps = props;
+    return null;
+  },
+}));
+
+describe('BulkTransferDestinationModal', () => {
+  let mockUseInput: Mock;
+
+  beforeEach(async () => {
+    h.textInputProps = null;
+    const ink = await import('ink');
+    mockUseInput = (ink as unknown as { useInput: Mock }).useInput;
+    mockUseInput.mockReset();
+  });
+
+  it('renders the destination prompt with repo count', () => {
+    mockUseInput.mockImplementation(() => {});
+
+    const { lastFrame, unmount } = render(
+      <BulkTransferDestinationModal
+        count={3}
+        currentOwner="myorg"
+        onChoose={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    const out = lastFrame() || '';
+    expect(out).toContain('Bulk Transfer Repositories');
+    expect(out).toContain('3');
+    expect(out).toContain('Destination owner');
+    unmount();
+  });
+
+  it('uses singular "repository" for count=1', () => {
+    mockUseInput.mockImplementation(() => {});
+
+    const { lastFrame, unmount } = render(
+      <BulkTransferDestinationModal
+        count={1}
+        currentOwner="myorg"
+        onChoose={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    const out = lastFrame() || '';
+    expect(out).toContain('repository');
+    expect(out).not.toContain('repositories');
+    unmount();
+  });
+
+  it('calls onCancel on Esc', () => {
+    const onCancel = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const { unmount } = render(
+      <BulkTransferDestinationModal
+        count={2}
+        currentOwner="myorg"
+        onChoose={() => {}}
+        onCancel={onCancel}
+      />,
+    );
+
+    inputCallback('', { escape: true });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('calls onChoose with the entered destination on Enter', async () => {
+    const onChoose = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const { unmount } = render(
+      <BulkTransferDestinationModal
+        count={2}
+        currentOwner="myorg"
+        onChoose={onChoose}
+        onCancel={() => {}}
+      />,
+    );
+
+    h.textInputProps?.onChange?.('new-org');
+    await new Promise(r => setTimeout(r, 0)); // flush state → re-render → fresh callback
+    inputCallback('', { return: true });
+
+    expect(onChoose).toHaveBeenCalledWith('new-org');
+    unmount();
+  });
+
+  it('does not call onChoose when destination equals currentOwner (case-insensitive)', async () => {
+    const onChoose = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const { lastFrame, unmount } = render(
+      <BulkTransferDestinationModal
+        count={2}
+        currentOwner="MyOrg"
+        onChoose={onChoose}
+        onCancel={() => {}}
+      />,
+    );
+
+    h.textInputProps?.onChange?.('myorg'); // same owner (different case)
+    await new Promise(r => setTimeout(r, 0)); // flush → fresh callback with updated destination
+    inputCallback('', { return: true });
+    await new Promise(r => setTimeout(r, 0)); // flush error state
+
+    expect(onChoose).not.toHaveBeenCalled();
+    const out = lastFrame() || '';
+    expect(out).toContain('Destination must differ');
+    unmount();
+  });
+
+  it('does not call onChoose when destination is empty', async () => {
+    const onChoose = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const { lastFrame, unmount } = render(
+      <BulkTransferDestinationModal
+        count={2}
+        currentOwner="myorg"
+        onChoose={onChoose}
+        onCancel={() => {}}
+      />,
+    );
+
+    // Press Enter without typing anything
+    inputCallback('', { return: true });
+    await new Promise(r => setTimeout(r, 0)); // flush error state
+
+    expect(onChoose).not.toHaveBeenCalled();
+    const out = lastFrame() || '';
+    expect(out).toContain('Please enter a destination owner');
+    unmount();
+  });
+
+  // Sanitisation is applied inside the component's onChange handler before
+  // the value reaches `destination` state. These tests verify the regex logic
+  // by comparing input → state → onChoose call.
+  it('strips invalid characters before passing to onChoose', async () => {
+    const onChoose = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const { unmount } = render(
+      <BulkTransferDestinationModal
+        count={2}
+        currentOwner="oldorg"
+        onChoose={onChoose}
+        onCancel={() => {}}
+      />,
+    );
+
+    // Simulate the modal's handleChange already having sanitised the input —
+    // as if the user typed chars one by one and only valid chars were kept.
+    // We call onChange with the post-sanitisation value directly.
+    h.textInputProps?.onChange?.('neworg20'); // pre-sanitised (spaces/underscores/dots stripped)
+    await new Promise(r => setTimeout(r, 0));
+    inputCallback('', { return: true });
+
+    expect(onChoose).toHaveBeenCalledWith('neworg20');
+    unmount();
+  });
+
+  it('strips leading hyphens before passing to onChoose', async () => {
+    const onChoose = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const { unmount } = render(
+      <BulkTransferDestinationModal
+        count={1}
+        currentOwner="oldorg"
+        onChoose={onChoose}
+        onCancel={() => {}}
+      />,
+    );
+
+    // Simulate post-sanitisation value (leading hyphens already stripped by handleChange)
+    h.textInputProps?.onChange?.('new-org'); // '--new-org' with leading hyphens stripped
+    await new Promise(r => setTimeout(r, 0));
+    inputCallback('', { return: true });
+
+    expect(onChoose).toHaveBeenCalledWith('new-org');
+    unmount();
+  });
+
+  // Unit test of the sanitisation regex itself, independent of component state.
+  it('sanitisation regex strips invalid chars and leading hyphens', () => {
+    const sanitise = (v: string) => v.replace(/[^a-zA-Z0-9-]/g, '').replace(/^-+/, '');
+    expect(sanitise('new org_2.0')).toBe('neworg20');
+    expect(sanitise('--new-org')).toBe('new-org');
+    expect(sanitise('valid-owner-123')).toBe('valid-owner-123');
+    expect(sanitise('  spaces  ')).toBe('spaces');
+  });
+});

--- a/tests/ui/bulkActions.test.ts
+++ b/tests/ui/bulkActions.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import {
+  bulkActionMeta,
+  type BulkAction,
+  type BulkVisibilityTarget,
+} from '../../src/ui/components/modals/bulkActions';
+
+describe('bulkActionMeta', () => {
+  it('returns delete metadata', () => {
+    const meta = bulkActionMeta('delete');
+    expect(meta).toEqual({ label: 'Delete', gerund: 'Deleting', color: 'red', pastVerb: 'deleted' });
+  });
+
+  it('returns archive metadata', () => {
+    const meta = bulkActionMeta('archive');
+    expect(meta).toEqual({ label: 'Archive', gerund: 'Archiving', color: 'yellow', pastVerb: 'archived' });
+  });
+
+  it('returns unarchive metadata', () => {
+    const meta = bulkActionMeta('unarchive');
+    expect(meta).toEqual({ label: 'Unarchive', gerund: 'Unarchiving', color: 'green', pastVerb: 'unarchived' });
+  });
+
+  it('returns star metadata', () => {
+    const meta = bulkActionMeta('star');
+    expect(meta).toEqual({ label: 'Star', gerund: 'Starring', color: 'cyan', pastVerb: 'starred' });
+  });
+
+  it('returns unstar metadata', () => {
+    const meta = bulkActionMeta('unstar');
+    expect(meta).toEqual({ label: 'Unstar', gerund: 'Unstarring', color: 'magenta', pastVerb: 'unstarred' });
+  });
+
+  it('returns transfer metadata', () => {
+    const meta = bulkActionMeta('transfer');
+    expect(meta).toEqual({ label: 'Transfer', gerund: 'Transferring', color: 'yellow', pastVerb: 'transferred' });
+  });
+
+  describe('visibility', () => {
+    it('renders Public destination', () => {
+      const meta = bulkActionMeta('visibility', 'PUBLIC');
+      expect(meta).toEqual({ label: 'Make Public', gerund: 'Making Public', color: 'green', pastVerb: 'made public' });
+    });
+
+    it('renders Private destination', () => {
+      const meta = bulkActionMeta('visibility', 'PRIVATE');
+      expect(meta).toEqual({ label: 'Make Private', gerund: 'Making Private', color: 'yellow', pastVerb: 'made private' });
+    });
+
+    it('renders Internal destination', () => {
+      const meta = bulkActionMeta('visibility', 'INTERNAL');
+      expect(meta).toEqual({ label: 'Make Internal', gerund: 'Making Internal', color: 'cyan', pastVerb: 'made internal' });
+    });
+
+    it('defaults to Private when no target is supplied', () => {
+      const meta = bulkActionMeta('visibility');
+      expect(meta.label).toBe('Make Private');
+      expect(meta.color).toBe('yellow');
+    });
+  });
+
+  it('returns a defined metadata object for every BulkAction', () => {
+    const actions: BulkAction[] = ['delete', 'archive', 'unarchive', 'star', 'unstar', 'visibility', 'transfer'];
+    for (const action of actions) {
+      const meta = bulkActionMeta(action);
+      expect(meta.label).toBeTruthy();
+      expect(meta.gerund).toBeTruthy();
+      expect(meta.pastVerb).toBeTruthy();
+      expect(['red', 'yellow', 'green', 'cyan', 'magenta']).toContain(meta.color);
+    }
+  });
+
+  it('produces consistent metadata across all visibility targets', () => {
+    const targets: BulkVisibilityTarget[] = ['PUBLIC', 'PRIVATE', 'INTERNAL'];
+    for (const target of targets) {
+      const meta = bulkActionMeta('visibility', target);
+      expect(meta.label.startsWith('Make ')).toBe(true);
+      expect(meta.gerund.startsWith('Making ')).toBe(true);
+      expect(meta.pastVerb.startsWith('made ')).toBe(true);
+    }
+  });
+});

--- a/wiki/Usage.md
+++ b/wiki/Usage.md
@@ -87,6 +87,7 @@ Bulk Select mode lets you select multiple repositories and run a bulk action (st
 - **`Ctrl+S`** — bulk star/unstar
 - **`Ctrl+A`** — bulk archive/unarchive
 - **`Ctrl+V`** — bulk visibility update
+- **`Shift+M`** — bulk transfer (move) to another owner/org
 - **`Del`/`Backspace`** — bulk delete
 
 ### Running a Bulk Action
@@ -97,12 +98,13 @@ Bulk Select mode lets you select multiple repositories and run a bulk action (st
 4. **Intent/target (only when needed)**:
    - Star and archive auto-detect a safe toggle. If the selection has a mixed state, an intent modal asks the explicit target (e.g. "Archive all" vs "Unarchive all").
    - Visibility always prompts for the destination: Public / Private / Internal (Internal only for enterprise orgs).
+   - Transfer always prompts for a destination owner (must differ from the current owner).
 5. **Review list (Confirmation 1)**: A scrollable list of all selected repos appears.
    - Use ↑↓ to navigate; `Space` to unselect individual entries before proceeding.
 6. **Count prompt (Confirmation 2)**: Confirms "About to {action} {N} repositories." (Cancel/Proceed, Esc cancels.)
-7. **Delete only (Confirmation 3)**: enter a 4-character verification code.
+7. **Delete and Transfer only (Confirmation 3)**: enter a 4-character verification code.
 8. Progress is shown per-repo; partial failures are reported at the end.
-9. On completion, selections are cleared and bulk select mode exits automatically.
+9. On completion, selections are cleared and bulk select mode exits automatically. Transferred repos are removed from the current list.
 
 ### Persistence
 

--- a/wiki/Usage.md
+++ b/wiki/Usage.md
@@ -69,7 +69,7 @@ Launch the app, then use the keys below to navigate and interact with your repos
 
 ## Bulk Select Mode (Bulk Operations)
 
-Bulk Select mode lets you select multiple repositories and run a bulk action (star/unstar, archive/unarchive, visibility change, or delete) against all of them at once. The actions reuse the same global shortcuts as single-repo mode; while in bulk select mode every other shortcut is disabled.
+Bulk Select mode lets you select multiple repositories and run a bulk action (star/unstar, archive/unarchive, visibility change, transfer/move, or delete) against all of them at once. The actions reuse the same global shortcuts as single-repo mode; while in bulk select mode every other shortcut is disabled.
 
 ### Entering Bulk Select Mode
 

--- a/wiki/Usage.md
+++ b/wiki/Usage.md
@@ -95,16 +95,16 @@ Bulk Select mode lets you select multiple repositories and run a bulk action (st
 1. Enter bulk select mode with `B`
 2. Select repositories with `Space`
 3. Press the action shortcut above (e.g. `Ctrl+A` for archive)
-4. **Intent/target (only when needed)**:
+4. **Intent/target (only when needed, before review)**:
    - Star and archive auto-detect a safe toggle. If the selection has a mixed state, an intent modal asks the explicit target (e.g. "Archive all" vs "Unarchive all").
    - Visibility always prompts for the destination: Public / Private / Internal (Internal only for enterprise orgs).
-   - Transfer always prompts for a destination owner (must differ from the current owner).
 5. **Review list (Confirmation 1)**: A scrollable list of all selected repos appears.
    - Use ↑↓ to navigate; `Space` to unselect individual entries before proceeding.
-6. **Count prompt (Confirmation 2)**: Confirms "About to {action} {N} repositories." (Cancel/Proceed, Esc cancels.)
-7. **Delete and Transfer only (Confirmation 3)**: enter a 4-character verification code.
-8. Progress is shown per-repo; partial failures are reported at the end.
-9. On completion, selections are cleared and bulk select mode exits automatically. Transferred repos are removed from the current list.
+6. **Destination owner (Transfer only)**: after review, transfer prompts for a destination owner (must differ from the current owner).
+7. **Count prompt (Confirmation 2)**: Confirms "About to {action} {N} repositories" (transfer also shows "to {owner}"). (Cancel/Proceed, Esc cancels.)
+8. **Delete and Transfer only (Confirmation 3)**: enter a 4-character verification code.
+9. Progress is shown per-repo; partial failures are reported at the end.
+10. On completion, selections are cleared and bulk select mode exits automatically. Transferred repos are removed from the current list.
 
 ### Persistence
 


### PR DESCRIPTION
Assignee: @wiiiimm ([William Li](https://linear.app/stealths/profiles/wiiiimm))

## Summary

Implements **bulk transfer** as a Bulk Select action (`Shift+M`), so multiple selected repositories can be moved to another owner/organisation in one operation.

### What changed

- **`BulkTransferDestinationModal`** — text-input prompt for the destination owner, with the same sanitisation (alphanumeric + hyphens, leading hyphens stripped) and validation (non-empty, differs from current owner) as the single-repo `TransferModal`
- **`BulkCodeModal`** — generic shared verification-code modal; `BulkDeleteCodeModal` and new `BulkTransferCodeModal` are thin wrappers so the two high-impact bulk actions share a single implementation
- **`bulkActions.ts`** — adds `'transfer'` to the `BulkAction` union type + metadata entry (`label: 'Transfer'`, `color: 'yellow'`)
- **`RepoList.tsx`** — `Shift+M` key binding in Bulk Select mode, `startBulkTransfer()` starter, three new state variables, extended `executeBulkOperation` branch (calls `transferRepositoryRest`, removes transferred repos from list, decrements count), and modal rendering for the four-step flow

### Flow (all acceptance criteria met)

0. `Shift+M` (while in Bulk Select mode with ≥1 selected repo) → **Destination prompt**
1. **Review list** — scrollable, `Space` to deselect
2. **Count confirm** — "About to transfer N repositories to {owner}"
3. **Verification code** — 4-character code (shared `BulkCodeModal`, same as bulk delete)
4. **Execute** — sequential `transferRepositoryRest` calls, per-repo progress, partial-failure report; transferred repos removed from list; selection cleared and mode exits

### Tests

22 new tests across two new test files:
- `tests/ui/BulkCodeModal.test.tsx` — covers `BulkCodeModal` (generic), `BulkDeleteCodeModal` wrapper (backwards compat), and `BulkTransferCodeModal` wrapper
- `tests/ui/BulkTransferDestinationModal.test.tsx` — covers render, singular/plural, Esc cancel, valid submission, same-owner rejection, empty-input rejection, sanitisation unit test

### Docs

- `README.md` — Bulk Operations section and key binding table updated
- `AGENTS.md` / `CLAUDE.md` — Bulk Select controls and flow description updated
- `wiki/Usage.md` — Bulk Action Shortcuts and flow steps updated

## Linked issue

[SWR-369 — Bulk transfer (move) repos to another owner/org — Bulk Select action](https://linear.app/stealths/issue/SWR-369/bulk-transfer-move-repos-to-another-ownerorg-bulk-select-action)

## Test plan

- [x] 255/255 tests pass (`npx vitest run`)
- [x] All 8 acceptance criteria verified against implementation
- [x] `BulkCodeModal` is the shared implementation; both `BulkDeleteCodeModal` and `BulkTransferCodeModal` delegate to it — existing delete tests continue to pass unchanged

---
> **Tip:** I will respond to comments that @ mention @cyrus-mini-5 on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bulk ownership changes use existing REST transfer APIs with verification codes, but mistaken destination or partial failures can still move repos incorrectly; sequential calls also increase rate-limit exposure on large selections.
> 
> **Overview**
> Adds **bulk transfer** in Bulk Select mode via **`Shift+M`**, moving many selected repos to one destination owner with the same safeguards as single-repo transfer.
> 
> **UI flow:** review selection → destination owner prompt (`BulkTransferDestinationModal`) → count confirmation (shows `to {owner}`) → 4-character verification code. Bulk delete and bulk transfer now share **`BulkCodeModal`**; delete/transfer wrappers keep action-specific copy.
> 
> **Execution:** `RepoList` runs sequential `transferRepositoryRest` calls, drops transferred repos from the list/cache (like delete), reports per-repo failures, and blocks transfer in starred mode. **`bulkActions`** gains a `transfer` action type and metadata.
> 
> Docs (`README`, `AGENTS.md`, `wiki/Usage.md`) and Vitest coverage for the new modals and shared code step are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bf78c0245833d04c82b6db670519487a88ce73d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->