### PR TITLE
docs: sync README and TODOs with current implementation (SWR-378) [semantic pr title]

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,12 @@ On first run, you'll be prompted to authenticate with GitHub (OAuth recommended)
 - **Rate Limit Monitoring**: Dual API rate limit display (GraphQL & REST) with real-time usage deltas and visual warnings
 
 ### Technical Features
-- **Preference Persistence**: UI settings (sort, density, visibility filter, archive filter, fork tracking) saved between sessions
-- **Server-side Filtering**: Visibility filtering performed at GitHub API level for accurate pagination
+- **Preference Persistence**: UI settings (sort, density, visibility filter, archive filter, fork tracking, colour theme) saved between sessions
+- **Client-side Filtering & Sorting**: Once the account is cached via background fetch-all, visibility/archive filtering and all sorting run locally over the complete set — instant, with no server refetch
 - **Cross-platform**: Works on macOS, Linux, and Windows
 - **Secure Storage**: Token stored with proper file permissions (0600)
 - **Error Handling**: Graceful error recovery with retry mechanisms
-- **Performance**: Efficient GraphQL queries with virtualized rendering and server-side filtering
+- **Performance**: Light bulk GraphQL queries, virtualized rendering, and `React.memo`-optimized rows for instant keyboard navigation
 - **Comprehensive Logging**: Structured JSON logging with automatic rotation and configurable verbosity
 
 ## Installation
@@ -271,7 +271,7 @@ Launch the app, then use the keys below:
 ### Navigation & View Controls
 - **Top/Bottom**: `Ctrl+G` (top), `G` (bottom)
 - **Page Navigation**: ↑↓ Arrow keys, PageUp/PageDown
-- **Search**: `/` to enter search mode, type 3+ characters for server-side search
+- **Search**: `/` to enter search mode — instant, typo-tolerant fuzzy search over the full cached set (no network calls). Matches as you type; searches name, owner, description, and language
   - Down arrow or Enter: Start browsing search results
   - Esc: Clear search and return to full repository list
 - **Sort**: `S` opens sort modal with options:
