### PR TITLE
refactor: extract visibility-filter predicate into a tested pure helper (SWR-372) [semantic pr title]

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -176,3 +176,20 @@ export async function copyToClipboard(text: string): Promise<void> {
   }
 }
 
+/** Visibility filter states used across the repository list (SWR-366). */
+export type VisibilityFilter = 'all' | 'public' | 'private';
+
+/**
+ * Whether a repository of the given visibility passes a visibility filter.
+ *
+ * Visibility is filtered client-side over the full cached set (SWR-366). This
+ * encodes the single source of truth for that rule, matching GitHub's own
+ * behaviour: the "private" filter includes both PRIVATE and INTERNAL
+ * repositories, and "all" passes everything.
+ */
+export function matchesVisibilityFilter(visibility: string, filter: VisibilityFilter): boolean {
+  if (filter === 'public') return visibility === 'PUBLIC';
+  if (filter === 'private') return visibility === 'PRIVATE' || visibility === 'INTERNAL';
+  return true; // 'all'
+}
+

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -17,7 +17,7 @@ import type { BulkAction, BulkVisibilityTarget, BulkProgressState } from '../com
 import { UnstarModal } from '../components/modals/UnstarModal';
 import { RepoRow, FilterInput, RepoListHeader } from '../components/repo';
 import { SlowSpinner } from '../components/common';
