### PR TITLE
fix: correct Bulk Select layout overflow and show hidden selection count (SWR-370) [semantic pr title]

### DIFF
--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -2175,7 +2175,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   const footerHeight = 4; // Footer with border + margin (flexible height)
   const containerPadding = 2; // Top and bottom padding inside container
   const contentHeight = Math.max(1, availableHeight - headerHeight - footerHeight - containerPadding);
-  const listHeight = Math.max(1, contentHeight - (filterMode ? 2 : 0) - 2);
+  const listHeight = Math.max(1, contentHeight - (filterMode ? 2 : 0) - (multiSelectMode ? 2 : 0) - 2);
 
   const spacingLines = density; // map density to spacer lines
 
@@ -3041,18 +3041,24 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
             />
 
             {/* Multi-select mode status bar */}
-            {multiSelectMode && (
-              <Box marginBottom={1} flexDirection="row" justifyContent="space-between">
-                <Text color="cyan" bold>
-                  {`[BULK SELECT] ${selectedRepos.size > 0 ? `${selectedRepos.size} selected` : 'No selection'}`}
-                </Text>
-                <Text color="gray">
-                  {selectedRepos.size > 0
-                    ? `Space select · X unselect all · Ctrl+S star · Ctrl+A archive · Ctrl+V visibility${starsMode ? '' : ' · Shift+M transfer'} · Del delete · B/Esc exit`
-                    : 'Space select · B/Esc exit'}
-                </Text>
-              </Box>
-            )}
+            {multiSelectMode && (() => {
+              const hiddenCount = filterActive
+                ? [...selectedRepos.keys()].filter(id => !visibleItems.some(r => r.id === id)).length
+                : 0;
+              const selectionLabel = selectedRepos.size > 0
+                ? `${selectedRepos.size} selected${hiddenCount > 0 ? ` (${hiddenCount} not shown in search)` : ''}`
+                : 'No selection';
+              return (
+                <Box marginBottom={1} flexDirection="row" justifyContent="space-between">
+                  <Text color="cyan" bold>{`[BULK SELECT] ${selectionLabel}`}</Text>
+                  <Text color="gray">
+                    {selectedRepos.size > 0
+                      ? `Space select · X unselect all · Ctrl+S star · Ctrl+A archive · Ctrl+V visibility${starsMode ? '' : ' · Shift+M transfer'} · Del delete · B/Esc exit`
+                      : 'Space select · B/Esc exit'}
+                  </Text>
+                </Box>
+              );
+            })()}
 
             {/* Filter input */}
             {filterMode && (
@@ -3182,7 +3188,12 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
             <Text color={multiSelectMode ? 'cyan' : 'gray'} dimColor={!multiSelectMode}>
               {multiSelectMode
                 ? (selectedRepos.size > 0
-                    ? `Space select • X unselect all • Ctrl+S star • Ctrl+A archive • Ctrl+V visibility${starsMode ? '' : ' • Shift+M transfer'} • Del delete • B/Esc exit (${selectedRepos.size} selected)`
+                    ? (() => {
+                        const hiddenCount = filterActive
+                          ? [...selectedRepos.keys()].filter(id => !visibleItems.some(r => r.id === id)).length
+                          : 0;
+                        return `Space select • X unselect all • Ctrl+S star • Ctrl+A archive • Ctrl+V visibility${starsMode ? '' : ' • Shift+M transfer'} • Del delete • B/Esc exit (${selectedRepos.size} selected${hiddenCount > 0 ? `, ${hiddenCount} not in search` : ''})`;
+                      })()
                     : 'B/Esc exit bulk select • Space select (no selection)')
                 : 'B Bulk Select mode (star/archive/visibility/delete)'
               }

--- a/tests/ui/BulkSelectSearch.test.tsx
+++ b/tests/ui/BulkSelectSearch.test.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from 'ink-testing-library';
+import { Box, Text } from 'ink';
+import type { RepoNode } from '../../src/types';
+
+const makeRepo = (id: string, name: string): RepoNode => ({
+  id,
+  name,
+  nameWithOwner: `user/${name}`,
+  description: null,
+  isArchived: false,
+  isPrivate: false,
+  isFork: false,
+  stargazerCount: 0,
+  forkCount: 0,
+  primaryLanguage: null,
+  updatedAt: '2024-01-01T00:00:00Z',
+  pushedAt: '2024-01-01T00:00:00Z',
+  diskUsage: 0,
+  visibility: 'PUBLIC',
+});
+
+// Inline the "hidden by search" computation from RepoList so we can unit-test it
+function computeHiddenCount(
+  selectedRepos: Map<string, RepoNode>,
+  visibleItems: RepoNode[],
+  filterActive: boolean,
+): number {
+  if (!filterActive) return 0;
+  return [...selectedRepos.keys()].filter(id => !visibleItems.some(r => r.id === id)).length;
+}
+
+// Minimal status bar component that mirrors the bulk-select status bar in RepoList
+function BulkStatusBar({
+  selectedRepos,
+  visibleItems,
+  filterActive,
+}: {
+  selectedRepos: Map<string, RepoNode>;
+  visibleItems: RepoNode[];
+  filterActive: boolean;
+}) {
+  const hiddenCount = computeHiddenCount(selectedRepos, visibleItems, filterActive);
+  const selectionLabel = selectedRepos.size > 0
+    ? `${selectedRepos.size} selected${hiddenCount > 0 ? ` (${hiddenCount} not shown in search)` : ''}`
+    : 'No selection';
+  return (
+    <Box>
+      <Text>{`[BULK SELECT] ${selectionLabel}`}</Text>
+    </Box>
+  );
+}
+
+describe('BulkSelectSearch — hidden-count computation', () => {
+  it('returns 0 when filterActive is false regardless of selection', () => {
+    const repos = [makeRepo('1', 'alpha'), makeRepo('2', 'beta')];
+    const selected = new Map([['1', repos[0]], ['2', repos[1]]]);
+    expect(computeHiddenCount(selected, [], false)).toBe(0);
+  });
+
+  it('returns 0 when all selected repos are visible', () => {
+    const repos = [makeRepo('1', 'alpha'), makeRepo('2', 'beta')];
+    const selected = new Map([['1', repos[0]]]);
+    expect(computeHiddenCount(selected, repos, true)).toBe(0);
+  });
+
+  it('returns correct count of selected repos not in visibleItems', () => {
+    const allRepos = [makeRepo('1', 'alpha'), makeRepo('2', 'beta'), makeRepo('3', 'gamma')];
+    // visibleItems contains only repo 1 (the search matched only "alpha")
+    const visibleItems = [allRepos[0]];
+    // user had selected repos 1, 2, and 3 before the search narrowed the view
+    const selected = new Map(allRepos.map(r => [r.id, r]));
+    expect(computeHiddenCount(selected, visibleItems, true)).toBe(2);
+  });
+
+  it('returns count equal to selection size when no selected repos are visible', () => {
+    const repos = [makeRepo('1', 'alpha'), makeRepo('2', 'beta')];
+    const selected = new Map([['1', repos[0]], ['2', repos[1]]]);
+    // search returns nothing from the selection
+    const visibleItems = [makeRepo('99', 'zeta')];
+    expect(computeHiddenCount(selected, visibleItems, true)).toBe(2);
+  });
+});
+
+describe('BulkStatusBar rendering', () => {
+  it('shows "No selection" when nothing is selected', () => {
+    const { lastFrame, unmount } = render(
+      <BulkStatusBar
+        selectedRepos={new Map()}
+        visibleItems={[]}
+        filterActive={false}
+      />
+    );
+    expect(lastFrame()).toContain('[BULK SELECT] No selection');
+    unmount();
+  });
+
+  it('shows selected count without hidden note when search is not active', () => {
+    const repo = makeRepo('1', 'alpha');
+    const { lastFrame, unmount } = render(
+      <BulkStatusBar
+        selectedRepos={new Map([['1', repo]])}
+        visibleItems={[repo]}
+        filterActive={false}
+      />
+    );
+    const output = lastFrame() || '';
+    expect(output).toContain('1 selected');
+    expect(output).not.toContain('not shown in search');
+    unmount();
+  });
+
+  it('shows hidden count when search hides some selected repos', () => {
+    const allRepos = [makeRepo('1', 'alpha'), makeRepo('2', 'beta'), makeRepo('3', 'gamma')];
+    const selected = new Map(allRepos.map(r => [r.id, r]));
+    const visibleItems = [allRepos[0]]; // only "alpha" matches the search
+
+    const { lastFrame, unmount } = render(
+      <BulkStatusBar
+        selectedRepos={selected}
+        visibleItems={visibleItems}
+        filterActive={true}
+      />
+    );
+    const output = lastFrame() || '';
+    expect(output).toContain('3 selected');
+    expect(output).toContain('2 not shown in search');
+    unmount();
+  });
+
+  it('does not show hidden note when all selected repos are in search results', () => {
+    const repos = [makeRepo('1', 'alpha'), makeRepo('2', 'beta')];
+    const selected = new Map(repos.map(r => [r.id, r]));
+
+    const { lastFrame, unmount } = render(
+      <BulkStatusBar
+        selectedRepos={selected}
+        visibleItems={repos}
+        filterActive={true}
+      />
+    );
+    const output = lastFrame() || '';
+    expect(output).toContain('2 selected');
+    expect(output).not.toContain('not shown in search');
+    unmount();
+  });
+});


### PR DESCRIPTION
## Summary

Forward-ports the SWR-370 fix from #73 onto current `main`. PR #73 was branched from `1.46.1` and, diffed against today's `main`, would revert bulk transfer (#70), session usage tracking (#58) and the visibility-filter refactor (#75). This branch is cut from current `main`, so it applies cleanly with no merge conflict and preserves all of those features (including the `Shift+M transfer` hints).

### Bug 1 — Layout overflow / UI corruption (the real bug)

The 2-row Bulk Select status bar was rendered but **never subtracted from `listHeight`**. Whenever `multiSelectMode` is active the repo-list box is 2 rows taller than its bordered container, overflowing the terminal and garbling the output. (This happens in *any* bulk-select state, not only after a search — search is just the easiest repro.)

**Fix:**
```ts
const listHeight = Math.max(1, contentHeight - (filterMode ? 2 : 0) - (multiSelectMode ? 2 : 0) - 2);
```
This restores the layout invariant `header + bars + listHeight = contentHeight` for every mode combination.

### Bug 2 — Selection count not legible when search hides repos

When a fuzzy search narrows the list, previously-selected repos that no longer match were invisible yet still counted. The status bar and footer now report how many selected repos are absent from current results:
- Status bar: `3 selected (2 not shown in search)`
- Footer hint: `… (3 selected, 2 not in search)`

## Test plan

- [x] `npx vitest run` — **291 tests pass** (incl. new `tests/ui/BulkSelectSearch.test.tsx`, 8 tests)
- [x] `pnpm build` succeeds
- [x] No conflict with `main` (branch cut from current `main`)
- [ ] Manual verification across iTerm2, Terminal.app, Termius

## Note

Supersedes #73, which can be closed (stale base). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal UI layout and selection messaging only; no API, auth, or bulk action behavior changes beyond clearer counts.
> 
> **Overview**
> Fixes **bulk select terminal layout** by reserving two rows for the bulk status bar in `listHeight` (same pattern as search filter mode), so the repo list no longer overflows its bordered container while bulk select is on.
> 
> When a **fuzzy search** is active, the bulk status bar and footer hint now report how many selected repos are **not in the current results** (e.g. `3 selected (2 not shown in search)`), while selection still uses the full `selectedRepos` map.
> 
> Adds **`tests/ui/BulkSelectSearch.test.tsx`** to cover the hidden-count logic and status-bar copy via a small mirror of the RepoList UI strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99f55e08685298bdce9e67788ccf04d044898095. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->