### PR TITLE
refactor: extract visibility-filter predicate into a tested pure helper (SWR-372) [semantic pr title]

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -176,3 +176,20 @@ export async function copyToClipboard(text: string): Promise<void> {
   }
 }
 
+/** Visibility filter states used across the repository list (SWR-366). */
+export type VisibilityFilter = 'all' | 'public' | 'private';
+
+/**
+ * Whether a repository of the given visibility passes a visibility filter.
+ *
+ * Visibility is filtered client-side over the full cached set (SWR-366). This
+ * encodes the single source of truth for that rule, matching GitHub's own
+ * behaviour: the "private" filter includes both PRIVATE and INTERNAL
+ * repositories, and "all" passes everything.
+ */
+export function matchesVisibilityFilter(visibility: string, filter: VisibilityFilter): boolean {
+  if (filter === 'public') return visibility === 'PUBLIC';
+  if (filter === 'private') return visibility === 'PRIVATE' || visibility === 'INTERNAL';
+  return true; // 'all'
+}
+

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -17,7 +17,7 @@ import type { BulkAction, BulkVisibilityTarget, BulkProgressState } from '../com
 import { UnstarModal } from '../components/modals/UnstarModal';
 import { RepoRow, FilterInput, RepoListHeader } from '../components/repo';
 import { SlowSpinner } from '../components/common';
-import { truncate, formatDate, copyToClipboard, computeWindow, matchesVisibilityFilter } from '../../lib/utils';
+import { truncate, formatDate, copyToClipboard, computeWindow, matchesVisibilityFilter, type VisibilityFilter } from '../../lib/utils';
 
 // Allow customizable repos per fetch via env var (1-50, default 15)
 const getPageSize = () => {
@@ -1103,8 +1103,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     }
   }
 
-  // Visibility filter - 'all' | 'public' | 'private'
-  type VisibilityFilter = 'all' | 'public' | 'private';
+  // Visibility filter - 'all' | 'public' | 'private' (VisibilityFilter type
+  // shared from lib/utils, see import above)
   const [visibilityFilter, setVisibilityFilter] = useState<VisibilityFilter>('all');
   // nameWithOwner of a repo queued to receive cursor focus once it appears in
   // the (re-sorted/filtered) visible list — e.g. a freshly created repo, whose

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -17,7 +17,7 @@ import type { BulkAction, BulkVisibilityTarget, BulkProgressState } from '../com
 import { UnstarModal } from '../components/modals/UnstarModal';
 import { RepoRow, FilterInput, RepoListHeader } from '../components/repo';
 import { SlowSpinner } from '../components/common';
