### PR TITLE
perf: add daily tick to refresh stale relative date labels in RepoRow (SWR-377)

### DIFF
--- a/src/ui/components/repo/RepoRow.tsx
+++ b/src/ui/components/repo/RepoRow.tsx
@@ -18,6 +18,10 @@ interface RepoRowProps {
   multiSelectMode?: boolean;
   isChecked?: boolean;
   theme?: Theme;
+  /** Integer day counter (Math.floor(Date.now() / 86_400_000)). Incremented by
+   *  RepoList once per minute so the "Updated …" label recomputes when midnight
+   *  rolls over without causing per-keystroke re-renders. */
+  dayBucket?: number;
 }
 
 function arePropsEqual(prev: RepoRowProps, next: RepoRowProps): boolean {
@@ -32,7 +36,8 @@ function arePropsEqual(prev: RepoRowProps, next: RepoRowProps): boolean {
     prev.spacingLines === next.spacingLines &&
     prev.maxWidth === next.maxWidth &&
     prev.index === next.index &&
-    prev.theme === next.theme
+    prev.theme === next.theme &&
+    prev.dayBucket === next.dayBucket
   );
 }
 
@@ -48,6 +53,7 @@ function RepoRow({
   multiSelectMode = false,
   isChecked = false,
   theme: themeProp,
+  dayBucket: _dayBucket,
 }: RepoRowProps) {
   const { theme, c } = useTheme(themeProp?.name ?? 'default');
 
@@ -136,6 +142,7 @@ function RepoRow({
     multiSelectMode,
     isChecked,
     c,
+    _dayBucket,
   ]);
 
   const { fullText, spacingAbove, spacingBelow } = formattedContent;

--- a/src/ui/components/repo/RepoRow.tsx
+++ b/src/ui/components/repo/RepoRow.tsx
@@ -18,10 +18,13 @@ interface RepoRowProps {
   multiSelectMode?: boolean;
   isChecked?: boolean;
   theme?: Theme;
-  /** Integer day counter (Math.floor(Date.now() / 86_400_000)). Incremented by
-   *  RepoList once per minute so the "Updated …" label recomputes when midnight
-   *  rolls over without causing per-keystroke re-renders. */
-  dayBucket?: number;
+  /** Whole-minute counter (Math.floor(Date.now() / 60_000)). Incremented by
+   *  RepoList once per minute so the relative "Updated …" label recomputes near
+   *  its real per-repo boundary. `formatDate` flips a row at `updatedAt + k·24h`
+   *  (its own time-of-day), not at midnight, so a coarser day bucket would leave
+   *  rows stale for hours (SWR-377). The token only changes once a minute, never
+   *  between keystrokes, so per-keystroke memoisation is preserved. */
+  refreshTick?: number;
 }
 
 function arePropsEqual(prev: RepoRowProps, next: RepoRowProps): boolean {
@@ -37,7 +40,7 @@ function arePropsEqual(prev: RepoRowProps, next: RepoRowProps): boolean {
     prev.maxWidth === next.maxWidth &&
     prev.index === next.index &&
     prev.theme === next.theme &&
-    prev.dayBucket === next.dayBucket
+    prev.refreshTick === next.refreshTick
   );
 }
 
@@ -53,7 +56,7 @@ function RepoRow({
   multiSelectMode = false,
   isChecked = false,
   theme: themeProp,
-  dayBucket: _dayBucket,
+  refreshTick: _refreshTick,
 }: RepoRowProps) {
   const { theme, c } = useTheme(themeProp?.name ?? 'default');
 
@@ -142,7 +145,7 @@ function RepoRow({
     multiSelectMode,
     isChecked,
     c,
-    _dayBucket,
+    _refreshTick,
   ]);
 
   const { fullText, spacingAbove, spacingBelow } = formattedContent;

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -94,6 +94,18 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   const [density, setDensity] = useState<0 | 1 | 2>(2);
   const [prefsLoaded, setPrefsLoaded] = useState(false);
 
+  // Day-bucket tick: increments (in whole-day integer units) whenever local midnight
+  // rolls over. Passed to RepoRow so the useMemo that builds the chalk string
+  // recomputes "Updated …" labels after a day boundary without per-keystroke cost.
+  const [dayBucket, setDayBucket] = useState(() => Math.floor(Date.now() / 86_400_000));
+  useEffect(() => {
+    const id = setInterval(() => {
+      const next = Math.floor(Date.now() / 86_400_000);
+      setDayBucket(prev => (prev !== next ? next : prev));
+    }, 60_000);
+    return () => clearInterval(id);
+  }, []);
+
   // Theme state
   const [themeName, setThemeName] = useState<ThemeName>('default');
   const [themeToast, setThemeToast] = useState<string | null>(null);
@@ -3111,6 +3123,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                       multiSelectMode={multiSelectMode}
                       isChecked={selectedRepos.has(repo.id)}
                       theme={theme}
+                      dayBucket={dayBucket}
                     />
                   );
                 })

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -94,15 +94,20 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   const [density, setDensity] = useState<0 | 1 | 2>(2);
   const [prefsLoaded, setPrefsLoaded] = useState(false);
 
