### PR TITLE
fix: correct layout overflow and show hidden selection count in Bulk Select + search (SWR-370) [semantic pr title]

### DIFF
--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -2125,7 +2125,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   const footerHeight = 4; // Footer with border + margin (flexible height)
   const containerPadding = 2; // Top and bottom padding inside container
   const contentHeight = Math.max(1, availableHeight - headerHeight - footerHeight - containerPadding);
-  const listHeight = Math.max(1, contentHeight - (filterMode ? 2 : 0) - 2);
+  const listHeight = Math.max(1, contentHeight - (filterMode ? 2 : 0) - (multiSelectMode ? 2 : 0) - 2);
 
   const spacingLines = density; // map density to spacer lines
 
@@ -2953,18 +2953,24 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
             />
 
             {/* Multi-select mode status bar */}
-            {multiSelectMode && (
-              <Box marginBottom={1} flexDirection="row" justifyContent="space-between">
-                <Text color="cyan" bold>
-                  {`[BULK SELECT] ${selectedRepos.size > 0 ? `${selectedRepos.size} selected` : 'No selection'}`}
-                </Text>
-                <Text color="gray">
-                  {selectedRepos.size > 0
-                    ? 'Space select · X unselect all · Ctrl+S star · Ctrl+A archive · Ctrl+V visibility · Del delete · B/Esc exit'
-                    : 'Space select · B/Esc exit'}
-                </Text>
-              </Box>
-            )}
+            {multiSelectMode && (() => {
+              const hiddenCount = filterActive
+                ? [...selectedRepos.keys()].filter(id => !visibleItems.some(r => r.id === id)).length
+                : 0;
+              const selectionLabel = selectedRepos.size > 0
+                ? `${selectedRepos.size} selected${hiddenCount > 0 ? ` (${hiddenCount} not shown in search)` : ''}`
+                : 'No selection';
+              return (
+                <Box marginBottom={1} flexDirection="row" justifyContent="space-between">
+                  <Text color="cyan" bold>{`[BULK SELECT] ${selectionLabel}`}</Text>
+                  <Text color="gray">
+                    {selectedRepos.size > 0
+                      ? 'Space select · X unselect all · Ctrl+S star · Ctrl+A archive · Ctrl+V visibility · Del delete · B/Esc exit'
+                      : 'Space select · B/Esc exit'}
+                  </Text>
+                </Box>
+              );
+            })()}
 
             {/* Filter input */}
             {filterMode && (
@@ -3094,7 +3100,12 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
             <Text color={multiSelectMode ? 'cyan' : 'gray'} dimColor={!multiSelectMode}>
               {multiSelectMode
                 ? (selectedRepos.size > 0
-                    ? `Space select • X unselect all • Ctrl+S star • Ctrl+A archive • Ctrl+V visibility • Del delete • B/Esc exit (${selectedRepos.size} selected)`
+                    ? (() => {
+                        const hiddenCount = filterActive
+                          ? [...selectedRepos.keys()].filter(id => !visibleItems.some(r => r.id === id)).length
+                          : 0;
+                        return `Space select • X unselect all • Ctrl+S star • Ctrl+A archive • Ctrl+V visibility • Del delete • B/Esc exit (${selectedRepos.size} selected${hiddenCount > 0 ? `, ${hiddenCount} not in search` : ''})`;
+                      })()
                     : 'B/Esc exit bulk select • Space select (no selection)')
                 : 'B Bulk Select mode (star/archive/visibility/delete)'
               }

--- a/tests/ui/BulkSelectSearch.test.tsx
+++ b/tests/ui/BulkSelectSearch.test.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from 'ink-testing-library';
+import { Box, Text } from 'ink';
+import type { RepoNode } from '../../src/types';
+
+const makeRepo = (id: string, name: string): RepoNode => ({
+  id,
+  name,
+  nameWithOwner: `user/${name}`,
+  description: null,
+  isArchived: false,
+  isPrivate: false,
+  isFork: false,
+  stargazerCount: 0,
+  forkCount: 0,
+  primaryLanguage: null,
+  updatedAt: '2024-01-01T00:00:00Z',
+  pushedAt: '2024-01-01T00:00:00Z',
+  diskUsage: 0,
+  visibility: 'PUBLIC',
+});
+
+// Inline the "hidden by search" computation from RepoList so we can unit-test it
+function computeHiddenCount(
+  selectedRepos: Map<string, RepoNode>,
+  visibleItems: RepoNode[],
+  filterActive: boolean,
+): number {
+  if (!filterActive) return 0;
+  return [...selectedRepos.keys()].filter(id => !visibleItems.some(r => r.id === id)).length;
+}
+
+// Minimal status bar component that mirrors the bulk-select status bar in RepoList
+function BulkStatusBar({
+  selectedRepos,
+  visibleItems,
+  filterActive,
+}: {
+  selectedRepos: Map<string, RepoNode>;
+  visibleItems: RepoNode[];
+  filterActive: boolean;
+}) {
+  const hiddenCount = computeHiddenCount(selectedRepos, visibleItems, filterActive);
+  const selectionLabel = selectedRepos.size > 0
+    ? `${selectedRepos.size} selected${hiddenCount > 0 ? ` (${hiddenCount} not shown in search)` : ''}`
+    : 'No selection';
+  return (
+    <Box>
+      <Text>{`[BULK SELECT] ${selectionLabel}`}</Text>
+    </Box>
+  );
+}
+
+describe('BulkSelectSearch — hidden-count computation', () => {
+  it('returns 0 when filterActive is false regardless of selection', () => {
+    const repos = [makeRepo('1', 'alpha'), makeRepo('2', 'beta')];
+    const selected = new Map([['1', repos[0]], ['2', repos[1]]]);
+    expect(computeHiddenCount(selected, [], false)).toBe(0);
+  });
+
+  it('returns 0 when all selected repos are visible', () => {
+    const repos = [makeRepo('1', 'alpha'), makeRepo('2', 'beta')];
+    const selected = new Map([['1', repos[0]]]);
+    expect(computeHiddenCount(selected, repos, true)).toBe(0);
+  });
+
+  it('returns correct count of selected repos not in visibleItems', () => {
+    const allRepos = [makeRepo('1', 'alpha'), makeRepo('2', 'beta'), makeRepo('3', 'gamma')];
+    // visibleItems contains only repo 1 (the search matched only "alpha")
+    const visibleItems = [allRepos[0]];
+    // user had selected repos 1, 2, and 3 before the search narrowed the view
+    const selected = new Map(allRepos.map(r => [r.id, r]));
+    expect(computeHiddenCount(selected, visibleItems, true)).toBe(2);
+  });
+
+  it('returns count equal to selection size when no selected repos are visible', () => {
+    const repos = [makeRepo('1', 'alpha'), makeRepo('2', 'beta')];
+    const selected = new Map([['1', repos[0]], ['2', repos[1]]]);
+    // search returns nothing from the selection
+    const visibleItems = [makeRepo('99', 'zeta')];
+    expect(computeHiddenCount(selected, visibleItems, true)).toBe(2);
+  });
+});
+
+describe('BulkStatusBar rendering', () => {
+  it('shows "No selection" when nothing is selected', () => {
+    const { lastFrame, unmount } = render(
+      <BulkStatusBar
+        selectedRepos={new Map()}
+        visibleItems={[]}
+        filterActive={false}
+      />
+    );
+    expect(lastFrame()).toContain('[BULK SELECT] No selection');
+    unmount();
+  });
+
+  it('shows selected count without hidden note when search is not active', () => {
+    const repo = makeRepo('1', 'alpha');
+    const { lastFrame, unmount } = render(
+      <BulkStatusBar
+        selectedRepos={new Map([['1', repo]])}
+        visibleItems={[repo]}
+        filterActive={false}
+      />
+    );
+    const output = lastFrame() || '';
+    expect(output).toContain('1 selected');
+    expect(output).not.toContain('not shown in search');
+    unmount();
+  });
+
+  it('shows hidden count when search hides some selected repos', () => {
+    const allRepos = [makeRepo('1', 'alpha'), makeRepo('2', 'beta'), makeRepo('3', 'gamma')];
+    const selected = new Map(allRepos.map(r => [r.id, r]));
+    const visibleItems = [allRepos[0]]; // only "alpha" matches the search
+
+    const { lastFrame, unmount } = render(
+      <BulkStatusBar
+        selectedRepos={selected}
+        visibleItems={visibleItems}
+        filterActive={true}
+      />
+    );
+    const output = lastFrame() || '';
+    expect(output).toContain('3 selected');
+    expect(output).toContain('2 not shown in search');
+    unmount();
+  });
+
+  it('does not show hidden note when all selected repos are in search results', () => {
+    const repos = [makeRepo('1', 'alpha'), makeRepo('2', 'beta')];
+    const selected = new Map(repos.map(r => [r.id, r]));
+
+    const { lastFrame, unmount } = render(
+      <BulkStatusBar
+        selectedRepos={selected}
+        visibleItems={repos}
+        filterActive={true}
+      />
+    );
+    const output = lastFrame() || '';
+    expect(output).toContain('2 selected');
+    expect(output).not.toContain('not shown in search');
+    unmount();
+  });
+});

--- a/tests/ui/RepoRow.test.tsx
+++ b/tests/ui/RepoRow.test.tsx
@@ -37,5 +37,63 @@ describe('RepoRow', () => {
     expect(output).toMatch(/TypeScript/);
     unmount();
   });
+
+  it('does not show a checkbox when multiSelectMode is false', () => {
+    const { lastFrame, unmount } = render(
+      <RepoRow
+        repo={repoStub}
+        selected={false}
+        index={1}
+        maxWidth={80}
+        spacingLines={0}
+        forkTracking={false}
+        multiSelectMode={false}
+      />
+    );
+
+    const output = lastFrame() || '';
+    expect(output).not.toContain('[');
+    expect(output).not.toContain('✓');
+    unmount();
+  });
+
+  it('shows unchecked checkbox when multiSelectMode is true and not checked', () => {
+    const { lastFrame, unmount } = render(
+      <RepoRow
+        repo={repoStub}
+        selected={false}
+        index={1}
+        maxWidth={80}
+        spacingLines={0}
+        forkTracking={false}
+        multiSelectMode={true}
+        isChecked={false}
+      />
+    );
+
+    const output = lastFrame() || '';
+    expect(output).toContain('[ ]');
+    expect(output).not.toContain('✓');
+    unmount();
+  });
+
+  it('shows checked checkbox when multiSelectMode is true and checked', () => {
+    const { lastFrame, unmount } = render(
+      <RepoRow
+        repo={repoStub}
+        selected={false}
+        index={1}
+        maxWidth={80}
+        spacingLines={0}
+        forkTracking={false}
+        multiSelectMode={true}
+        isChecked={true}
+      />
+    );
+
+    const output = lastFrame() || '';
+    expect(output).toContain('[✓]');
+    unmount();
+  });
 });
 