@@ -333,6 +333,16 @@ Status bar shows loaded count vs total. A rate-limit line displays `remaining/li
 - **Background fetch-all:** the first page renders immediately, then the remaining repositories load in the background until the whole account is cached locally. Filtering, sorting, and search then operate over the complete set, client-side and instant.
 - Fetches 100 repos per page by default (configurable via `REPOS_PER_FETCH` environment variable, 1-100).
 - Reads `totalCount` from the first page and shows background-load progress (`loaded/total`) while filling. The list stays usable from the first page throughout; very large accounts simply take longer to finish loading.
+
+## Session Summary
+
+When you quit the app with `Q`, gh-manager-cli prints a short end-of-session report as two distinct framed panels:
+
+- **📊 Session Summary** — session duration, total operations performed, and a per-operation breakdown (e.g. "2 repositories archived", "1 repository transferred"). If nothing was changed, it simply notes "No changes were made this session."
+- **⏱ Estimated time saved** — a rough, friendly estimate of how much time you saved versus performing those operations by hand on github.com (each operation type has a conservative manual-time weight, e.g. delete ≈ 45s, transfer ≈ 60s, star ≈ 6s). Shown only when at least one operation was performed.
+- **💚 Thank you** — a separate sponsorship/feedback panel.
+
+Both single-repo and bulk actions are counted. The summary is not shown when exiting via `Ctrl+C`.
 
 ## Development
 
@@ -412,26 +422,26 @@ git push origin main
 Both NPM and Homebrew will be automatically updated within minutes of any version change.
 
 Environment variables:
-- `REPOS_PER_FETCH`: Number of repositories to fetch per page (1-50, default: 15)
+- `REPOS_PER_FETCH`: Number of repositories to fetch per page (1-100, default: 100)
 - `GH_MANAGER_DEBUG=1`: Enables debug mode with performance metrics, detailed errors, and console logging
 - `GH_TOKEN`: GitHub Personal Access Token (alternative to OAuth authentication)
 - `NO_COLOR`: Disable colored output in terminal
 
 Project layout:
-- `src/index.tsx` — CLI entry and error handling
-- `src/ui/App.tsx` — token bootstrap, renders `RepoList`
-- `src/ui/RepoList.tsx` — main list UI with modal management
-- `src/ui/components/` — modular components (modals, repo, common)
-  - `modals/` — DeleteModal, ArchiveModal, SyncModal, InfoModal, LogoutModal
-  - `repo/` — RepoRow, FilterInput, RepoListHeader
-  - `common/` — SlowSpinner and shared UI elements
-- `src/ui/OrgSwitcher.tsx` — organization switching component
-- `src/github.ts` — GraphQL client and queries (repos + rateLimit)
-- `src/config.ts` — token read/write and UI preferences
-- `src/logger.ts` — structured logging with rotation
+- `src/index.tsx` — CLI entry, flag parsing, error handling, end-of-session summary
 - `src/types.ts` — shared types
-- `src/utils.ts` — utility functions (truncate, formatDate)
-- `src/apolloMeta.ts` — Apollo cache management
+- `src/ui/App.tsx` — token bootstrap, renders `RepoList`
+- `src/ui/views/` — `RepoList.tsx` (main list UI, key handling, modal management) and `RepoList.main.tsx`
+- `src/ui/OrgSwitcher.tsx` — organisation switching component
+- `src/ui/hooks/` — `useTheme` and other shared hooks
+- `src/ui/components/` — modular components
+  - `modals/` — Delete, Archive, Sync, Info, Logout, Rename, Transfer, CopyUrl, CreateRepo, ChangeVisibility, Visibility, Sort, SortDirection, ArchiveFilter, Star, Unstar, OpenInBrowser, and the Bulk\* modals (Confirm, Review, Intent, Progress, Code, DeleteCode, TransferCode, TransferDestination, Visibility) plus `bulkActions.ts`
+  - `repo/` — RepoRow (memoised with `React.memo`), FilterInput, RepoListHeader
+  - `auth/` — AuthMethodSelector, OAuthProgress
+  - `common/` — SlowSpinner and shared UI elements
+- `src/services/` — `github.ts` (GraphQL client and queries), `oauth.ts` (device-flow auth), `apolloMeta.ts` (Apollo cache management)
+- `src/config/` — `config.ts` (token read/write and UI preferences), `constants.ts`, `themes.ts` (colour themes)
+- `src/lib/` — `logger.ts` (structured logging with rotation), `utils.ts` (truncate, formatDate), `session.ts` (usage tracking + summary), `fuzzySearch.ts` (fuse.js search)
 - `viewlogs.sh` — utility script for viewing logs
 
 ## Logging
@@ -513,7 +523,7 @@ Even with caching enabled, API credits may decrease due to:
 ### Configuration
 
 ```bash
-# Number of repositories to fetch per page (1-50, default: 15)
+# Number of repositories to fetch per page (1-100, default: 100)
 REPOS_PER_FETCH=10 npx gh-manager-cli@latest
 
 # Custom cache TTL (milliseconds) - default: 30 minutes
@@ -539,20 +549,23 @@ For the up-to-date task board, see [TODOs.md](./TODOs.md).
 Recently implemented:
 - ✅ OAuth login flow as an alternative to Personal Access Token
 - ✅ Density toggle for row spacing (compact/cozy/comfy)
-- ✅ Repo actions (archive/unarchive, delete, change visibility) with confirmations
+- ✅ Colour themes (Default, Ocean, Forest, Monochrome) cycled with `Shift+T`
+- ✅ Repo actions (archive/unarchive, delete, change visibility, rename, transfer) with confirmations
+- ✅ Bulk Select mode (`B`) — bulk star, archive/unarchive, visibility, delete, and transfer
 - ✅ Organization support and switching (press `W`) with enterprise detection
-- ✅ Enhanced server-side search with improved UX and organization context support
-- ✅ Smart infinite scroll with 80% prefetch trigger
+- ✅ Background fetch-all with instant client-side fuzzy search (fuse.js)
+- ✅ Fork ahead/behind enrichment after fetch-all completes
 - ✅ Modal-based sort and visibility filtering
 - ✅ GitHub Enterprise support with Internal repository visibility
 - ✅ Change repository visibility modal (`Ctrl+V`)