-  // Day-bucket tick: increments (in whole-day integer units) whenever local midnight
-  // rolls over. Passed to RepoRow so the useMemo that builds the chalk string
-  // recomputes "Updated …" labels after a day boundary without per-keystroke cost.
-  const [dayBucket, setDayBucket] = useState(() => Math.floor(Date.now() / 86_400_000));
+  // Refresh tick: a whole-minute integer counter. `formatDate` derives its
+  // relative "Updated …" label from the elapsed time since each repo's own
+  // `updatedAt`, so a row flips (e.g. "today" → "yesterday") at `updatedAt +
+  // k·24h` — its own time-of-day, not at midnight. A coarse day bucket would
+  // therefore leave most rows stale for hours (SWR-377). Ticking once per
+  // minute re-renders the (virtualised) visible rows within ~a minute of their
+  // true boundary. It never changes between keystrokes, so the per-keystroke
+  // memoisation from SWR-358 is preserved.
+  const [refreshTick, setRefreshTick] = useState(() => Math.floor(Date.now() / 60_000));
   useEffect(() => {
     const id = setInterval(() => {
-      const next = Math.floor(Date.now() / 86_400_000);
-      setDayBucket(prev => (prev !== next ? next : prev));
-    }, 60_000);
+      const next = Math.floor(Date.now() / 60_000);
+      setRefreshTick(prev => (prev !== next ? next : prev));
+    }, 30_000);
     return () => clearInterval(id);
   }, []);
 
@@ -3123,7 +3128,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                       multiSelectMode={multiSelectMode}
                       isChecked={selectedRepos.has(repo.id)}
                       theme={theme}
-                      dayBucket={dayBucket}
+                      refreshTick={refreshTick}
                     />
                   );
                 })

--- a/tests/ui/RepoRow.test.tsx
+++ b/tests/ui/RepoRow.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render } from 'ink-testing-library';
 import RepoRow from '../../src/ui/components/repo/RepoRow';
 
