### PR TITLE
fix: keep bulk review visibility badge inline with highlight background (SWR-374) [semantic pr title]

### DIFF
--- a/src/ui/components/modals/BulkReviewModal.tsx
+++ b/src/ui/components/modals/BulkReviewModal.tsx
@@ -130,15 +130,29 @@ export default function BulkReviewModal({
           {localRepos.slice(listStart, listEnd).map((repo, relIdx) => {
             const absIdx = listStart + relIdx;
             const isCursorRow = focusArea === 'list' && absIdx === listCursor;
+            // Visibility / archived badges, composed up-front so the highlighted
+            // row can include them inside its background segment — they must stay
+            // inline with the name rather than wrapping onto the next line.
+            const visText = repo.isPrivate
+              ? ' Private'
+              : repo.visibility === 'INTERNAL'
+                ? ' Internal'
+                : '';
+            const archText = repo.isArchived ? ' Archived' : '';
             let line = '';
             if (isCursorRow) {
-              line += chalk.bgCyan.black(` ✓ ${repo.nameWithOwner.padEnd(Math.max(0, modalWidth - 10))} `);
+              // One highlighted segment: name + badges + trailing pad, so the
+              // background spans the whole row and the badges never wrap.
+              const content = ` ✓ ${repo.nameWithOwner}${visText}${archText} `;
+              const target = Math.max(0, modalWidth - 6);
+              const padded =
+                content.length < target ? content + ' '.repeat(target - content.length) : content;
+              line += chalk.bgCyan.black(padded);
             } else {
               line += chalk.cyan(' ✓ ') + chalk.white(repo.nameWithOwner);
+              if (visText) line += (repo.isPrivate ? chalk.yellow : chalk.magenta)(visText);
+              if (archText) line += chalk.gray(archText);
             }
-            if (repo.isPrivate) line += chalk.yellow(' Private');
-            else if (repo.visibility === 'INTERNAL') line += chalk.magenta(' Internal');
-            if (repo.isArchived) line += chalk.gray(' Archived');
             return (
               <Box key={repo.id}>
                 <Text>{line}</Text>

--- a/tests/ui/BulkReviewModal.test.tsx
+++ b/tests/ui/BulkReviewModal.test.tsx
@@ -12,7 +12,11 @@ vi.mock('ink', async () => {
   return { ...actual, useInput: vi.fn() };
 });
 
-function repo(id: string, nameWithOwner: string): RepoNode {
+function repo(
+  id: string,
+  nameWithOwner: string,
+  overrides: Partial<RepoNode> = {},
+): RepoNode {
   return {
     id,
     nameWithOwner,
@@ -20,6 +24,7 @@ function repo(id: string, nameWithOwner: string): RepoNode {
     isPrivate: false,
     visibility: 'PUBLIC',
     isArchived: false,
+    ...overrides,
   } as unknown as RepoNode;
 }
 
@@ -52,6 +57,50 @@ describe('BulkReviewModal', () => {
     expect(out).toContain('me/alpha');
     expect(out).toContain('me/beta');
     expect(out).toContain('2 repositories selected');
+    unmount();
+  });
+
+  it('keeps the visibility badge inline with the name on the highlighted row, sharing the highlight background', () => {
+    // The first repo is the highlighted (cursor) row by default. Regression for
+    // SWR-374: the badge must not wrap to the next line and must sit inside the
+    // background-highlighted segment.
+    const { lastFrame, unmount } = render(
+      <BulkReviewModal
+        selectedRepos={makeSelection(
+          repo('1', 'me/secret', { isPrivate: true, visibility: 'PRIVATE' }),
+          repo('2', 'me/beta'),
+        )}
+        actionLabel="Delete"
+        actionColor="red"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const out = lastFrame() || '';
+    const nameLine = out.split('\n').find(l => l.includes('me/secret')) || '';
+    // Same visual line as the name (would be on a separate wrapped line if broken).
+    expect(nameLine).toContain('Private');
+    // bgCyan open code ([46m) is present on that line → badge is highlighted.
+    expect(nameLine).toContain('[46m');
+    unmount();
+  });
+
+  it('shows the Internal badge inline for an internal repo on the highlighted row', () => {
+    const { lastFrame, unmount } = render(
+      <BulkReviewModal
+        selectedRepos={makeSelection(
+          repo('1', 'org/intra', { visibility: 'INTERNAL' }),
+        )}
+        actionLabel="Archive"
+        actionColor="yellow"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    const out = lastFrame() || '';
+    const nameLine = out.split('\n').find(l => l.includes('org/intra')) || '';
+    expect(nameLine).toContain('Internal');
+    expect(nameLine).toContain('[46m');
     unmount();
   });
 

--- a/tests/ui/BulkReviewModal.test.tsx
+++ b/tests/ui/BulkReviewModal.test.tsx
@@ -79,9 +79,8 @@ describe('BulkReviewModal', () => {
     const out = lastFrame() || '';
     const nameLine = out.split('\n').find(l => l.includes('me/secret')) || '';
     // Same visual line as the name (would be on a separate wrapped line if broken).
-    expect(nameLine).toContain('Private');
     // bgCyan open code ([46m) is present on that line → badge is highlighted.
-    expect(nameLine).toContain('[46m');
+    expect(nameLine).toMatch(/\x1b\[46m[^\n]*Private/);
     unmount();
   });
 
@@ -99,8 +98,7 @@ describe('BulkReviewModal', () => {
     );
     const out = lastFrame() || '';
     const nameLine = out.split('\n').find(l => l.includes('org/intra')) || '';
-    expect(nameLine).toContain('Internal');
-    expect(nameLine).toContain('[46m');
+    expect(nameLine).toMatch(/\x1b\[46m[^\n]*Internal/);
     unmount();
   });
 


### PR DESCRIPTION
## Summary

Fixes [SWR-374](https://linear.app/stealths/issue/SWR-374/bulk-select-confirmation-modal-visibility-badge-wraps-to-next-line-and).

In Bulk Select mode's selected-repo review modal (`BulkReviewModal` — the shared modal reused by **all** bulk actions: delete, archive/unarchive, change visibility, transfer), the visibility badge (`Private` / `Internal`) on the **highlighted** row was pushed onto the next line and rendered **without** the highlight background.

**Root cause:** the highlighted row padded the repo name to nearly the full modal width inside the `bgCyan` segment, then appended the badge *after* that padding and *outside* the `chalk.bgCyan.black(...)` call — so it had no room (wrapped) and no background.

**Fix:** compose the name + visibility/archived badges into a single string, then pad-and-background the whole thing in one `chalk.bgCyan.black(...)` call. The badge now stays inline with the name and shares the highlighted background. Non-highlighted rows keep their coloured badge text (yellow `Private` / magenta `Internal` / gray `Archived`) unchanged.

## Changes

- `src/ui/components/modals/BulkReviewModal.tsx` — recompose the highlighted-row line so badges are inside the background segment and counted toward padding.
- `tests/ui/BulkReviewModal.test.tsx` — add regression tests asserting the `Private` / `Internal` badge stays on the same line as the name and carries the `bgCyan` highlight code.

## Testing

- `pnpm vitest run` — all 285 tests pass (7 in `BulkReviewModal`, incl. 2 new).
- `pnpm build` — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal UI rendering only in the bulk review modal; behavior for non-highlighted rows is unchanged and covered by new tests.
> 
> **Overview**
> Fixes **SWR-374** in `BulkReviewModal`: on the **cursor/highlighted** repo row, `Private` / `Internal` / `Archived` badges were drawn **after** a full-width `bgCyan` segment (name-only padding), so they wrapped to the next line and lost the highlight.
> 
> The highlighted row now builds **one** string (`✓ name + badges`), pads to modal width, and wraps it in a **single** `chalk.bgCyan.black(...)` call so badges stay on the same line and share the background. Non-highlighted rows still use yellow/magenta/gray badge styling unchanged.
> 
> Tests add a `repo()` override helper and two regressions asserting `Private` and `Internal` appear on the same line as the name with the cyan background ANSI code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cd4dc36fb0e85c8d2ea0e945c409ec1d9bb2beb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed visibility badges ("Private", "Internal") in the bulk review modal that were wrapping to a separate line; they now display inline with the highlighted row.

* **Tests**
  * Added UI regression tests to verify visibility badge display and positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->