-import { truncate, formatDate, copyToClipboard, computeWindow } from '../../lib/utils';
+import { truncate, formatDate, copyToClipboard, computeWindow, matchesVisibilityFilter } from '../../lib/utils';
 
 // Allow customizable repos per fetch via env var (1-50, default 15)
 const getPageSize = () => {
@@ -726,10 +726,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     // reset to 'all' so it isn't filtered out of the list. The client-side
     // 'private' filter includes both PRIVATE and INTERNAL (matching GitHub and
     // executeVisibilityChange), so an INTERNAL repo passes it.
-    const passesVisibilityFilter =
-      visibilityFilter === 'all' ||
-      (visibilityFilter === 'public' && visibility === 'PUBLIC') ||
-      (visibilityFilter === 'private' && (visibility === 'PRIVATE' || visibility === 'INTERNAL'));
+    const passesVisibilityFilter = matchesVisibilityFilter(visibility, visibilityFilter);
     if (!passesVisibilityFilter) {
       storeUIPrefs({ visibilityFilter: 'all' });
       setVisibilityFilter('all');
@@ -2021,14 +2018,12 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     let result = items;
     
     // Apply visibility filter locally over the full cached set (SWR-366).
-    // Match GitHub's behaviour: Private filter includes both PRIVATE and INTERNAL.
-    if (visibilityFilter === 'private') {
-      // Show both PRIVATE and INTERNAL repos (matching GitHub's behaviour)
-      result = result.filter(r => r.visibility === 'PRIVATE' || r.visibility === 'INTERNAL');
-    } else if (visibilityFilter === 'public') {
-      result = result.filter(r => r.visibility === 'PUBLIC');
+    // matchesVisibilityFilter encodes GitHub's behaviour (Private includes
+    // PRIVATE and INTERNAL); 'all' is a no-op.
+    if (visibilityFilter !== 'all') {
+      result = result.filter(r => matchesVisibilityFilter(r.visibility, visibilityFilter));
     }
-    
+
     // Apply archive filter
     if (archiveFilter === 'archived') {
       result = result.filter(r => r.isArchived);
@@ -2066,10 +2061,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   const fuzzyItems = useMemo(() => {
     if (!filterActive) return [];
     let results = fuzzySearch(items, filter);
-    if (visibilityFilter === 'private') {
-      results = results.filter(r => r.visibility === 'PRIVATE' || r.visibility === 'INTERNAL');
-    } else if (visibilityFilter === 'public') {
-      results = results.filter(r => r.visibility === 'PUBLIC');
+    if (visibilityFilter !== 'all') {
+      results = results.filter(r => matchesVisibilityFilter(r.visibility, visibilityFilter));
     }
     if (archiveFilter === 'archived') results = results.filter(r => r.isArchived);
     else if (archiveFilter === 'unarchived') results = results.filter(r => !r.isArchived);

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { truncate, formatDate, computeWindow } from '../src/lib/utils';
+import { truncate, formatDate, computeWindow, matchesVisibilityFilter } from '../src/lib/utils';
 
 describe('truncate', () => {
   it('returns string unchanged if shorter than max', () => {
@@ -237,5 +237,32 @@ describe('computeWindow – out-of-range cursor safety', () => {
   it('returns an empty window for an empty list', () => {
     expect(computeWindow([], 0, 20, 0)).toEqual({ start: 0, end: 0 });
     expect(computeWindow([], 5, 20, 1)).toEqual({ start: 0, end: 0 });
+  });
+});
+
+describe('matchesVisibilityFilter', () => {
+  it('passes every visibility when the filter is "all"', () => {
+    expect(matchesVisibilityFilter('PUBLIC', 'all')).toBe(true);
+    expect(matchesVisibilityFilter('PRIVATE', 'all')).toBe(true);
+    expect(matchesVisibilityFilter('INTERNAL', 'all')).toBe(true);
+  });
+
+  it('passes only PUBLIC repos when the filter is "public"', () => {
+    expect(matchesVisibilityFilter('PUBLIC', 'public')).toBe(true);
+    expect(matchesVisibilityFilter('PRIVATE', 'public')).toBe(false);
+    expect(matchesVisibilityFilter('INTERNAL', 'public')).toBe(false);
+  });
+
+  it('passes PRIVATE and INTERNAL when the filter is "private" (matching GitHub)', () => {
+    expect(matchesVisibilityFilter('PRIVATE', 'private')).toBe(true);
+    expect(matchesVisibilityFilter('INTERNAL', 'private')).toBe(true);
+    expect(matchesVisibilityFilter('PUBLIC', 'private')).toBe(false);
+  });
+
+  it('treats unknown visibility values as non-matching for specific filters', () => {
+    expect(matchesVisibilityFilter('', 'public')).toBe(false);
+    expect(matchesVisibilityFilter('SECRET', 'private')).toBe(false);
+    // …but the "all" filter still passes them through
+    expect(matchesVisibilityFilter('SECRET', 'all')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
Follow-up to SWR-366 (#61). The visibility-match rule — *which repo visibilities pass an `all | public | private` filter* — was duplicated as an inline predicate in **three** places in `src/ui/views/RepoList.tsx`. This extracts it into a single pure helper and adds the unit-test coverage that rule never had.

Resolves **SWR-372**.

> [!NOTE]
> **Stacked on #61.** Base branch is `claude/repo-caching-refresh-review-oxc7C` (the SWR-366 PR), which establishes the fully client-side filtering this helper consolidates. GitHub will auto-retarget this PR to `main` once #61 merges.

## Changes
- **`src/lib/utils.ts`** — new pure helper `matchesVisibilityFilter(visibility, filter)` (and exported `VisibilityFilter` type). Encodes the single source of truth, matching GitHub: the **Private** filter includes both `PRIVATE` and `INTERNAL`; `all` passes everything.
- **`src/ui/views/RepoList.tsx`** — the `filtered` memo, the `fuzzyItems` (search) memo, and `executeCreate`'s `passesVisibilityFilter` now all call the helper. No behavioural change; removes ~17 lines of duplicated predicate logic.
- **`tests/utils.test.ts`** — unit tests for the helper: `all` passes everything; `public` → only `PUBLIC`; `private` → `PRIVATE` **and** `INTERNAL` (not `PUBLIC`); unknown values handled.

## Why
The rule is the heart of SWR-366 but lived inline in a large stateful component that no test renders, so it had zero regression coverage (which is how the related eviction bugs slipped through). Extracting it makes the rule testable, de-duplicates it, and gives a clean unit to assert against.

## Verification
- `pnpm build` ✅
- `pnpm test` ✅ — **237 passed** (+4 new), 24 files
- No user-facing behaviour change (pure refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with tests and no intended behavior change; risk is limited to subtle filter mismatches if call sites diverge later.
> 
> **Overview**
> Centralizes the repo list **visibility filter** rule (SWR-366 / SWR-372) by adding **`matchesVisibilityFilter`** and exported **`VisibilityFilter`** in `src/lib/utils.ts`, with **`private`** treating both `PRIVATE` and `INTERNAL` like GitHub.
> 
> **`RepoList`** now uses that helper in the main list filter, fuzzy search results, and post-create “would this repo show?” checks instead of three copies of the same inline logic—behavior should be unchanged.
> 
> **`tests/utils.test.ts`** adds unit coverage for `all` / `public` / `private` and unknown visibility strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76d54ccc0174e5c927b399fd6c19c3a2f279317e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced visibility filtering to ensure consistent application across repository views and search functionality for improved reliability.

* **Tests**
  * Added comprehensive test coverage for visibility filtering behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->