@@ -98,6 +98,137 @@ describe('RepoRow', () => {
     const output = lastFrame() || '';
     expect(output).toContain('[✓]');
     unmount();
+  });
+
+  describe('dayBucket day-rollover refresh (SWR-377)', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('shows "today" when updatedAt is the current day', () => {
+      vi.useFakeTimers();
+      // Set clock to Jan 1 2024 at noon UTC — same day as repoStub.updatedAt
+      vi.setSystemTime(new Date('2024-01-01T12:00:00Z'));
+
+      const day1Bucket = Math.floor(Date.now() / 86_400_000);
+      const repo = { ...repoStub, updatedAt: '2024-01-01T00:00:00Z' };
+
+      const { lastFrame, unmount } = render(
+        <RepoRow
+          repo={repo}
+          selected={false}
+          index={1}
+          maxWidth={80}
+          spacingLines={0}
+          forkTracking={false}
+          dayBucket={day1Bucket}
+        />
+      );
+
+      expect(lastFrame() || '').toContain('today');
+      unmount();
+    });
+
+    it('updates "today" to "yesterday" when dayBucket advances across midnight', () => {
+      vi.useFakeTimers();
+      // Start at Jan 1 2024 noon — same day as updatedAt → "today"
+      vi.setSystemTime(new Date('2024-01-01T12:00:00Z'));
+      const day1Bucket = Math.floor(Date.now() / 86_400_000);
+      const repo = { ...repoStub, updatedAt: '2024-01-01T00:00:00Z' };
+
+      const baseProps = {
+        repo,
+        selected: false,
+        index: 1,
+        maxWidth: 80,
+        spacingLines: 0,
+        forkTracking: false as const,
+      };
+
+      const { lastFrame, rerender, unmount } = render(
+        <RepoRow {...baseProps} dayBucket={day1Bucket} />
+      );
+
+      expect(lastFrame() || '').toContain('today');
+
+      // Advance clock to Jan 2 2024 noon — a new day
+      vi.setSystemTime(new Date('2024-01-02T12:00:00Z'));
+      const day2Bucket = Math.floor(Date.now() / 86_400_000);
+      expect(day2Bucket).toBe(day1Bucket + 1);
+
+      // Rerender with the new dayBucket — memo must recompute the chalk string
+      rerender(<RepoRow {...baseProps} dayBucket={day2Bucket} />);
+
+      expect(lastFrame() || '').toContain('yesterday');
+      unmount();
+    });
+
+    it('does not update the date label when dayBucket stays the same after midnight', () => {
+      vi.useFakeTimers();
+      // Start at Jan 1 2024 noon — same day as updatedAt → "today"
+      vi.setSystemTime(new Date('2024-01-01T12:00:00Z'));
+      const day1Bucket = Math.floor(Date.now() / 86_400_000);
+      const repo = { ...repoStub, updatedAt: '2024-01-01T00:00:00Z' };
+
+      const baseProps = {
+        repo,
+        selected: false,
+        index: 1,
+        maxWidth: 80,
+        spacingLines: 0,
+        forkTracking: false as const,
+      };
+
+      const { lastFrame, rerender, unmount } = render(
+        <RepoRow {...baseProps} dayBucket={day1Bucket} />
+      );
+
+      expect(lastFrame() || '').toContain('today');
+
+      // Advance clock past midnight but do NOT change dayBucket (tick hasn't fired yet)
+      vi.setSystemTime(new Date('2024-01-02T00:00:30Z'));
+
+      // Rerender with the same dayBucket — arePropsEqual returns true, memo is skipped,
+      // so formatDate is NOT re-called and the label stays "today" (stale but correct
+      // pre-tick behaviour)
+      rerender(<RepoRow {...baseProps} dayBucket={day1Bucket} />);
+
+      // The cached "today" label persists until the tick fires
+      expect(lastFrame() || '').toContain('today');
+      unmount();
+    });
+
+    it('handles a label boundary of "yesterday" advancing to "2 days ago" on rollover', () => {
+      vi.useFakeTimers();
+      // updatedAt is Jan 1; clock is Jan 2 → "yesterday"
+      vi.setSystemTime(new Date('2024-01-02T12:00:00Z'));
+      const day2Bucket = Math.floor(Date.now() / 86_400_000);
+      const repo = { ...repoStub, updatedAt: '2024-01-01T00:00:00Z' };
+
+      const baseProps = {
+        repo,
+        selected: false,
+        index: 1,
+        maxWidth: 80,
+        spacingLines: 0,
+        forkTracking: false as const,
+      };
+
+      const { lastFrame, rerender, unmount } = render(
+        <RepoRow {...baseProps} dayBucket={day2Bucket} />
+      );
+
+      expect(lastFrame() || '').toContain('yesterday');
+
+      // Advance to Jan 3 → "2 days ago"
+      vi.setSystemTime(new Date('2024-01-03T12:00:00Z'));
+      const day3Bucket = Math.floor(Date.now() / 86_400_000);
+
+      rerender(<RepoRow {...baseProps} dayBucket={day3Bucket} />);
+
+      expect(lastFrame() || '').toContain('2 days ago');
+      unmount();
+    });
   });
 });
 

--- a/tests/ui/RepoRow.test.tsx
+++ b/tests/ui/RepoRow.test.tsx
@@ -100,18 +100,18 @@ describe('RepoRow', () => {
     unmount();
   });
 
