### PR TITLE
feat: redesign session usage summary as a distinct panel with time-saved estimate (SWR-375) [semantic pr title]

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ import pkg from '../package.json';
 import 'dotenv/config';
 import App from './ui/App';
 import { logger } from './lib/logger';
-import { formatSessionSummary } from './lib/session';
+import { formatSessionSummary, formatSupportMessage } from './lib/session';
 
 // Basic CLI flags (handled before rendering Ink)
 const argv = process.argv.slice(2);
@@ -87,17 +87,13 @@ const handleShutdown = (signal: string) => {
   process.exit(0);
 };
 
-// Function to show session summary and sponsorship message
+// Function to show the session usage summary followed by the (visually
+// separate) sponsorship message. Each is its own framed panel, so the summary
+// no longer piles onto the thank-you / sponsor block.
 const showSponsorshipMessage = () => {
   process.stdout.write(formatSessionSummary());
-  console.log('💚 Thank you for using gh-manager-cli!\n');
-  console.log('If this app saved you time, please consider supporting');
-  console.log('the development of more open-source projects like this:\n');
-  console.log('  💖 Sponsor on GitHub: https://github.com/sponsors/wiiiimm');
-  console.log('  🚀 Visit my site: https://wiiiimm.codes');
-  console.log('  💬 Leave feedback: https://github.com/wiiiimm/gh-manager-cli');
-  console.log('\nYour support keeps this project alive! 🙏\n');
-  console.log('─'.repeat(60) + '\n');
+  process.stdout.write(formatSupportMessage());
+  process.stdout.write('\n');
 };
 
 // Register shutdown handlers

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -72,6 +72,35 @@ const OPERATION_LABELS: Record<OperationType, string> = {
   transfer: 'transferred',
 };
 
+// Rough estimate of how long each operation takes to perform by hand in the
+// GitHub web UI (in seconds): navigating to the repo, opening Settings, the
+// Danger Zone confirmation dialogs, typing the repo name, etc. These are
+// deliberately conservative, round figures — the summary presents the result
+// as an approximation ("~"), not a precise measurement.
+const MANUAL_TIME_SECONDS: Record<OperationType, number> = {
+  delete: 45, // Settings → Danger Zone → type repo name → confirm
+  archive: 40, // Settings → Danger Zone → archive → confirm
+  unarchive: 40,
+  visibilityChange: 40, // Settings → Danger Zone → change visibility → confirm
+  syncFork: 20, // Open fork → "Sync fork" → update branch
+  rename: 30, // Settings → rename → confirm
+  star: 6, // Open repo → click star
+  unstar: 6,
+  transfer: 60, // Settings → Danger Zone → transfer → type name + new owner
+};
+
+// Estimate the time saved this session by doing the tracked operations in the
+// CLI instead of by hand on github.com. The per-keystroke cost in the CLI is
+// negligible next to the web UI's navigation + confirmation flows, so we treat
+// the manual time as the saving. Returns milliseconds.
+export function estimateTimeSavedMs(): number {
+  let seconds = 0;
+  for (const [type, n] of Object.entries(counts) as [OperationType, number][]) {
+    seconds += n * MANUAL_TIME_SECONDS[type];
+  }
+  return seconds * 1000;
+}
+
 // Map a bulk (multi-select) action to its session OperationType. Kept here so
 // both the single-repo handlers and the bulk loop record the same per-type
 // counts in the end-of-session summary. 'visibility' is the only name that
@@ -82,27 +111,73 @@ export function bulkActionToOperation(
   return action === 'visibility' ? 'visibilityChange' : action;
 }
 