-- ✅ Compact filter modals for better screen space utilization
+- ✅ Copy repository URL to clipboard (`C`) with SSH/HTTPS options
+- ✅ End-of-session usage summary with time-saved estimate
 - ✅ Enhanced rate limit display showing both GraphQL and REST API limits with delta tracking
 
 Highlights on deck:
 - Optional OS keychain storage via `keytar`
-- Bulk selection and actions
-- Repository renaming
+- Language filter and indicators
+- Additional sort fields (created, size) and more CLI flags
 
 ## Support & Sponsorship
 

--- a/TODOs.md
+++ b/TODOs.md
@@ -84,7 +84,7 @@ Legend:
     - On failure: show error in modal with proper error handling
 
 - [x] Sync fork with upstream
-  - Assigned key `Ctrl+S` to trigger sync
+  - Assigned key `Ctrl+F` to trigger sync (`Ctrl+S` is star/unstar)
   - Only shown for forked repositories that are behind upstream
   - Confirmation modal showing:
     - Fork name and upstream repository
@@ -130,12 +130,15 @@ Legend:
   - [x] `RepoListHeaderVisibility` - Visibility filter display tests (new test file)
   - [x] `FilterInput` - Input handling and filter logic (6 tests - mocked TextInput)
   - [x] `SlowSpinner` - Animation component (5 tests)
-  - [x] `ArchiveModal` - Archive/unarchive confirmation flow (6 tests - mocked useInput)
-  - [~] `SyncModal` - Fork sync confirmation flow (not implemented)
-  - [x] `LogoutModal` - Logout confirmation flow (6 tests - mocked useInput)
+  - [x] `ArchiveModal` - Archive/unarchive confirmation flow (mocked useInput)
+  - [x] `SyncModal` - Fork sync confirmation flow
+  - [x] `LogoutModal` - Logout confirmation flow (mocked useInput)
+  - [x] `DeleteModal`, `RenameModal`, `TransferModal`, `CreateRepoModal`, `ChangeVisibilityModal`, `CopyUrlModal`, `StarModal`, `UnstarModal` - action modals with loading-guard tests
+  - [x] `BulkConfirmModal`, `BulkReviewModal`, `BulkCodeModal`, `BulkTransferDestinationModal`, `bulkActions` - bulk-select flow
+  - [x] `BulkSelectSearch` - bulk selection persisting across search
   - [~] `InfoModal` - Repository information display (not implemented)
   - [ ] `SortModal` - Sort selection modal (needs tests)
-  - [ ] `VisibilityModal` - Visibility filter modal (needs tests)
+  - [ ] `VisibilityModal` - Visibility filter modal (needs tests; `RepoListHeaderVisibility` covers the header display)
   - [ ] `RepoList` - Main component integration tests
   - [ ] `OrgSwitcher` - Organization switching logic
   
@@ -146,11 +149,11 @@ Legend:
   - [ ] Sorting and filtering combinations
   - [ ] Rate limit handling
   
-  **Current Progress:**
-  - Total test files: 12 (added RepoListHeaderVisibility.test.tsx)
-  - Total tests passing: 82+
-  - Components with tests: 8/13 (62%) - Added 2 new modals needing tests
-  - Utilities with tests: 4/4 (100%)
+  **Current Progress (as of v1.49.x):**
+  - Total test files: 31
+  - Total test cases: ~308
+  - Utilities/services with tests: utils, config, github, apolloMeta, logger, oauth, session, sponsorship
+  - Remaining gaps: InfoModal, SortModal, VisibilityModal, OrgSwitcher, RepoList integration
   
   **Testing Approach for useInput Components:**
   Successfully implemented mocking strategy for components using `useInput` hook:
@@ -177,19 +180,19 @@ Legend:
     - Header displays current context (org/@user or @user)
     - Automatic affiliation switching (OWNER for personal, ORGANIZATION_MEMBER for orgs)
 
-- [ ] Bulk selection and actions
+- [x] Bulk Select mode and actions (SWR-369/370/374)
   - Multi-select mode