-  describe('dayBucket day-rollover refresh (SWR-377)', () => {
+  describe('refreshTick relative-label refresh (SWR-377)', () => {
+    const minuteTick = () => Math.floor(Date.now() / 60_000);
+
     afterEach(() => {
       vi.useRealTimers();
     });
 
-    it('shows "today" when updatedAt is the current day', () => {
+    it('shows "today" when updatedAt is within the last 24h', () => {
       vi.useFakeTimers();
-      // Set clock to Jan 1 2024 at noon UTC — same day as repoStub.updatedAt
-      vi.setSystemTime(new Date('2024-01-01T12:00:00Z'));
-
-      const day1Bucket = Math.floor(Date.now() / 86_400_000);
-      const repo = { ...repoStub, updatedAt: '2024-01-01T00:00:00Z' };
+      // updatedAt at noon; clock 6h later → 0 elapsed days → "today"
+      vi.setSystemTime(new Date('2024-01-01T18:00:00Z'));
+      const repo = { ...repoStub, updatedAt: '2024-01-01T12:00:00Z' };
 
       const { lastFrame, unmount } = render(
         <RepoRow
@@ -121,7 +121,7 @@ describe('RepoRow', () => {
           maxWidth={80}
           spacingLines={0}
           forkTracking={false}
-          dayBucket={day1Bucket}
+          refreshTick={minuteTick()}
         />
       );
 
@@ -129,12 +129,13 @@ describe('RepoRow', () => {
       unmount();
     });
 
-    it('updates "today" to "yesterday" when dayBucket advances across midnight', () => {
+    it('refreshes "today" → "yesterday" at the repo\'s own 24h boundary, not at midnight', () => {
       vi.useFakeTimers();
-      // Start at Jan 1 2024 noon — same day as updatedAt → "today"
-      vi.setSystemTime(new Date('2024-01-01T12:00:00Z'));
-      const day1Bucket = Math.floor(Date.now() / 86_400_000);
-      const repo = { ...repoStub, updatedAt: '2024-01-01T00:00:00Z' };
+      // updatedAt at noon. Start 6h later → "today". The flip to "yesterday"
+      // happens at the next noon (updatedAt + 24h), which is NOT a midnight
+      // boundary — the exact case a day bucket missed (SWR-377).
+      vi.setSystemTime(new Date('2024-01-01T18:00:00Z'));
+      const repo = { ...repoStub, updatedAt: '2024-01-01T12:00:00Z' };
 
       const baseProps = {
         repo,
@@ -146,29 +147,27 @@ describe('RepoRow', () => {
       };
 
       const { lastFrame, rerender, unmount } = render(
-        <RepoRow {...baseProps} dayBucket={day1Bucket} />
+        <RepoRow {...baseProps} refreshTick={minuteTick()} />
       );
 
       expect(lastFrame() || '').toContain('today');
 
-      // Advance clock to Jan 2 2024 noon — a new day
-      vi.setSystemTime(new Date('2024-01-02T12:00:00Z'));
-      const day2Bucket = Math.floor(Date.now() / 86_400_000);
-      expect(day2Bucket).toBe(day1Bucket + 1);
+      // Advance just past the 24h boundary (12:00:30, mid-day — far from midnight).
+      vi.setSystemTime(new Date('2024-01-02T12:00:30Z'));
+      const nextTick = minuteTick();
 
-      // Rerender with the new dayBucket — memo must recompute the chalk string
-      rerender(<RepoRow {...baseProps} dayBucket={day2Bucket} />);
+      // The minute tick changes → memo recomputes → label refreshes.
+      rerender(<RepoRow {...baseProps} refreshTick={nextTick} />);
 
       expect(lastFrame() || '').toContain('yesterday');
       unmount();
     });
 
-    it('does not update the date label when dayBucket stays the same after midnight', () => {
+    it('does not recompute the label between keystrokes (same refreshTick → memo skip)', () => {
       vi.useFakeTimers();
-      // Start at Jan 1 2024 noon — same day as updatedAt → "today"
-      vi.setSystemTime(new Date('2024-01-01T12:00:00Z'));
-      const day1Bucket = Math.floor(Date.now() / 86_400_000);
-      const repo = { ...repoStub, updatedAt: '2024-01-01T00:00:00Z' };
+      vi.setSystemTime(new Date('2024-01-01T18:00:00Z'));
+      const repo = { ...repoStub, updatedAt: '2024-01-01T12:00:00Z' };
+      const tick = minuteTick();
 
       const baseProps = {
         repo,
@@ -180,30 +179,26 @@ describe('RepoRow', () => {
       };
 
       const { lastFrame, rerender, unmount } = render(
-        <RepoRow {...baseProps} dayBucket={day1Bucket} />
+        <RepoRow {...baseProps} refreshTick={tick} />
       );
 
       expect(lastFrame() || '').toContain('today');
 
-      // Advance clock past midnight but do NOT change dayBucket (tick hasn't fired yet)
-      vi.setSystemTime(new Date('2024-01-02T00:00:30Z'));
+      // Advance the clock past the boundary but rerender with the SAME refreshTick
+      // (as happens on a keystroke-driven rerender within the same minute):
+      // arePropsEqual returns true, memo is skipped, the cached label is kept.
+      vi.setSystemTime(new Date('2024-01-02T12:00:30Z'));
+      rerender(<RepoRow {...baseProps} refreshTick={tick} />);
 
-      // Rerender with the same dayBucket — arePropsEqual returns true, memo is skipped,
-      // so formatDate is NOT re-called and the label stays "today" (stale but correct
-      // pre-tick behaviour)
-      rerender(<RepoRow {...baseProps} dayBucket={day1Bucket} />);
-
-      // The cached "today" label persists until the tick fires
       expect(lastFrame() || '').toContain('today');
       unmount();
     });
 
-    it('handles a label boundary of "yesterday" advancing to "2 days ago" on rollover', () => {
+    it('refreshes "yesterday" → "2 days ago" at the next 24h boundary', () => {
       vi.useFakeTimers();
-      // updatedAt is Jan 1; clock is Jan 2 → "yesterday"
-      vi.setSystemTime(new Date('2024-01-02T12:00:00Z'));
-      const day2Bucket = Math.floor(Date.now() / 86_400_000);
-      const repo = { ...repoStub, updatedAt: '2024-01-01T00:00:00Z' };
+      // updatedAt at noon Jan 1; clock Jan 2 18:00 → 1 elapsed day → "yesterday"
+      vi.setSystemTime(new Date('2024-01-02T18:00:00Z'));
+      const repo = { ...repoStub, updatedAt: '2024-01-01T12:00:00Z' };
 
       const baseProps = {
         repo,
@@ -215,16 +210,14 @@ describe('RepoRow', () => {
       };
 
       const { lastFrame, rerender, unmount } = render(
-        <RepoRow {...baseProps} dayBucket={day2Bucket} />
+        <RepoRow {...baseProps} refreshTick={minuteTick()} />
       );
 
       expect(lastFrame() || '').toContain('yesterday');
 
-      // Advance to Jan 3 → "2 days ago"
-      vi.setSystemTime(new Date('2024-01-03T12:00:00Z'));
-      const day3Bucket = Math.floor(Date.now() / 86_400_000);
-
-      rerender(<RepoRow {...baseProps} dayBucket={day3Bucket} />);
+      // Advance past the 48h boundary (noon Jan 3) → "2 days ago"
+      vi.setSystemTime(new Date('2024-01-03T12:00:30Z'));
+      rerender(<RepoRow {...baseProps} refreshTick={minuteTick()} />);
 
       expect(lastFrame() || '').toContain('2 days ago');
       unmount();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the stale "Updated …" date label bug introduced when `RepoRow` was memoised in SWR-358. After memoisation, the chalk string (built by `useMemo`) could show an incorrect relative date if the app was left open across a local midnight without any user interaction.

## Changes

### `src/ui/views/RepoList.tsx`
- Added a `dayBucket` state initialised to `Math.floor(Date.now() / 86_400_000)`.
- A `setInterval` (60 s cadence) computes the current bucket and only calls `setDayBucket` when the integer value has changed — zero cost on most ticks, one state update per midnight.
- The new prop is threaded down to each `<RepoRow>` call.

### `src/ui/components/repo/RepoRow.tsx`
- Added optional `dayBucket?: number` to `RepoRowProps` (with JSDoc explaining its purpose).
- Added `prev.dayBucket === next.dayBucket` to `arePropsEqual` so `React.memo` allows a re-render on day rollover.
- Added `_dayBucket` to the `useMemo` dependency array so `formatDate` is re-evaluated when the day changes. The underscore prefix signals it is a dependency token, not used directly in JSX.

### `tests/ui/RepoRow.test.tsx`
Four new tests in a `dayBucket day-rollover refresh (SWR-377)` describe block using `vi.useFakeTimers` / `vi.setSystemTime`:

1. **"today" shown on the correct day** — baseline render check.
2. **dayBucket advance updates the label** — "today" → "yesterday" when `dayBucket` changes by 1.
3. **unchanged dayBucket keeps the label stale** — advancing the clock without changing `dayBucket` leaves the cached "today" label intact (demonstrates memo skip is intentional pre-tick behaviour).
4. **boundary "yesterday" → "2 days ago"** — verifies subsequent rollovers work the same way.

## Acceptance criteria

- [x] Leaving the app open across local midnight updates labels without user interaction (daily tick fires)
- [x] No per-keystroke re-render regression (tick fires at most once per minute, state only updates on actual day change)
- [x] `arePropsEqual` and the `useMemo` deps both include `dayBucket` (kept in sync per AGENTS.md)
- [x] New tests cover day-rollover refresh
- [x] `pnpm build` and `pnpm test` (RepoRow suite) pass
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SWR-377](https://linear.app/stealths/issue/SWR-377/reporow-refresh-relative-updated-date-labels-across-day-boundaries)

<div><a href="https://cursor.com/agents/bc-a732807d-3745-4a21-a2b5-4ccc63c600e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a732807d-3745-4a21-a2b5-4ccc63c600e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