-import { truncate, formatDate, copyToClipboard, computeWindow } from '../../lib/utils';
+import { truncate, formatDate, copyToClipboard, computeWindow, matchesVisibilityFilter } from '../../lib/utils';
 
 // Allow customizable repos per fetch via env var (1-50, default 15)
 const getPageSize = () => {
@@ -757,10 +757,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     // reset to 'all' so it isn't filtered out of the list. The client-side
     // 'private' filter includes both PRIVATE and INTERNAL (matching GitHub and
     // executeVisibilityChange), so an INTERNAL repo passes it.
-    const passesVisibilityFilter =
-      visibilityFilter === 'all' ||
-      (visibilityFilter === 'public' && visibility === 'PUBLIC') ||
-      (visibilityFilter === 'private' && (visibility === 'PRIVATE' || visibility === 'INTERNAL'));
+    const passesVisibilityFilter = matchesVisibilityFilter(visibility, visibilityFilter);
     if (!passesVisibilityFilter) {
       storeUIPrefs({ visibilityFilter: 'all' });
       setVisibilityFilter('all');
@@ -2065,14 +2062,12 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     let result = items;
     
     // Apply visibility filter locally over the full cached set (SWR-366).
-    // Match GitHub's behaviour: Private filter includes both PRIVATE and INTERNAL.
-    if (visibilityFilter === 'private') {
-      // Show both PRIVATE and INTERNAL repos (matching GitHub's behaviour)
-      result = result.filter(r => r.visibility === 'PRIVATE' || r.visibility === 'INTERNAL');
-    } else if (visibilityFilter === 'public') {
-      result = result.filter(r => r.visibility === 'PUBLIC');
+    // matchesVisibilityFilter encodes GitHub's behaviour (Private includes
+    // PRIVATE and INTERNAL); 'all' is a no-op.
+    if (visibilityFilter !== 'all') {
+      result = result.filter(r => matchesVisibilityFilter(r.visibility, visibilityFilter));
     }
-    
+
     // Apply archive filter
     if (archiveFilter === 'archived') {
       result = result.filter(r => r.isArchived);
@@ -2110,10 +2105,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   const fuzzyItems = useMemo(() => {
     if (!filterActive) return [];
     let results = fuzzySearch(items, filter);
-    if (visibilityFilter === 'private') {
-      results = results.filter(r => r.visibility === 'PRIVATE' || r.visibility === 'INTERNAL');
-    } else if (visibilityFilter === 'public') {
-      results = results.filter(r => r.visibility === 'PUBLIC');
+    if (visibilityFilter !== 'all') {
+      results = results.filter(r => matchesVisibilityFilter(r.visibility, visibilityFilter));
     }
     if (archiveFilter === 'archived') results = results.filter(r => r.isArchived);
     else if (archiveFilter === 'unarchived') results = results.filter(r => !r.isArchived);

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -17,7 +17,7 @@ import type { BulkAction, BulkVisibilityTarget, BulkProgressState } from '../com
 import { UnstarModal } from '../components/modals/UnstarModal';
 import { RepoRow, FilterInput, RepoListHeader } from '../components/repo';
 import { SlowSpinner } from '../components/common';
-import { truncate, formatDate, copyToClipboard, computeWindow, matchesVisibilityFilter } from '../../lib/utils';
+import { truncate, formatDate, copyToClipboard, computeWindow, matchesVisibilityFilter, type VisibilityFilter } from '../../lib/utils';
 
 // Allow customizable repos per fetch via env var (1-50, default 15)
 const getPageSize = () => {
@@ -1134,8 +1134,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     }
   }
 
-  // Visibility filter - 'all' | 'public' | 'private'
-  type VisibilityFilter = 'all' | 'public' | 'private';
+  // Visibility filter - 'all' | 'public' | 'private' (VisibilityFilter type
+  // shared from lib/utils, see import above)
   const [visibilityFilter, setVisibilityFilter] = useState<VisibilityFilter>('all');
   // nameWithOwner of a repo queued to receive cursor focus once it appears in
   // the (re-sorted/filtered) visible list — e.g. a freshly created repo, whose

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { truncate, formatDate, computeWindow } from '../src/lib/utils';
+import { truncate, formatDate, computeWindow, matchesVisibilityFilter } from '../src/lib/utils';
 
 describe('truncate', () => {
   it('returns string unchanged if shorter than max', () => {
@@ -237,5 +237,32 @@ describe('computeWindow – out-of-range cursor safety', () => {
   it('returns an empty window for an empty list', () => {
     expect(computeWindow([], 0, 20, 0)).toEqual({ start: 0, end: 0 });
     expect(computeWindow([], 5, 20, 1)).toEqual({ start: 0, end: 0 });
+  });
+});
+
+describe('matchesVisibilityFilter', () => {
+  it('passes every visibility when the filter is "all"', () => {
+    expect(matchesVisibilityFilter('PUBLIC', 'all')).toBe(true);
+    expect(matchesVisibilityFilter('PRIVATE', 'all')).toBe(true);
+    expect(matchesVisibilityFilter('INTERNAL', 'all')).toBe(true);
+  });
+
+  it('passes only PUBLIC repos when the filter is "public"', () => {
+    expect(matchesVisibilityFilter('PUBLIC', 'public')).toBe(true);
+    expect(matchesVisibilityFilter('PRIVATE', 'public')).toBe(false);
+    expect(matchesVisibilityFilter('INTERNAL', 'public')).toBe(false);
+  });
+
+  it('passes PRIVATE and INTERNAL when the filter is "private" (matching GitHub)', () => {
+    expect(matchesVisibilityFilter('PRIVATE', 'private')).toBe(true);
+    expect(matchesVisibilityFilter('INTERNAL', 'private')).toBe(true);
+    expect(matchesVisibilityFilter('PUBLIC', 'private')).toBe(false);
+  });
+
+  it('treats unknown visibility values as non-matching for specific filters', () => {
+    expect(matchesVisibilityFilter('', 'public')).toBe(false);
+    expect(matchesVisibilityFilter('SECRET', 'private')).toBe(false);
+    // …but the "all" filter still passes them through
+    expect(matchesVisibilityFilter('SECRET', 'all')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Extracts the visibility-match rule — which repo visibilities pass an `all | public | private` filter — into a single pure helper `matchesVisibilityFilter(visibility, filter)` in `src/lib/utils.ts`, and unit-tests it. The rule (including GitHub's behaviour that the **Private** filter includes both `PRIVATE` and `INTERNAL`) was previously duplicated as an inline predicate in three places in `RepoList.tsx` with no test coverage:

1. the `filtered` memo (main list)
2. the `fuzzyItems` memo (search results)
3. `passesVisibilityFilter` in `executeCreate` (repo-creation filter reconciliation)

All three now call the shared helper. The local `VisibilityFilter` type in `RepoList.tsx` is also removed in favour of the one exported alongside the helper, so the rule and its type have a single source of truth. No user-facing behaviour change — pure refactor + test-coverage improvement.

## Acceptance criteria (SWR-372)

- [x] `matchesVisibilityFilter` added to `src/lib/utils.ts` (pure, no React/Apollo deps)
- [x] `filtered`, `fuzzyItems`, and `executeCreate`'s `passesVisibilityFilter` all use the helper — no behavioural change
- [x] Unit tests cover: `all` passes everything; `public` → only `PUBLIC`; `private` → `PRIVATE` **and** `INTERNAL` (not `PUBLIC`); plus an unknown-visibility edge case
- [x] `pnpm build` and `pnpm test` green (280 tests pass)

## Notes

Supersedes #72, which auto-closed when its stacked base branch (the SWR-366 branch, #61) was merged into `main` and deleted. This branch is the same two commits rebased cleanly onto current `main`, so the diff is just the three SWR-372 files with no SWR-366 carry-over. See #72 for the original review discussion.

Closes SWR-372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with unit tests; list filtering and create-reconcile logic should behave the same as before.
> 
> **Overview**
> Centralizes the repo list **visibility filter** rule (`all` | `public` | `private`) in **`matchesVisibilityFilter`** and exported **`VisibilityFilter`** in `src/lib/utils.ts`, including GitHub-aligned behavior where **private** matches both `PRIVATE` and `INTERNAL`.
> 
> **`RepoList.tsx`** drops three inline copies of that logic—the main `filtered` memo, fuzzy-search `fuzzyItems`, and post-create `passesVisibilityFilter` in `executeCreate`—and uses the shared helper instead. The local `VisibilityFilter` type is removed in favor of the utils export.
> 
> Adds **unit tests** in `tests/utils.test.ts` for `all` / `public` / `private` and unknown visibility values. **No intended user-facing behavior change**—refactor plus test coverage (SWR-372).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fed1f559b37acb76f65a6aea7b877e1b6e6b3c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->