-    - Enter multi-select with a key (e.g., `M`)
-    - Use Up/Down to navigate; Space toggles selection; `*` selects all in view; `U` unselects all
-    - Show selected count in header/footer
-  - Bulk operations
-    - Bulk archive/unarchive selected
-    - Bulk delete selected (with aggregate confirmation including per-repo list)
-    - Two-step confirm for destructive operations; follow modal UX (Left/Right, Enter, Y/C)
+    - Enter/exit Bulk Select with `B`; `Esc` exits and clears selection
+    - Up/Down to navigate; `Space` toggles selection; `X` unselects all
+    - Selected count shown; selections persist across search/filter/sort changes
+  - Bulk operations (reuse the global shortcuts)
+    - `Ctrl+S` bulk star/unstar, `Ctrl+A` bulk archive/unarchive, `Ctrl+V` bulk visibility
+    - `Del`/`Backspace` bulk delete, `Shift+M` bulk transfer to another owner/org
+    - Toggle actions auto-detect a safe direction; mixed selections show an intent modal
+    - Two-step confirm: review list (unselect) → count prompt → 4-char code (delete/transfer); modal UX (Left/Right, Enter, Y/C)
   - Performance and UX
-    - Use batched REST/GraphQL calls; display progress with spinner and per-item status
-    - On success: update local list states (archived flag or removal) without full refetch
-    - On failure: show summary with failed items and suggested remediation
+    - Sequential execution with per-repo progress; partial-failure summary at completion
+    - On success: update local list states (archived flag or removal) without full refetch; transferred repos removed from the list
 
 - [x] Infinite scroll improvements
   - [x] Inline loading indicator at end of list
@@ -213,6 +216,7 @@ Legend:
   - [x] Balanced repository item spacing (1 line above, 1 line below)
 
 - [x] Server‑side search  
+  - **Superseded (SWR-361):** the `/` search is now instant **client-side fuzzy** search (fuse.js) over the full cached set populated by background fetch-all (SWR-360). There is no longer a 3+ character minimum or a server-side query in the search path. The Apollo cache/persistence below remains; the rest is kept for historical context.
   - Support GitHub search for repos (beyond loaded pages) ✓
   - Integrate with `/` filter bar; show mode indicator ✓
   - Implemented Apollo Client + apollo3-cache-persist for normalized caching and persistence ✓
@@ -335,19 +339,16 @@ Legend:
 - [ ] Language filter and indicators
   - Quick language cycling; language legend in footer
 
-- [ ] Bulk actions
-  - Multi‑select and apply action to selection
-
 - [~] CLI flags (partial implementation)
   - [x] `--version` / `-v` flag to show version
   - [x] `--help` / `-h` flag to show usage
   - [x] `--org` to start with specific organization
     - Launch with `--org <slug>` to jump to that organisation context if accessible; otherwise ignored
     - Works with already authenticated session; overrides persisted context for the run
-  - [ ] `--token` / `-t` to provide a token for this run
-    - Accepts `--token <pat>` and `--token=<pat>` (and `-t` forms)
-    - Overrides env/config for the current process only; does not persist
-    - Show a brief security note about shell history; prefer env var or interactive prompt
+  - [x] `--token` / `-t` to provide a token for this run
+    - Accepts `--token <pat>` and `--token=<pat>` (and `-t` forms) ✓
+    - Overrides env/config for the current process only; does not persist ✓
+    - Show a brief security note about shell history; prefer env var or interactive prompt ✓
   - [ ] `--sort` to set initial sort field
   - [ ] `--filter` to set initial filter
   - [ ] `--page-size` to override default page size
@@ -363,6 +364,14 @@ Legend:
 
 ## Done
 
+- [x] Background fetch-all pagination + light bulk query (SWR-360); fork ahead/behind enrichment (SWR-362)
+- [x] Instant client-side fuzzy search over the full cached set with fuse.js (SWR-361)
+- [x] Client-side visibility filtering, dropping the redundant server refetch (SWR-366)
+- [x] Colour themes (Default, Ocean, Forest, Monochrome) cycled with `Shift+T`, persisted (SWR-354); theme-aware selected-row highlight (SWR-364)
+- [x] Transfer (move) repository to another owner/org, single and bulk (`Shift+M`) (SWR-369)
+- [x] Create new repository in the current context (`Ctrl+N`)
+- [x] End-of-session usage summary panel with time-saved estimate (SWR-19/SWR-375)
+- [x] Memoise `RepoRow` with `React.memo` + `arePropsEqual` to cut per-keystroke re-renders (SWR-358)
 - [x] Token bootstrap: prompt → validate → persist (0600)
 - [x] List personal repos with metadata
 - [x] Infinite scroll with page prefetch and dynamic totalCount
