### PR TITLE
fix: resolve all tsc --noEmit strict-type errors across the codebase (SWR-376) [semantic pr title]

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "start:debug": "GH_MANAGER_DEBUG=1 node dist/index.js",
     "start:dev": "REPOS_PER_FETCH=5 GH_MANAGER_DEBUG=1 node dist/index.js",
     "prepublishOnly": "pnpm run build",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -1,0 +1,7 @@
+// clipboardy is an optional runtime dependency (not always installed).
+// The dynamic import is wrapped in try/catch in copyToClipboard; this
+// ambient declaration keeps tsc happy without affecting the build.
+declare module 'clipboardy' {
+  export function write(text: string): Promise<void>;
+  export function read(): Promise<string>;
+}

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -4,4 +4,11 @@
 declare module 'clipboardy' {
   export function write(text: string): Promise<void>;
   export function read(): Promise<string>;
+  // clipboardy ships as an ESM default export as well as named exports;
+  // declaring both lets `(clipboardy.default ?? clipboardy).write(...)` type-check.
+  const clipboardy: {
+    write(text: string): Promise<void>;
+    read(): Promise<string>;
+  };
+  export default clipboardy;
 }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -8,7 +8,7 @@ type Density = 0 | 1 | 2;
 export type OwnerContext = 'personal' | { type: 'organization', login: string, name?: string };
 
 interface UIPrefs {
-  sortKey?: 'updated' | 'pushed' | 'name' | 'stars';
+  sortKey?: 'updated' | 'pushed' | 'name' | 'stars' | 'forks';
   sortDir?: 'asc' | 'desc';
   density?: Density;
   forkTracking?: boolean;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -122,8 +122,8 @@ export function computeWindow(
 export async function copyToClipboard(text: string): Promise<void> {
   try {
     // Try clipboardy first (cross-platform)
-    const clipboardy = await import('clipboardy');
-    await clipboardy.write(text);
+    const clipboardy = await import('clipboardy') as any;
+    await (clipboardy.default ?? clipboardy).write(text);
     return;
   } catch (error) {
     // Fallback to OS-specific commands using spawn for security

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -122,7 +122,7 @@ export function computeWindow(
 export async function copyToClipboard(text: string): Promise<void> {
   try {
     // Try clipboardy first (cross-platform)
-    const clipboardy = await import('clipboardy') as any;
+    const clipboardy = await import('clipboardy');
     await (clipboardy.default ?? clipboardy).write(text);
     return;
   } catch (error) {

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -13,6 +13,37 @@ export function makeClient(token: string) {
   });
 }
 
+// Minimal shapes for the GitHub REST JSON bodies we parse. `Response.json()` is
+// typed as `Promise<unknown>` (undici), so these let us narrow without `any`.
+interface GitHubRestErrorBody {
+  message?: string;
+  errors?: Array<{ message?: string; field?: string; code?: string }>;
+}
+
+interface CreateRepoRestResponse {
+  full_name: string;
+  html_url: string;
+}
+
+interface SyncForkRestResponse {
+  message: string;
+  merge_type: string;
+  base_branch: string;
+}
+
+interface RestRateLimitResource {
+  limit: number;
+  remaining: number;
+  reset: number;
+}
+
+interface RestRateLimitResponse {
+  resources?: {
+    core?: RestRateLimitResource;
+    graphql?: RestRateLimitResource;
+  };
+}
+
 // Singleton Apollo client instance
 let apolloClientInstance: { client: ApolloClient<any>, gql: any } | null = null;
 
@@ -698,7 +729,7 @@ export async function deleteRepositoryRest(
   
   let msg = `GitHub REST delete failed (status ${res.status})`;
   try {
-    const body = await res.json() as any;
+    const body = await res.json() as GitHubRestErrorBody;
     if (body && body.message) msg += `: ${body.message}`;
   } catch {
     // ignore
@@ -727,11 +758,11 @@ export async function deleteRepositoryRest(
 async function parseGitHubRestError(res: Response, defaultMessage: string): Promise<string> {
   let msg = defaultMessage;
   try {
-    const errBody = await res.json() as any;
+    const errBody = await res.json() as GitHubRestErrorBody;
     if (errBody?.message) msg = errBody.message;
     if (Array.isArray(errBody?.errors) && errBody.errors.length > 0) {
       const details = errBody.errors
-        .map((e: any) => e.message || (e.field ? `${e.field}: ${e.code}` : e.code))
+        .map((e) => e.message || (e.field ? `${e.field}: ${e.code}` : e.code))
         .filter(Boolean)
         .join('; ');
       if (details) msg += ` (${details})`;
@@ -800,7 +831,7 @@ export async function createRepositoryRest(
   }
 
   if (res.status === 201) {
-    const data = await res.json() as any;
+    const data = await res.json() as CreateRepoRestResponse;
     logger.info('Successfully created repository', {
       nameWithOwner: data.full_name,
       url: data.html_url
@@ -1113,7 +1144,7 @@ export async function changeRepositoryVisibility(
     }
   `;
   
-  const result = await client(query, { id: repositoryId }) as any;
+  const result = await client<{ node?: { nameWithOwner?: string } | null }>(query, { id: repositoryId });
   const repo = result.node;
   
   if (!repo || !repo.nameWithOwner) {
@@ -1317,7 +1348,7 @@ export async function syncForkWithUpstream(
   }
   
   if (res.status === 200) {
-    const body = await res.json() as { message: string; merge_type: string; base_branch: string };
+    const body = await res.json() as SyncForkRestResponse;
     logger.info('Successfully synced fork with upstream', {
       owner,
       repo,
@@ -1331,7 +1362,7 @@ export async function syncForkWithUpstream(
 
   let msg = `Fork sync failed (status ${res.status})`;
   try {
-    const body = await res.json() as any;
+    const body = await res.json() as GitHubRestErrorBody;
     if (body && body.message) {
       msg += `: ${body.message}`;
       if (res.status === 409) {
@@ -1503,7 +1534,7 @@ export async function fetchRestRateLimits(token: string): Promise<RestRateLimitI
       return null;
     }
     
-    const data = await response.json() as any;
+    const data = await response.json() as RestRateLimitResponse;
 
     logger.debug('Successfully fetched REST rate limits', {
       core: data.resources?.core,
@@ -1567,7 +1598,7 @@ export async function renameRepositoryById(
   `;
   
   try {
-    const result = await client(mutation, { repositoryId, name: newName }) as any;
+    const result = await client<{ updateRepository?: { repository?: { name?: string } } }>(mutation, { repositoryId, name: newName });
 
     logger.info('Repository renamed successfully', {
       repositoryId,

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -698,7 +698,7 @@ export async function deleteRepositoryRest(
   
   let msg = `GitHub REST delete failed (status ${res.status})`;
   try {
-    const body = await res.json();
+    const body = await res.json() as any;
     if (body && body.message) msg += `: ${body.message}`;
   } catch {
     // ignore
@@ -727,7 +727,7 @@ export async function deleteRepositoryRest(
 async function parseGitHubRestError(res: Response, defaultMessage: string): Promise<string> {
   let msg = defaultMessage;
   try {
-    const errBody = await res.json();
+    const errBody = await res.json() as any;
     if (errBody?.message) msg = errBody.message;
     if (Array.isArray(errBody?.errors) && errBody.errors.length > 0) {
       const details = errBody.errors
@@ -800,7 +800,7 @@ export async function createRepositoryRest(
   }
 
   if (res.status === 201) {
-    const data = await res.json();
+    const data = await res.json() as any;
     logger.info('Successfully created repository', {
       nameWithOwner: data.full_name,
       url: data.html_url
@@ -1113,7 +1113,7 @@ export async function changeRepositoryVisibility(
     }
   `;
   
-  const result = await client(query, { id: repositoryId });
+  const result = await client(query, { id: repositoryId }) as any;
   const repo = result.node;
   
   if (!repo || !repo.nameWithOwner) {
@@ -1317,7 +1317,7 @@ export async function syncForkWithUpstream(
   }
   
   if (res.status === 200) {
-    const body = await res.json();
+    const body = await res.json() as { message: string; merge_type: string; base_branch: string };
     logger.info('Successfully synced fork with upstream', {
       owner,
       repo,
@@ -1328,10 +1328,10 @@ export async function syncForkWithUpstream(
     });
     return body;
   }
-  
+
   let msg = `Fork sync failed (status ${res.status})`;
   try {
-    const body = await res.json();
+    const body = await res.json() as any;
     if (body && body.message) {
       msg += `: ${body.message}`;
       if (res.status === 409) {
@@ -1503,13 +1503,13 @@ export async function fetchRestRateLimits(token: string): Promise<RestRateLimitI
       return null;
     }
     
-    const data = await response.json();
-    
+    const data = await response.json() as any;
+
     logger.debug('Successfully fetched REST rate limits', {
       core: data.resources?.core,
       graphql: data.resources?.graphql
     });
-    
+
     return {
       core: data.resources?.core || { limit: 0, remaining: 0, reset: 0 },
       graphql: data.resources?.graphql || { limit: 0, remaining: 0, reset: 0 }
@@ -1567,8 +1567,8 @@ export async function renameRepositoryById(
   `;
   
   try {
-    const result = await client(mutation, { repositoryId, name: newName });
-    
+    const result = await client(mutation, { repositoryId, name: newName }) as any;
+
     logger.info('Repository renamed successfully', {
       repositoryId,
       newName: result?.updateRepository?.repository?.name

--- a/src/services/oauth.ts
+++ b/src/services/oauth.ts
@@ -22,6 +22,21 @@ export interface DeviceCodeResponse {
   interval: number;
 }
 
+// GitHub's device-code endpoint returns either a DeviceCodeResponse or an error pair.
+interface DeviceCodeApiResponse extends Partial<DeviceCodeResponse> {
+  error?: string;
+  error_description?: string;
+}
+
+// GitHub's token endpoint returns either an access token or an error pair.
+interface TokenApiResponse {
+  access_token?: string;
+  token_type?: string;
+  scope?: string;
+  error?: string;
+  error_description?: string;
+}
+
 /**
  * Starts the GitHub Device Authorization Grant flow
  */
@@ -107,7 +122,7 @@ export async function requestDeviceCode(): Promise<DeviceCodeResponse> {
     throw new Error(`HTTP error ${response.status}: ${await response.text()}`);
   }
 
-  const data = await response.json() as any;
+  const data = await response.json() as DeviceCodeApiResponse;
 
   if (data.error) {
     throw new Error(`${data.error}: ${data.error_description || 'Unknown error'}`);
@@ -158,7 +173,7 @@ async function pollForToken(deviceCodeResponse: DeviceCodeResponse): Promise<str
         throw new Error(`HTTP error ${response.status}: ${errorText}`);
       }
 
-      const data = await response.json() as any;
+      const data = await response.json() as TokenApiResponse;
 
       if (process.env.GH_MANAGER_DEBUG) {
         console.log('📨 GitHub response:', JSON.stringify(data, null, 2));

--- a/src/services/oauth.ts
+++ b/src/services/oauth.ts
@@ -107,13 +107,13 @@ export async function requestDeviceCode(): Promise<DeviceCodeResponse> {
     throw new Error(`HTTP error ${response.status}: ${await response.text()}`);
   }
 
-  const data = await response.json();
-  
+  const data = await response.json() as any;
+
   if (data.error) {
     throw new Error(`${data.error}: ${data.error_description || 'Unknown error'}`);
   }
 
-  return data;
+  return data as DeviceCodeResponse;
 }
 
 /**
@@ -158,8 +158,8 @@ async function pollForToken(deviceCodeResponse: DeviceCodeResponse): Promise<str
         throw new Error(`HTTP error ${response.status}: ${errorText}`);
       }
 
-      const data = await response.json();
-      
+      const data = await response.json() as any;
+
       if (process.env.GH_MANAGER_DEBUG) {
         console.log('📨 GitHub response:', JSON.stringify(data, null, 2));
       }

--- a/src/services/oauth.ts
+++ b/src/services/oauth.ts
@@ -128,7 +128,25 @@ export async function requestDeviceCode(): Promise<DeviceCodeResponse> {
     throw new Error(`${data.error}: ${data.error_description || 'Unknown error'}`);
   }
 
-  return data as DeviceCodeResponse;
+  // Validate the required fields are present rather than force-casting a partial
+  // body to DeviceCodeResponse, so callers never receive a malformed payload.
+  if (
+    !data.device_code ||
+    !data.user_code ||
+    !data.verification_uri ||
+    typeof data.expires_in !== 'number' ||
+    typeof data.interval !== 'number'
+  ) {
+    throw new Error('Invalid device-code response from GitHub.');
+  }
+
+  return {
+    device_code: data.device_code,
+    user_code: data.user_code,
+    verification_uri: data.verification_uri,
+    expires_in: data.expires_in,
+    interval: data.interval,
+  };
 }
 
 /**

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -387,13 +387,13 @@ export default function App({ initialOrgSlug, inlineToken, inlineTokenEphemeral 
         {header}
         <Box flexGrow={1} justifyContent="center" alignItems="center">
           <Box borderStyle="single" borderColor="yellow" paddingX={3} paddingY={2} flexDirection="column" width={Math.min(dims.cols - 8, 80)}>
-            <Text bold color="yellow" marginBottom={1}>⚠️  Rate Limit Exceeded</Text>
-            <Text color="gray" marginBottom={1}>
-              You've hit GitHub's API rate limit for your token.
-            </Text>
-            <Text color="gray" marginBottom={1}>
-              This happens when you make too many requests in a short time.
-            </Text>
+            <Box marginBottom={1}><Text bold color="yellow">⚠️  Rate Limit Exceeded</Text></Box>
+            <Box marginBottom={1}>
+              <Text color="gray">You've hit GitHub's API rate limit for your token.</Text>
+            </Box>
+            <Box marginBottom={1}>
+              <Text color="gray">This happens when you make too many requests in a short time.</Text>
+            </Box>
             
             {rateLimitReset && (
               <Box marginTop={1} marginBottom={1}>
@@ -415,9 +415,9 @@ export default function App({ initialOrgSlug, inlineToken, inlineTokenEphemeral 
               </Box>
             </Box>
             
-            <Text color="gray" dimColor marginTop={2}>
-              Tip: Using multiple tokens or waiting between requests can help avoid rate limits.
-            </Text>
+            <Box marginTop={2}>
+              <Text color="gray" dimColor>Tip: Using multiple tokens or waiting between requests can help avoid rate limits.</Text>
+            </Box>
           </Box>
         </Box>
       </Box>
@@ -432,7 +432,7 @@ export default function App({ initialOrgSlug, inlineToken, inlineTokenEphemeral 
           <Box flexDirection="column" alignItems="center">
             <AuthMethodSelector onSelect={handleAuthMethodSelect} />
             {error && (
-              <Text color="red" marginTop={1}>{error}</Text>
+              <Box marginTop={1}><Text color="red">{error}</Text></Box>
             )}
           </Box>
         </Box>
@@ -457,10 +457,10 @@ export default function App({ initialOrgSlug, inlineToken, inlineTokenEphemeral 
         {header}
         <Box flexGrow={1} justifyContent="center" alignItems="center">
           <Box borderStyle="single" borderColor="cyan" paddingX={2} paddingY={1} flexDirection="column">
-            <Text bold marginBottom={1}>Authentication Required</Text>
-            <Text color="gray" marginBottom={1}>
-              Enter your GitHub Personal Access Token
-            </Text>
+            <Box marginBottom={1}><Text bold>Authentication Required</Text></Box>
+            <Box marginBottom={1}>
+              <Text color="gray">Enter your GitHub Personal Access Token</Text>
+            </Box>
             <Box>
               <Text>Token: </Text>
               <TextInput
@@ -471,14 +471,14 @@ export default function App({ initialOrgSlug, inlineToken, inlineTokenEphemeral 
               />
             </Box>
             {error && (
-              <Text color="red" marginTop={1}>{error}</Text>
+              <Box marginTop={1}><Text color="red">{error}</Text></Box>
             )}
-            <Text color="gray" dimColor marginTop={1}>
-              The token will be stored securely in your local config
-            </Text>
-            <Text color="gray" dimColor marginTop={1}>
-              Press Esc to go back
-            </Text>
+            <Box marginTop={1}>
+              <Text color="gray" dimColor>The token will be stored securely in your local config</Text>
+            </Box>
+            <Box marginTop={1}>
+              <Text color="gray" dimColor>Press Esc to go back</Text>
+            </Box>
           </Box>
         </Box>
       </Box>
@@ -493,9 +493,7 @@ export default function App({ initialOrgSlug, inlineToken, inlineTokenEphemeral 
           <Box flexDirection="column" alignItems="center">
             <Text color="yellow">Validating token...</Text>
             {mode === 'validating' && (
-              <Text color="gray" dimColor marginTop={1}>
-                Press Esc to cancel
-              </Text>
+              <Box marginTop={1}><Text color="gray" dimColor>Press Esc to cancel</Text></Box>
             )}
           </Box>
         </Box>

--- a/src/ui/components/auth/AuthMethodSelector.tsx
+++ b/src/ui/components/auth/AuthMethodSelector.tsx
@@ -46,9 +46,7 @@ export default function AuthMethodSelector({ onSelect, onQuit }: AuthMethodSelec
 
   return (
     <Box flexDirection="column" borderStyle="single" borderColor="cyan" paddingX={2} paddingY={1}>
-      <Text bold marginBottom={1}>
-        Choose Authentication Method
-      </Text>
+      <Box marginBottom={1}><Text bold>Choose Authentication Method</Text></Box>
       
       <Box flexDirection="column" marginY={1}>
         {methods.map((method, index) => {
@@ -71,9 +69,7 @@ export default function AuthMethodSelector({ onSelect, onQuit }: AuthMethodSelec
         })}
       </Box>
       
-      <Text color="gray" dimColor marginTop={1}>
-        Use arrow keys to navigate, Enter to select, or press 1/2 • Q/Esc to quit
-      </Text>
+      <Box marginTop={1}><Text color="gray" dimColor>Use arrow keys to navigate, Enter to select, or press 1/2 • Q/Esc to quit</Text></Box>
     </Box>
   );
 }

--- a/src/ui/components/auth/OAuthProgress.tsx
+++ b/src/ui/components/auth/OAuthProgress.tsx
@@ -61,9 +61,7 @@ export default function OAuthProgress({ status, error, deviceCode }: OAuthProgre
 
   return (
     <Box flexDirection="column" borderStyle="single" borderColor={status === 'error' ? 'red' : 'cyan'} paddingX={2} paddingY={1}>
-      <Text bold marginBottom={1}>
-        GitHub OAuth Authentication
-      </Text>
+      <Box marginBottom={1}><Text bold>GitHub OAuth Authentication</Text></Box>
       
       <Box marginY={1}>
         {showSpinner ? (
@@ -82,15 +80,13 @@ export default function OAuthProgress({ status, error, deviceCode }: OAuthProgre
       
       {(status === 'waiting_for_authorization' || status === 'polling_for_token') && deviceCode && (
         <Box marginY={1} flexDirection="column">
-          <Text bold color="cyan" marginBottom={1}>
-            📋 Please complete these steps:
-          </Text>
-          
+          <Box marginBottom={1}><Text bold color="cyan">📋 Please complete these steps:</Text></Box>
+
           <Box marginBottom={1}>
             <Text>1. Visit: </Text>
             <Text bold color="blue">{deviceCode.verification_uri}</Text>
           </Box>
-          
+
           <Box marginBottom={1} flexDirection="column">
             <Text>2. Enter this code:</Text>
             <Box borderStyle="single" borderColor="yellow" paddingX={2} paddingY={1} marginTop={1}>
@@ -99,11 +95,9 @@ export default function OAuthProgress({ status, error, deviceCode }: OAuthProgre
               </Text>
             </Box>
           </Box>
-          
+
           {status === 'waiting_for_authorization' && (
-            <Text color="gray" marginTop={1}>
-              Your browser should open automatically.
-            </Text>
+            <Box marginTop={1}><Text color="gray">Your browser should open automatically.</Text></Box>
           )}
           
           {status === 'polling_for_token' && (
@@ -111,9 +105,7 @@ export default function OAuthProgress({ status, error, deviceCode }: OAuthProgre
               <Text color="gray">
                 Waiting for you to complete authorization in your browser...
               </Text>
-              <Text color="gray" dimColor marginTop={1}>
-                This will timeout in 15 minutes. Press Esc to cancel.
-              </Text>
+              <Box marginTop={1}><Text color="gray" dimColor>This will timeout in 15 minutes. Press Esc to cancel.</Text></Box>
             </Box>
           )}
         </Box>
@@ -122,16 +114,12 @@ export default function OAuthProgress({ status, error, deviceCode }: OAuthProgre
       {status === 'error' && error && (
         <Box marginY={1} flexDirection="column">
           <Text color="red">{error}</Text>
-          <Text color="gray" marginTop={1}>
-            Press Esc to go back and try again.
-          </Text>
+          <Box marginTop={1}><Text color="gray">Press Esc to go back and try again.</Text></Box>
         </Box>
       )}
       
       {status === 'success' && (
-        <Text color="gray" marginTop={1}>
-          Returning to application...
-        </Text>
+        <Box marginTop={1}><Text color="gray">Returning to application...</Text></Box>
       )}
     </Box>
   );

--- a/src/ui/components/modals/ArchiveModal.tsx
+++ b/src/ui/components/modals/ArchiveModal.tsx
@@ -66,7 +66,17 @@ export default function ArchiveModal({ repo, onArchive, onCancel }: ArchiveModal
   if (!repo) return null;
 
   const action = repo.isArchived ? 'Unarchive' : 'Archive';
-  const colorScheme = repo.isArchived ? 'green' : 'yellow';
+  const colorScheme: 'green' | 'yellow' = repo.isArchived ? 'green' : 'yellow';
+
+  // Pre-compute the styled confirm-button label with explicit chalk methods
+  // (avoids dynamic `chalk[...]` indexing that defeats type-checking).
+  const actionLabel = archiveFocus === 'confirm'
+    ? (colorScheme === 'green'
+        ? chalk.bgGreen.black.bold(` ${action} `)
+        : chalk.bgYellow.black.bold(` ${action} `))
+    : (colorScheme === 'green'
+        ? chalk.green.bold(action)
+        : chalk.yellow.bold(action));
 
   return (
     <Box 
@@ -111,12 +121,7 @@ export default function ArchiveModal({ repo, onArchive, onCancel }: ArchiveModal
               paddingY={1} 
               flexDirection="column"
             >
-              <Text>
-                {archiveFocus === 'confirm' ?
-                  (chalk as any)[`bg${colorScheme.charAt(0).toUpperCase() + colorScheme.slice(1)}`].black.bold(` ${action} `) :
-                  (chalk as any)[colorScheme].bold(action)
-                }
-              </Text>
+              <Text>{actionLabel}</Text>
             </Box>
             <Box 
               paddingX={2} 

--- a/src/ui/components/modals/ArchiveModal.tsx
+++ b/src/ui/components/modals/ArchiveModal.tsx
@@ -112,9 +112,9 @@ export default function ArchiveModal({ repo, onArchive, onCancel }: ArchiveModal
               flexDirection="column"
             >
               <Text>
-                {archiveFocus === 'confirm' ? 
-                  chalk[`bg${colorScheme.charAt(0).toUpperCase() + colorScheme.slice(1)}`].black.bold(` ${action} `) : 
-                  chalk[colorScheme].bold(action)
+                {archiveFocus === 'confirm' ?
+                  (chalk as any)[`bg${colorScheme.charAt(0).toUpperCase() + colorScheme.slice(1)}`].black.bold(` ${action} `) :
+                  (chalk as any)[colorScheme].bold(action)
                 }
               </Text>
             </Box>

--- a/src/ui/components/modals/SortDirectionModal.tsx
+++ b/src/ui/components/modals/SortDirectionModal.tsx
@@ -107,6 +107,8 @@ export default function SortDirectionModal({
       case 'pushed': return 'Last Pushed';
       case 'name': return 'Name';
       case 'stars': return 'Stars';
+      case 'forks': return 'Forks';
+      default: return currentSortKey;
     }
   };
 

--- a/src/ui/components/modals/SortModal.tsx
+++ b/src/ui/components/modals/SortModal.tsx
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import type { Theme } from '../../../config/themes';
 import { useTheme } from '../../hooks/useTheme';
 
-export type SortKey = 'updated' | 'pushed' | 'name' | 'stars';
+export type SortKey = 'updated' | 'pushed' | 'name' | 'stars' | 'forks';
 
 interface SortModalProps {
   currentSort: SortKey;
@@ -103,6 +103,8 @@ export default function SortModal({
       case 'pushed': return 'Last Pushed';
       case 'name': return 'Name';
       case 'stars': return 'Stars';
+      case 'forks': return 'Forks';
+      default: return sort;
     }
   };
 

--- a/src/ui/components/modals/SyncModal.tsx
+++ b/src/ui/components/modals/SyncModal.tsx
@@ -69,7 +69,7 @@ export default function SyncModal({ repo, onSync, onCancel }: SyncModalProps) {
     && repo.parent.defaultBranchRef.target?.history && repo.defaultBranchRef.target?.history;
   
   const commitsBehind = hasCommitData
-    ? (repo.parent.defaultBranchRef.target.history.totalCount - repo.defaultBranchRef.target.history.totalCount)
+    ? ((repo.parent?.defaultBranchRef?.target?.history?.totalCount ?? 0) - (repo.defaultBranchRef?.target?.history?.totalCount ?? 0))
     : 0;
 
   return (

--- a/src/ui/hooks/useTheme.ts
+++ b/src/ui/hooks/useTheme.ts
@@ -1,29 +1,29 @@
 import { useMemo } from 'react';
-import chalk from 'chalk';
+import chalk, { type ChalkInstance } from 'chalk';
 import { type Theme, type ThemeName, getTheme } from '../../config/themes';
 
 export interface ThemeColors {
-  primary: chalk.Chalk;
-  secondary: chalk.Chalk;
-  success: chalk.Chalk;
-  warning: chalk.Chalk;
-  error: chalk.Chalk;
-  muted: chalk.Chalk;
-  text: chalk.Chalk;
-  selected: chalk.Chalk;
-  private: chalk.Chalk;
-  archived: chalk.Chalk;
-  internal: chalk.Chalk;
-  fork: chalk.Chalk;
-  dim: chalk.Chalk;
+  primary: ChalkInstance;
+  secondary: ChalkInstance;
+  success: ChalkInstance;
+  warning: ChalkInstance;
+  error: ChalkInstance;
+  muted: ChalkInstance;
+  text: ChalkInstance;
+  selected: ChalkInstance;
+  private: ChalkInstance;
+  archived: ChalkInstance;
+  internal: ChalkInstance;
+  fork: ChalkInstance;
+  dim: ChalkInstance;
   /** Selected option arrow indicator in modals, e.g. bgPrimary.black(' → ') */
-  arrow: chalk.Chalk;
+  arrow: ChalkInstance;
   /** Neutral arrow indicator for the focused cancel/muted option in modals */
-  arrowMuted: chalk.Chalk;
+  arrowMuted: ChalkInstance;
   /** Background+text for confirmed/active button */
-  btnPrimary: chalk.Chalk;
+  btnPrimary: ChalkInstance;
   /** Background+text for muted/cancel button */
-  btnMuted: chalk.Chalk;
+  btnMuted: ChalkInstance;
 }
 
 export interface UseThemeResult {
@@ -31,11 +31,11 @@ export interface UseThemeResult {
   c: ThemeColors;
 }
 
-function chalkFor(color: string): chalk.Chalk {
+function chalkFor(color: string): ChalkInstance {
   return (chalk as any)[color] ?? chalk.white;
 }
 
-function bgChalkFor(color: string): chalk.Chalk {
+function bgChalkFor(color: string): ChalkInstance {
   const bgKey = 'bg' + color.charAt(0).toUpperCase() + color.slice(1);
   return (chalk as any)[bgKey] ?? chalk.bgWhite;
 }

--- a/src/ui/views/RepoList.main.tsx
+++ b/src/ui/views/RepoList.main.tsx
@@ -67,9 +67,9 @@ function RepoRow({ repo, selected, index, maxWidth, spacingLines, dim, forkTrack
     && repo.parent.defaultBranchRef.target?.history && repo.defaultBranchRef.target?.history;
   
   const commitsBehind = hasCommitData
-    ? (repo.parent.defaultBranchRef.target.history.totalCount - repo.defaultBranchRef.target.history.totalCount)
+    ? ((repo.parent?.defaultBranchRef?.target?.history?.totalCount ?? 0) - (repo.defaultBranchRef?.target?.history?.totalCount ?? 0))
     : 0;
-  
+
   const showCommitsBehind = forkTracking && hasCommitData;
   
   // Build colored line 1
@@ -288,7 +288,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   const [filterMode, setFilterMode] = useState(false);
 
   // Sorting state - only support GitHub API sortable fields
-  type SortKey = 'updated' | 'pushed' | 'name' | 'stars';
+  type SortKey = 'updated' | 'pushed' | 'name' | 'stars' | 'forks';
   const [sortKey, setSortKey] = useState<SortKey>('updated');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
   
@@ -300,7 +300,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     'updated': 'UPDATED_AT',
     'pushed': 'PUSHED_AT',
     'name': 'NAME',
-    'stars': 'STARGAZERS'
+    'stars': 'STARGAZERS',
+    'forks': 'UPDATED_AT',  // forks sort is client-side; server falls back to UPDATED_AT
   };
 
   const fetchPage = async (
@@ -553,8 +554,6 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
           sortDir,
           pageSize: PAGE_SIZE,
           forkTracking,
-          ownerContext: orgLogin ? `org:${orgLogin}` : 'personal',
-          affiliations: ownerAffiliations.join(',')
         });
         policy = isFresh(key, 90 * 1000) ? 'cache-first' : 'network-only';
       } catch {}
@@ -879,9 +878,9 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         const hasCommitData = repo.defaultBranchRef && repo.parent.defaultBranchRef
           && repo.parent.defaultBranchRef.target?.history && repo.defaultBranchRef.target?.history;
         const commitsBehind = hasCommitData
-          ? (repo.parent.defaultBranchRef.target.history.totalCount - repo.defaultBranchRef.target.history.totalCount)
+          ? ((repo.parent?.defaultBranchRef?.target?.history?.totalCount ?? 0) - (repo.defaultBranchRef?.target?.history?.totalCount ?? 0))
           : 0;
-        
+
         setSyncTarget(repo);
         setSyncMode(true);
         setSyncError(null);

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -1034,7 +1034,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   const [filterMode, setFilterMode] = useState(false);
 
   // Sorting state - only support GitHub API sortable fields
-  type SortKey = 'updated' | 'pushed' | 'name' | 'stars';
+  type SortKey = 'updated' | 'pushed' | 'name' | 'stars' | 'forks';
   const [sortKey, setSortKey] = useState<SortKey>('updated');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
   
@@ -1164,7 +1164,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     'updated': 'UPDATED_AT',
     'pushed': 'PUSHED_AT',
     'name': 'NAME',
-    'stars': 'STARGAZERS'
+    'stars': 'STARGAZERS',
+    'forks': 'UPDATED_AT',  // forks sort is client-side; server falls back to UPDATED_AT
   };
 
   const fetchPage = async (
@@ -1835,9 +1836,9 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         const hasCommitData = repo.defaultBranchRef && repo.parent.defaultBranchRef
           && repo.parent.defaultBranchRef.target?.history && repo.defaultBranchRef.target?.history;
         const commitsBehind = hasCommitData
-          ? (repo.parent.defaultBranchRef.target.history.totalCount - repo.defaultBranchRef.target.history.totalCount)
+          ? ((repo.parent?.defaultBranchRef?.target?.history?.totalCount ?? 0) - (repo.defaultBranchRef?.target?.history?.totalCount ?? 0))
           : 0;
-        
+
         setSyncTarget(repo);
         setSyncMode(true);
         setSyncError(null);

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -82,6 +82,24 @@ describe('OAuth', () => {
 
       await expect(requestDeviceCode()).rejects.toThrow('Network error');
     });
+
+    it('throws when GitHub returns an error payload', async () => {
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ error: 'unauthorized_client', error_description: 'Bad client' })
+      });
+
+      await expect(requestDeviceCode()).rejects.toThrow('unauthorized_client: Bad client');
+    });
+
+    it('throws when the success body is missing required fields', async () => {
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ device_code: 'only-this-field' })
+      });
+
+      await expect(requestDeviceCode()).rejects.toThrow('Invalid device-code response from GitHub.');
+    });
   });
 
   // TODO: Fix polling tests - they timeout due to async timer issues


### PR DESCRIPTION
Assignee: @wiiiimm ([William Li](https://linear.app/stealths/profiles/wiiiimm))

## Summary

Fixes all 104 TypeScript strict-mode errors reported by `tsc --noEmit` so that type-checking can be added as a CI gate. The build (tsup/esbuild) was not affected — these errors only surfaced when running `tsc --noEmit` directly.

Closes [SWR-376](https://linear.app/stealths/issue/SWR-376/resolve-remaining-tsc-noemit-strict-type-errors-across-the-codebase)

## Changes by file

| File | Fix |
|---|---|
| `src/ui/hooks/useTheme.ts` | Import `ChalkInstance` type instead of `chalk.Chalk` namespace (TS2503 ×19) |
| `src/ambient.d.ts` *(new)* | Ambient module declaration for optional `clipboardy` dep (TS2307 ×1) |
| `src/lib/utils.ts` | Cast `import('clipboardy')` as `any`; handle `.default?.write` fallback |
| `src/services/github.ts` | Cast `res.json()` / `client()` returns to typed shapes (TS18046, TS2339, TS2322 ×22) |
| `src/services/oauth.ts` | Cast `response.json()` as `any`; return typed as `DeviceCodeResponse` (TS18046, TS2322 ×11) |
| `src/ui/App.tsx` | Move `marginBottom`/`marginTop` from `<Text>` to wrapping `<Box>` — Ink `Text` does not accept margin props (TS2322 ×11) |
| `src/ui/components/auth/OAuthProgress.tsx` | Same `<Box>` margin fix (TS2322 ×6) |
| `src/ui/components/auth/AuthMethodSelector.tsx` | Same `<Box>` margin fix (TS2322 ×2) |
| `src/ui/components/modals/ArchiveModal.tsx` | Cast dynamic chalk property index as `any` (TS7053 ×1) |
| `src/ui/components/modals/SyncModal.tsx` | Optional chaining on `parent?.defaultBranchRef?.target?.history` (TS18047/48/49 ×7) |
| `src/ui/components/modals/SortModal.tsx` | Add `'forks'` to exported `SortKey` union; add `getButtonLabel` case |
| `src/ui/components/modals/SortDirectionModal.tsx` | Add `'forks'` case + default to `formatSortKey()` |
| `src/ui/views/RepoList.main.tsx` | Add `'forks'` to local `SortKey`; add to `sortFieldMap`; optional chaining; remove excess `ownerContext`/`affiliations` keys from `makeSearchKey` call (TS2353, TS2304) |
| `src/ui/views/RepoList.tsx` | Same `SortKey` / `sortFieldMap` / optional-chaining fixes |
| `src/config/config.ts` | Add `'forks'` to `UIPrefs.sortKey` union |
| `package.json` | Add `"typecheck": "tsc --noEmit"` script (stretch goal) |

## Acceptance criteria

- [x] `tsc --noEmit` exits with **0 errors**
- [x] No `// @ts-ignore` — `as any` used only where genuinely unavoidable (untyped `Response.json()` returns and optional runtime dep)
- [x] `pnpm build` passes (tsup build succeeds)
- [x] `pnpm test` passes — 306/308 tests pass; the 2 failures in `BulkReviewModal.test.tsx` are pre-existing and unrelated to this PR
- [x] `"typecheck": "tsc --noEmit"` npm script added

---
> **Tip:** I will respond to comments that @ mention @cyrus-mini-5 on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly compile-time and layout-wrapper changes; OAuth adds stricter device-code validation and fork math is null-safe with no auth or data-model changes.
> 
> **Overview**
> Makes **`tsc --noEmit`** pass by adding a **`typecheck`** script and tightening types across services and the Ink UI, without changing the tsup build path.
> 
> **Typing & APIs:** GitHub REST/OAuth **`response.json()`** results are narrowed via small interfaces in `github.ts` and `oauth.ts`; device-code responses are **validated** before return. Optional **`clipboardy`** gets `ambient.d.ts` and a **default/named** write path in `copyToClipboard`. Theme hooks use **`ChalkInstance`** instead of `chalk.Chalk`.
> 
> **UI (Ink):** Invalid **`margin*` props on `<Text>`** are moved to wrapping **`<Box>`** in auth/rate-limit screens. **`ArchiveModal`** drops dynamic `chalk[...]` indexing for explicit green/yellow styling. Fork “commits behind” math uses **optional chaining** so partial GraphQL history data type-checks.
> 
> **Sort types:** **`forks`** is added to persisted/config **`SortKey`** unions and client-side sort switches; list fetch still maps **`forks` → `UPDATED_AT`** on the server. **`makeSearchKey`** calls drop invalid extra keys that broke typing.
> 
> **Tests:** OAuth tests cover **error payloads** and **incomplete device-code bodies**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2cfc6c1241ebe786486a73cbbcfb4e4b90f57c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added 'forks' as a repository sorting option

* **Bug Fixes**
  * Improved stability in fork synchronisation calculations to prevent errors when historical data is incomplete

<!-- end of auto-generated comment: release notes by coderabbit.ai -->