### PR DESCRIPTION
Assignee: @wiiiimm ([William Li](https://linear.app/stealths/profiles/wiiiimm))

## Summary

Fixes two bugs that together caused the UI corruption described in [SWR-370](https://linear.app/stealths/issue/SWR-370/bulk-select-mode-after-a-search-corrupts-the-ui-and-obscures-whats):

### Bug 1 — Layout overflow / UI corruption

When `multiSelectMode` was entered after a fuzzy search, the 2-row Bulk Select status bar was rendered but **not subtracted from `listHeight`**. This caused the repo list box to be 2 rows taller than the available space, overflowing the terminal and producing garbled output.

**Fix:** `listHeight` now subtracts 2 when `multiSelectMode` is active:
```ts
const listHeight = Math.max(1, contentHeight - (filterMode ? 2 : 0) - (multiSelectMode ? 2 : 0) - 2);
```

### Bug 2 — Selection state not legible when search hides repos

When a fuzzy search narrowed the visible list, previously-selected repos that no longer matched the search were invisible — yet counted in the status bar as "selected". This made it impossible to trust what was actually selected.

**Fix:** The status bar and footer hint now compute how many selected repos are absent from the current search results and surface that count:
- Status bar: `3 selected (2 not shown in search)`
- Footer hint: `… (3 selected, 2 not in search)`

## Test plan

- [x] 244 tests pass (`npx vitest run`)
- [x] Build succeeds (`npx tsup`)
- [x] New `tests/ui/BulkSelectSearch.test.tsx` — 8 tests covering: hidden-count logic when filter inactive, all selected visible, partial hidden, all hidden; status bar renders No selection / count-only / count-with-hidden / count-no-hidden-note
- [x] Extended `tests/ui/RepoRow.test.tsx` — 3 new tests: no checkbox when `multiSelectMode=false`, unchecked `[ ]` box, checked `[✓]` box
- [ ] Manual verification across iTerm2, Terminal.app, Termius (per issue checklist)

---
> **Tip:** I will respond to comments that @ mention @cyrus-mini-5 on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal UI layout and copy only; no API, auth, or data-path changes. Risk is limited to list height math and bulk-select messaging.
> 
> **Overview**
> Fixes **bulk select + fuzzy search** layout corruption and unclear selection counts (SWR-370).
> 
> **Layout:** `listHeight` now reserves **2 rows** when `multiSelectMode` is on (same as filter mode), so the bulk status bar no longer pushes the repo list past the terminal and garbles the UI.
> 
> **Selection clarity:** While search is active, the bulk status bar and footer hint report how many selected repos are **not in current results** (e.g. `3 selected (2 not shown in search)` / `, 2 not in search`).
> 
> **Tests:** New `BulkSelectSearch.test.tsx` for hidden-count logic and status-bar copy; `RepoRow.test.tsx` extended for bulk checkbox rendering (`[ ]` / `[✓]`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cf76545dca0022efc0e283482d30d701cb97e59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The bulk-selection status bar now displays how many of your selected repositories are hidden by the active search or filter.

* **Tests**
  * Extended test coverage for multi-select checkbox rendering behaviour.
  * Extended test coverage for bulk-selection count logic and status bar messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->