+// Inner width of the framed panels (characters between the left/right rules).
+const PANEL_WIDTH = 58;
+
+// A boxed title bar like:
+//   ╭──────────────────────────────────────────────────────────╮
+//   │  📊  Session Summary
+//   ╰──────────────────────────────────────────────────────────╯
+// The right edge is intentionally left open on the title row so emoji width
+// quirks across terminals never misalign a closing border.
+function panelHeader(title: string): string[] {
+  const rule = '─'.repeat(PANEL_WIDTH);
+  return [
+    `  ╭${rule}╮`,
+    `  │  ${title}`,
+    `  ╰${rule}╯`,
+  ];
+}
+
 export function formatSessionSummary(): string {
   const durationMs = Date.now() - startTime.getTime();
   const durationStr = formatDuration(durationMs);
   const total = getTotalOperations();
 
-  const hr = '─'.repeat(60);
-  const lines: string[] = ['\n' + hr, ''];
+  const lines: string[] = ['', ...panelHeader('📊  Session Summary'), ''];
 
   if (total === 0) {
-    lines.push(`  Session: ${durationStr}  •  No changes made`);
+    lines.push(`     Duration:    ${durationStr}`);
+    lines.push('     No changes were made this session.');
   } else {
-    lines.push(`  Session: ${durationStr}  •  ${total} operation${total === 1 ? '' : 's'} performed`);
+    lines.push(`     Duration:    ${durationStr}`);
+    lines.push(`     Operations:  ${total} performed`);
     lines.push('');
     for (const [type, n] of Object.entries(counts) as [OperationType, number][]) {
       if (n > 0) {
         const noun = n === 1 ? 'repository' : 'repositories';
-        lines.push(`    • ${n} ${noun} ${OPERATION_LABELS[type]}`);
+        lines.push(`       • ${n} ${noun} ${OPERATION_LABELS[type]}`);
       }
+    }
+
+    const savedMs = estimateTimeSavedMs();
+    if (savedMs > 0) {
+      lines.push('');
+      lines.push(`     ⏱  Estimated time saved:  ~${formatDuration(savedMs)}`);
+      lines.push('        (vs performing these by hand on github.com)');
     }
   }
 
   lines.push('');
+  return lines.join('\n');
+}
+
+// The thank-you / sponsorship message, rendered as its own framed panel so it
+// reads as a section distinct from the usage summary above it.
+export function formatSupportMessage(): string {
+  const lines: string[] = [
+    '',
+    ...panelHeader('💚  Thank you for using gh-manager-cli!'),
+    '',
+    '     If this app saved you time, please consider supporting',
+    '     the development of more open-source projects like this:',
+    '',
+    '       💖 Sponsor on GitHub:  https://github.com/sponsors/wiiiimm',
+    '       🚀 Visit my site:      https://wiiiimm.codes',
+    '       💬 Leave feedback:     https://github.com/wiiiimm/gh-manager-cli',
+    '',
+    '     Your support keeps this project alive! 🙏',
+    '',
+  ];
   return lines.join('\n');
 }

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,10 +1,18 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   trackOperation,
   getTotalOperations,
   formatSessionSummary,
   bulkActionToOperation,
 } from '../src/lib/session';
+
+// The module is a process-level singleton whose counts only ever increase, so
+// for assertions that depend on absolute state (the zero-operations branch, the
+// exact time-saved total) we load a fresh, isolated copy via vi.resetModules().
+async function freshSession() {
+  vi.resetModules();
+  return import('../src/lib/session');
+}
 
 // The session tracker is a module-level singleton, so counts accumulate across
 // the whole process (i.e. across org/workspace switches) — exactly the
@@ -39,5 +47,73 @@ describe('trackOperation / session summary', () => {
     const summary = formatSessionSummary();
     expect(summary).toContain('deleted');
     expect(summary).toContain('visibility changed');
+  });
+});
+
+describe('estimateTimeSavedMs', () => {
+  it('returns 0 when no operations were performed', async () => {
+    const s = await freshSession();
+    expect(s.estimateTimeSavedMs()).toBe(0);
+  });
+
+  it('accumulates per-operation manual-time weights', async () => {
+    const s = await freshSession();
+    s.trackOperation('delete'); // 45s
+    s.trackOperation('delete'); // 45s
+    s.trackOperation('star'); // 6s
+    // (45 + 45 + 6) seconds, in milliseconds
+    expect(s.estimateTimeSavedMs()).toBe(96 * 1000);
+  });
+
+  it('weights a quick toggle below a destructive action', async () => {
+    const s = await freshSession();
+    s.trackOperation('star');
+    const starOnly = s.estimateTimeSavedMs();
+    s.trackOperation('delete');
+    const withDelete = s.estimateTimeSavedMs();
+    expect(withDelete - starOnly).toBeGreaterThan(starOnly);
+  });
+});
+
+describe('formatSessionSummary panel', () => {
+  it('renders a titled panel and omits the time-saved line with no operations', async () => {
+    const s = await freshSession();
+    const out = s.formatSessionSummary();
+    expect(out).toContain('Session Summary');
+    expect(out).toContain('No changes were made this session.');
+    expect(out).not.toContain('time saved');
+  });
+
+  it('shows duration, operation counts and a time-saved estimate when ops exist', async () => {
+    const s = await freshSession();
+    s.trackOperation('delete');
+    s.trackOperation('delete');
+    const out = s.formatSessionSummary();
+    expect(out).toContain('Session Summary');
+    expect(out).toContain('Operations:  2 performed');
+    expect(out).toContain('2 repositories deleted');
+    expect(out).toContain('Estimated time saved');
+  });
+});
+
+describe('formatSupportMessage', () => {
+  it('is a self-contained panel with the sponsorship links', async () => {
+    const s = await freshSession();
+    const out = s.formatSupportMessage();
+    expect(out).toContain('Thank you for using gh-manager-cli');
+    expect(out).toContain('https://github.com/sponsors/wiiiimm');
+    expect(out).toContain('Your support keeps this project alive');
+  });
+
+  it('renders as a panel separate from the usage summary', async () => {
+    const s = await freshSession();
+    const summary = s.formatSessionSummary();
+    const support = s.formatSupportMessage();
+    // Each is its own framed box…
+    expect(summary).toContain('╭');
+    expect(support).toContain('╭');
+    // …and the two concerns do not bleed into one another.
+    expect(summary).not.toContain('Thank you');
+    expect(support).not.toContain('Session Summary');
   });
 });