@@ -392,7 +401,7 @@ Legend:
   - Configured semantic-release to attach binaries to GitHub releases automatically
   - Added build:binaries script for local binary creation
   - Updated documentation with installation instructions for pre-built binaries
-- [x] Sync fork with upstream (`Ctrl+S`)
+- [x] Sync fork with upstream (`Ctrl+F`)
   - Shows modal with fork name, upstream repo, and commits behind
   - Executes sync via GitHub REST API with proper error handling
   - Updates local state and shows success/conflict messages


### PR DESCRIPTION
## Summary

Brings `README.md` and `TODOs.md` back in line with the v1.49.1 implementation. A codebase audit surfaced several **factual errors** (not just staleness) — corrected here. Closes SWR-378.

### README.md
- **Search**: was described as "type 3+ characters for **server-side** search" — it's actually instant **client-side fuzzy** search (fuse.js, `src/lib/fuzzySearch.ts`) from the first character.
- **Filtering**: removed the false "Server-side Filtering" claim — visibility/archive filtering and sorting run client-side over the cached set (SWR-366).
- **Project layout**: rewrote the stale tree to match the reorganised source (`src/services/`, `src/config/`, `src/lib/`, `src/ui/views/`, `src/ui/hooks/`, `auth/` components) and listed the full modal set (was 5 of 26).
- **Session summary**: documented the new end-of-session panel + time-saved estimate (SWR-375).
- **Roadmap**: moved shipped items (bulk select, rename, transfer, copy URL, themes, session summary) into "Recently implemented".
- **`REPOS_PER_FETCH`**: corrected to `1-100`, default `100` (two spots said `1-50`, default `15`).

### TODOs.md
- **Sync fork key**: `Ctrl+S` → `Ctrl+F` (`Ctrl+S` is star/unstar).
- **Test stats**: refreshed from "12 files / 82+ tests / 8/13 components" to **31 files / ~308 cases**, with remaining gaps listed.
- Marked **Bulk Select mode** and the **`--token` flag** as shipped.
- Noted the old server-side search is **superseded by client-side fuzzy** (SWR-361).
- Added Done entries for SWR-360/361/362/366/354/364/369/375/358.

## Notes / out of scope
Two stale references were found in **code/AGENTS.md** (not touched here, since this PR is scoped to README/TODOs):
- `src/index.tsx` `--help` text and the `getPageSize` comment still say "1-50, default 15" (code actually defaults to 100, accepts 1-100).
- AGENTS.md still lists an `F` fork-tracking toggle (fork tracking is now always-on) and references `automated-release.yml` (now `release.yml`).

## Test plan
Docs-only change — no code touched, no build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or build impact.
> 
> **Overview**
> **Docs-only PR (SWR-378)** — aligns `README.md` and `TODOs.md` with the v1.49.x app; no application code changes.
> 
> **README** fixes prior inaccuracies: search is described as **instant client-side fuzzy** (fuse.js) instead of a 3+ character server-side query; technical features now emphasize **client-side filtering/sorting** over the background-cached set instead of “server-side filtering.” It adds **Session Summary** (quit with `Q`), updates **pagination** (background fetch-all, `REPOS_PER_FETCH` **1–100**, default **100**), rewrites the **project layout** to `src/services/`, `src/config/`, `src/lib/`, `src/ui/views/`, and the full modal set, and moves shipped work (bulk select, themes, transfer, copy URL, etc.) into **Recently implemented**.
> 
> **TODOs** updates the sync-fork shortcut to **`Ctrl+F`**, refreshes **test coverage** stats (~31 files / ~308 cases), marks **bulk select** and **`--token`** as done, notes server-side search is **superseded** by client-side fuzzy, and adds **Done** entries for recent SWR tickets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 239c6b50c55ca784aa68ec66e4829e1ab924333f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->