### PR DESCRIPTION
## Summary

The end-of-session usage summary (shown on quit) used to pile straight onto the thank-you / sponsor message inside a single set of dividers, so it read as one undifferentiated block. This splits it into **two clearly framed, titled panels** and adds a **time-saved estimate**.

Closes SWR-375. Builds on SWR-19 (which introduced the summary + operation tracking).

## Changes

- **`📊 Session Summary`** is now its own framed panel — session duration, total operation count, and a scannable per-operation breakdown.
- **`💚 Thank you …`** sponsor/feedback block is now its own separate framed panel (extracted from `index.tsx` into a testable `formatSupportMessage()`), no longer fused to the summary.
- **Time-saved estimate** under the summary: each operation type carries a rough "how long it'd take by hand on github.com" weight (delete 45s, archive/visibility 40s, transfer 60s, sync 20s, rename 30s, star/unstar 6s). Summed and shown as `⏱  Estimated time saved: ~Xm Ys (vs performing these by hand on github.com)`. Omitted entirely when no operations were performed.

### Before
```
────────────────────────────────────────────────────────────

  Session: 5m  •  3 operations performed

    • 2 repositories deleted
    • 1 repository archived
💚 Thank you for using gh-manager-cli!
If this app saved you time, please consider supporting
...
────────────────────────────────────────────────────────────
```

### After
```
  ╭──────────────────────────────────────────────────────────╮
  │  📊  Session Summary
  ╰──────────────────────────────────────────────────────────╯

     Duration:    5m
     Operations:  3 performed

       • 2 repositories deleted
       • 1 repository archived

     ⏱  Estimated time saved:  ~2m 10s
        (vs performing these by hand on github.com)

  ╭──────────────────────────────────────────────────────────╮
  │  💚  Thank you for using gh-manager-cli!
  ╰──────────────────────────────────────────────────────────╯

     If this app saved you time, please consider supporting
     ...
```

## Tests

- New coverage in `tests/session.test.ts`: `estimateTimeSavedMs` (zero-ops, weighted accumulation, toggle-vs-destructive ordering), the summary panel (titled, omits time-saved with no ops, shows duration/counts/estimate with ops), and `formatSupportMessage` (sponsor links + separation from the summary panel).
- Full suite green: **308 passed**. `pnpm build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect stdout on normal CLI exit and session formatting helpers; no API, auth, or repo mutation behavior.
> 
> **Overview**
> On normal quit, the end-of-session output is split into **two framed panels** instead of one divider block: a **Session Summary** panel and a separate **thank-you / sponsor** panel via new `formatSupportMessage()` (moved out of `index.tsx`).
> 
> The summary panel is restyled with duration, operation count, and per-operation bullets, and adds an **estimated time saved** line (~manual GitHub UI seconds per operation type) when any operations were tracked; that line is omitted when the session had zero ops.
> 
> Tests add `vi.resetModules()` isolation for singleton session state and cover time-saved math, panel content, and separation between summary and support messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5f4295d2ae8bef511433831231bf9e8792d741f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->