### PR TITLE
feat: show open PR and issue counts inline on repo rows (SWR-357) [semantic pr title]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ See the living roadmap in [TODOs.md](./TODOs.md) for the canonical, up-to-date l
 - Selected fields: name/nameWithOwner/description/visibility/isPrivate/isFork/isArchived/stargazerCount/forkCount/primaryLanguage/updatedAt/pushedAt/diskUsage, plus `parent { nameWithOwner }` and `defaultBranchRef { name }`.
 - **Light bulk query (SWR-360):** the list/search queries intentionally do NOT fetch per-repo commit history (`history.totalCount`). Computing that for each repo and its parent across 100 repos/page exceeds GitHub's per-query budget and returns HTTP 502. Fork `parent { nameWithOwner }` is still fetched so the "Fork of X" label always shows.
 - **Fork ahead/behind enrichment (SWR-362):** after the background fetch-all completes, a separate effect (`useEffect` gated on `!loading && !loadingMore && !hasNextPage`) enriches forks-only with commit counts. It uses `enrichForksWithAheadBehind` which builds a batched aliased GraphQL query (`fork_N: node(id:)` + `parent_N: repository(owner,name)`) capped at 5 forks per request (10 history queries). Results are merged directly into `items` state. A 200ms delay between batches throttles rate-limit consumption. Already-enriched IDs are tracked in `enrichmentDoneRef` to avoid re-fetching. Both `(N ahead)` and `(N behind)` are displayed in `RepoRow` and the sync confirmation modal.
+- **Open PR/Issue counts (SWR-357):** every list/search/starred query fetches `openPullRequests: pullRequests(states: OPEN) { totalCount }` and `openIssues: issues(states: OPEN) { totalCount }` inline, always on (no toggle, no enrichment pass). `totalCount`-only connections add ~0 node cost under GitHub's GraphQL cost formula, so a 100-repo page stays at cost ~1 — unlike `history.totalCount` (SWR-360), these indexed counts are cheap enough to fold into the main page fetches. Responses are normalised via `normalizeRepoNode` which flattens `{ totalCount: N }` → `RepoNode.openPullRequests` / `openIssues` (plain numbers) so renderers and threshold colouring see a flat shape. Rendered inline on every `RepoRow` (line 2) and behind the `L` keybinding's chooser modal.
 
 ## Controls
 
@@ -127,6 +128,7 @@ See the living roadmap in [TODOs.md](./TODOs.md) for the canonical, up-to-date l
 - `V`: visibility filter modal (All, Public, Private/Internal)
 - `W`: organisation switcher
 - Enter or `O`: open selected repo in browser; for forks shows a chooser (This repository / Parent/upstream, Esc cancels)
+- `L`: open the selected repo's PRs or Issues list — chooser modal (Pull Requests / Issues, Esc/C cancels). Counts are rendered inline on every row from the same fields (SWR-357)
 - `P`: on a fork — jump cursor to the parent repo if it is already loaded; otherwise fetches the parent repo and shows it in the Info modal
 - `I`: repository info modal
 - `K`: cache inspection

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ On first run, you'll be prompted to authenticate with GitHub (OAuth recommended)
 - **Repository Actions**:
   - View detailed info (`I`) - Shows repository metadata, language, size, and timestamps
   - Open in browser (Enter/`O`) — for forks a chooser lets you open this repo or the upstream
+  - Jump to PRs/Issues (`L`) — chooser modal for the selected repo's open pull requests or issues; counts are shown inline on every row so you can spot backlogs at a glance
   - Jump to upstream (`P`) — moves cursor to the parent if loaded; otherwise fetches and shows it
   - Create new repository (`Ctrl+N`) — prompts for a name (with the personal/organisation slug shown in front), choose visibility with `Tab`, and surfaces GitHub errors inline
   - Rename repository (`Ctrl+R`) with inline validation and automatic cache update
@@ -290,6 +291,7 @@ Launch the app, then use the keys below:
 
 ### Navigation & Account
 - **Open in browser**: Enter or `O` — non-forks open directly; forks show a chooser (**This repository** / **Parent/upstream**, Esc cancels)
+- **Open PRs / Issues**: `L` — chooser modal (**Pull Requests** / **Issues**) for the selected repo. Counts are shown inline on every row as `⇄ N PRs ◇ M issues`, colour-coded (muted at 0, default 1–9, amber 10–29, red 30+) so growing backlogs stand out. Esc/C cancels
 - **Jump to upstream**: `P` (on a fork) — moves cursor to the parent if it is already loaded; otherwise fetches the parent and shows it in the Info modal
 - **Refresh**: `R`
 - **Organisation switcher**: `W` to switch between personal account and organisations

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -182,6 +182,35 @@ export interface ReposPageResult {
   rateLimit?: RateLimitInfo;
 }
 
+/**
+ * Flatten the `openPullRequests { totalCount }` / `openIssues { totalCount }`
+ * GraphQL responses into plain numbers on `RepoNode` (SWR-357).
+ *
+ * The GraphQL queries request `openPullRequests: pullRequests(states: OPEN) { totalCount }`
+ * (and the same for issues). The raw response shape is `{ totalCount: N }`, but
+ * the rest of the app treats `RepoNode.openPullRequests` as a flat number for
+ * convenience in row-rendering and threshold colouring. Nodes that do not
+ * include the connections (older cache reads, fragments without the fields)
+ * fall through untouched.
+ */
+export function normalizeRepoNode<T extends Record<string, any>>(node: T): T {
+  if (!node) return node;
+  const result: any = { ...node };
+  const pr = (node as any).openPullRequests;
+  if (pr && typeof pr === 'object' && 'totalCount' in pr) {
+    result.openPullRequests = pr.totalCount as number;
+  }
+  const iss = (node as any).openIssues;
+  if (iss && typeof iss === 'object' && 'totalCount' in iss) {
+    result.openIssues = iss.totalCount as number;
+  }
+  return result as T;
+}
+
+function normalizeRepoNodes(nodes: any[]): RepoNode[] {
+  return (nodes || []).map(n => normalizeRepoNode(n)) as RepoNode[];
+}
+
 export type OwnerAffiliation = 'OWNER' | 'COLLABORATOR' | 'ORGANIZATION_MEMBER';
 
 export async function fetchViewerReposPage(
@@ -243,6 +272,8 @@ export async function fetchViewerReposPage(
               stargazerCount
               forkCount
               viewerHasStarred
+              openPullRequests: pullRequests(states: OPEN) { totalCount }
+              openIssues: issues(states: OPEN) { totalCount }
               primaryLanguage {
                 name
                 color
@@ -299,14 +330,14 @@ export async function fetchViewerReposPage(
     
     const data = res.organization.repositories;
     return {
-      nodes: data.nodes as RepoNode[],
+      nodes: normalizeRepoNodes(data.nodes),
       endCursor: data.pageInfo.endCursor,
       hasNextPage: data.pageInfo.hasNextPage,
       totalCount: data.totalCount,
       rateLimit: res.rateLimit as RateLimitInfo,
     };
   }
-  
+
   // For personal context (viewer's repositories)
   const query = /* GraphQL */ `
     query ViewerRepos(
@@ -344,6 +375,8 @@ export async function fetchViewerReposPage(
             isArchived
             stargazerCount
             forkCount
+            openPullRequests: pullRequests(states: OPEN) { totalCount }
+            openIssues: issues(states: OPEN) { totalCount }
             primaryLanguage {
               name
               color
@@ -398,7 +431,7 @@ export async function fetchViewerReposPage(
     const data = res.viewer.repositories;
     logger.info(`Octokit successfully fetched ${data.nodes.length} repositories`);
     return {
-      nodes: data.nodes as RepoNode[],
+      nodes: normalizeRepoNodes(data.nodes),
       endCursor: data.pageInfo.endCursor,
       hasNextPage: data.pageInfo.hasNextPage,
       totalCount: data.totalCount,
@@ -477,6 +510,8 @@ export async function fetchViewerReposPageUnified(
                   stargazerCount
                   forkCount
                   viewerHasStarred
+                  openPullRequests: pullRequests(states: OPEN) { totalCount }
+                  openIssues: issues(states: OPEN) { totalCount }
                   owner { __typename login }
                   primaryLanguage { name color }
                   updatedAt
@@ -511,6 +546,8 @@ export async function fetchViewerReposPageUnified(
                   stargazerCount
                   forkCount
                   viewerHasStarred
+                  openPullRequests: pullRequests(states: OPEN) { totalCount }
+                  openIssues: issues(states: OPEN) { totalCount }
                   owner { __typename login }
                   primaryLanguage { name color }
                   updatedAt
@@ -557,7 +594,7 @@ export async function fetchViewerReposPageUnified(
       });
         
       return {
-        nodes: data.nodes as RepoNode[],
+        nodes: normalizeRepoNodes(data.nodes),
         endCursor: data.pageInfo.endCursor,
         hasNextPage: data.pageInfo.hasNextPage,
         totalCount: data.totalCount,
@@ -565,7 +602,7 @@ export async function fetchViewerReposPageUnified(
       };
     }
   } catch (e: any) {
-    logger.error('Apollo query failed', { 
+    logger.error('Apollo query failed', {
       error: e.message, 
       stack: e.stack,
       graphQLErrors: e.graphQLErrors,
@@ -622,6 +659,8 @@ export async function searchRepositoriesUnified(
               stargazerCount
               forkCount
               viewerHasStarred
+              openPullRequests: pullRequests(states: OPEN) { totalCount }
+              openIssues: issues(states: OPEN) { totalCount }
               owner { __typename login }
               primaryLanguage { name color }
               updatedAt
@@ -641,7 +680,7 @@ export async function searchRepositoriesUnified(
     });
     const data = res.data.search;
     return {
-      nodes: data.nodes as RepoNode[],
+      nodes: normalizeRepoNodes(data.nodes),
       endCursor: data.pageInfo.endCursor,
       hasNextPage: data.pageInfo.hasNextPage,
       totalCount: data.repositoryCount,
@@ -916,6 +955,8 @@ export async function getStarredRepositories(
             stargazerCount
             forkCount
             viewerHasStarred
+            openPullRequests: pullRequests(states: OPEN) { totalCount }
+            openIssues: issues(states: OPEN) { totalCount }
             owner {
               __typename
               login
@@ -944,14 +985,14 @@ export async function getStarredRepositories(
     });
 
     const data = res.viewer.starredRepositories;
-    
+
     logger.info('Successfully fetched starred repositories', {
       count: data.nodes?.length || 0,
       totalCount: data.totalCount
     });
 
     return {
-      nodes: data.nodes as RepoNode[],
+      nodes: normalizeRepoNodes(data.nodes),
       endCursor: data.pageInfo.endCursor,
       hasNextPage: data.pageInfo.hasNextPage,
       totalCount: data.totalCount,

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,21 @@ export interface RepoNode {
   isArchived: boolean;
   stargazerCount: number;
   forkCount: number;
+  /**
+   * Open pull request count for the repository (SWR-357).
+   *
+   * Fetched inline on every list/search query as `pullRequests(states: OPEN) { totalCount }`
+   * — `totalCount`-only connections add ~0 node cost under GitHub's GraphQL cost
+   * formula, so this is always-on (no toggle, no enrichment pass). Always defined
+   * on freshly fetched nodes; the optional marker covers older cache reads that
+   * pre-date the field landing.
+   */
+  openPullRequests?: number;
+  /**
+   * Open issue count for the repository (SWR-357). See `openPullRequests` for
+   * why this is always-on; same cost characteristics apply.
+   */
+  openIssues?: number;
   viewerHasStarred?: boolean;
   primaryLanguage: Maybe<Language>;
   updatedAt: string; // ISO

--- a/src/ui/components/modals/OpenPRsIssuesModal.tsx
+++ b/src/ui/components/modals/OpenPRsIssuesModal.tsx
@@ -1,0 +1,102 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import type { RepoNode } from '../../../types';
+import type { Theme } from '../../../config/themes';
+import { useTheme } from '../../hooks/useTheme';
+
+interface OpenPRsIssuesModalProps {
+  repo: RepoNode;
+  onOpen: (url: string) => void;
+  onCancel: () => void;
+  theme?: Theme;
+}
+
+/**
+ * Chooser modal for jumping to the selected repository's `/pulls` or `/issues`
+ * page on github.com (SWR-357).
+ *
+ * Bound to the `L` ("Links") key in `RepoList`. Counts shown in each option
+ * mirror the inline badges on `RepoRow`, so the user can confirm they are
+ * heading to the right backlog before the browser opens.
+ */
+export default function OpenPRsIssuesModal({ repo, onOpen, onCancel, theme: themeProp }: OpenPRsIssuesModalProps) {
+  const { theme, c } = useTheme(themeProp?.name ?? 'default');
+  const [focus, setFocus] = useState<'prs' | 'issues'>('prs');
+
+  const prUrl = `https://github.com/${repo.nameWithOwner}/pulls`;
+  const issuesUrl = `https://github.com/${repo.nameWithOwner}/issues`;
+
+  const prCount = typeof repo.openPullRequests === 'number' ? repo.openPullRequests : null;
+  const issueCount = typeof repo.openIssues === 'number' ? repo.openIssues : null;
+
+  useInput((input, key) => {
+    if (key.escape || input.toLowerCase() === 'c') {
+      onCancel();
+      return;
+    }
+
+    if (key.leftArrow || key.rightArrow) {
+      setFocus(prev => (prev === 'prs' ? 'issues' : 'prs'));
+      return;
+    }
+
+    if (key.return) {
+      onOpen(focus === 'prs' ? prUrl : issuesUrl);
+      return;
+    }
+
+    if (input.toLowerCase() === 'p') {
+      onOpen(prUrl);
+      return;
+    }
+
+    if (input.toLowerCase() === 'i') {
+      onOpen(issuesUrl);
+      return;
+    }
+  });
+
+  const prLabel = prCount !== null ? `Pull Requests (${prCount})` : 'Pull Requests';
+  const issuesLabel = issueCount !== null ? `Issues (${issueCount})` : 'Issues';
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={theme.primary}
+      paddingX={3}
+      paddingY={2}
+      width={62}
+    >
+      <Text bold color={theme.primary}>Open PRs / Issues</Text>
+      <Box height={1}><Text> </Text></Box>
+      <Text bold>{repo.nameWithOwner}</Text>
+      <Box height={1}><Text> </Text></Box>
+      <Text>Which backlog would you like to open?</Text>
+      <Box height={1}><Text> </Text></Box>
+
+      <Box marginTop={1} flexDirection="row" justifyContent="center" gap={4}>
+        <Box paddingX={2} paddingY={1}>
+          <Text>
+            {focus === 'prs'
+              ? c.primary.inverse.bold(` ${prLabel} `)
+              : c.primary.bold(prLabel)}
+          </Text>
+        </Box>
+        <Box paddingX={2} paddingY={1}>
+          <Text>
+            {focus === 'issues'
+              ? c.success.inverse.bold(` ${issuesLabel} `)
+              : c.success.bold(issuesLabel)}
+          </Text>
+        </Box>
+      </Box>
+
+      <Box marginTop={1} flexDirection="row" justifyContent="center">
+        <Text color={theme.muted}>
+          ←/→ Choose • Enter to Open • P PRs • I Issues • C/Esc Cancel
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/components/modals/index.ts
+++ b/src/ui/components/modals/index.ts
@@ -23,5 +23,6 @@ export type { BulkProgressState } from './BulkProgressModal';
 export type { BulkAction, BulkVisibilityTarget, BulkActionColor } from './bulkActions';
 export { bulkActionMeta } from './bulkActions';
 export { default as OpenInBrowserModal } from './OpenInBrowserModal';
+export { default as OpenPRsIssuesModal } from './OpenPRsIssuesModal';
 export { default as CreateRepoModal } from './CreateRepoModal';
 export { default as TransferModal } from './TransferModal';

--- a/src/ui/components/repo/RepoRow.tsx
+++ b/src/ui/components/repo/RepoRow.tsx
@@ -122,7 +122,33 @@ function RepoRow({
     let line2 = '     ';
     const metaColor = selected ? c.text : c.muted;
     if (langName) line2 += chalk.hex(langColor)('● ') + metaColor(`${langName}  `);
-    line2 += metaColor(`★ ${repo.stargazerCount}  ⑂ ${repo.forkCount}  Updated ${formatDate(repo.updatedAt)}`);
+    line2 += metaColor(`★ ${repo.stargazerCount}  ⑂ ${repo.forkCount}`);
+
+    // Open PR / Issue counts with threshold-based colouring (SWR-357).
+    // Cutoffs: 0 → muted ("nothing to do"), 1-9 → text (visible but neutral),
+    // 10-29 → warning (amber), 30+ → error (red). Picked to flag accounts with
+    // growing backlogs without making small counts feel alarming. `c.text` (not
+    // `metaColor`) is used for the 1-9 band so the colour is distinct from the 0
+    // band even when the row isn't selected (`metaColor` collapses to muted in
+    // that state). The counts only render when the field is defined on the node
+    // — older cache reads (pre-SWR-357) leave them out, in which case the row
+    // falls back to its prior shape rather than showing "?".
+    const prCount = repo.openPullRequests;
+    const issueCount = repo.openIssues;
+    const colourForCount = (n: number) => {
+      if (n === 0) return c.muted;
+      if (n < 10) return c.text;
+      if (n < 30) return c.warning;
+      return c.error;
+    };
+    if (typeof prCount === 'number') {
+      line2 += metaColor('  ') + colourForCount(prCount)(`⇄ ${prCount} PR${prCount === 1 ? '' : 's'}`);
+    }
+    if (typeof issueCount === 'number') {
+      line2 += metaColor('  ') + colourForCount(issueCount)(`◇ ${issueCount} issue${issueCount === 1 ? '' : 's'}`);
+    }
+
+    line2 += metaColor(`  Updated ${formatDate(repo.updatedAt)}`);
 
     // Build line 3
     const line3 = repo.description ? `     ${truncate(repo.description, Math.max(30, maxWidth - 10))}` : null;

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -12,7 +12,7 @@ import type { RepoNode, RateLimitInfo, RestRateLimitInfo } from '../../types';
 import { exec } from 'child_process';
 import OrgSwitcher from '../OrgSwitcher';
 import { logger } from '../../lib/logger';
-import { ArchiveFilterModal, DeleteModal, ArchiveModal, SyncModal, InfoModal, LogoutModal, VisibilityModal, SortModal, SortDirectionModal, ChangeVisibilityModal, CopyUrlModal, RenameModal, StarModal, BulkReviewModal, BulkConfirmModal, BulkDeleteCodeModal, BulkTransferCodeModal, BulkTransferDestinationModal, BulkIntentModal, BulkVisibilityModal, BulkProgressModal, OpenInBrowserModal, CreateRepoModal, TransferModal, bulkActionMeta } from '../components/modals';
+import { ArchiveFilterModal, DeleteModal, ArchiveModal, SyncModal, InfoModal, LogoutModal, VisibilityModal, SortModal, SortDirectionModal, ChangeVisibilityModal, CopyUrlModal, RenameModal, StarModal, BulkReviewModal, BulkConfirmModal, BulkDeleteCodeModal, BulkTransferCodeModal, BulkTransferDestinationModal, BulkIntentModal, BulkVisibilityModal, BulkProgressModal, OpenInBrowserModal, OpenPRsIssuesModal, CreateRepoModal, TransferModal, bulkActionMeta } from '../components/modals';
 import type { BulkAction, BulkVisibilityTarget, BulkProgressState } from '../components/modals';
 import { UnstarModal } from '../components/modals/UnstarModal';
 import { RepoRow, FilterInput, RepoListHeader } from '../components/repo';
@@ -243,6 +243,9 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   // Open-in-browser chooser modal state (fork vs upstream)
   const [openInBrowserMode, setOpenInBrowserMode] = useState(false);
   const [openInBrowserTarget, setOpenInBrowserTarget] = useState<RepoNode | null>(null);
+  // SWR-357: chooser modal for jumping to the selected repo's PRs/Issues list
+  const [openLinksMode, setOpenLinksMode] = useState(false);
+  const [openLinksTarget, setOpenLinksTarget] = useState<RepoNode | null>(null);
 
   // Fork enrichment (ahead/behind) state
   const [enrichingForks, setEnrichingForks] = useState(false);
@@ -1632,6 +1635,11 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return; // OpenInBrowserModal component handles its own keyboard input
     }
 
+    // When open-PRs/issues modal is open, trap inputs for modal (SWR-357)
+    if (openLinksMode) {
+      return; // OpenPRsIssuesModal component handles its own keyboard input
+    }
+
     // When copy URL modal is open, trap inputs for modal
     if (copyUrlMode) {
       return; // CopyUrlModal component handles its own keyboard input
@@ -2020,6 +2028,19 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       return;
     }
 
+    // Open PRs / Issues chooser (L for "Links") — SWR-357.
+    // Plain L only; Ctrl+L is reserved for logout. The modal works fine even
+    // when the count fields are missing (older cache reads pre-SWR-357), so
+    // we don't gate on `openPullRequests` / `openIssues` being present.
+    if (input && input.toUpperCase() === 'L' && !key.ctrl) {
+      const repo = visibleItems[cursor];
+      if (repo) {
+        setOpenLinksTarget(repo);
+        setOpenLinksMode(true);
+      }
+      return;
+    }
+
     // Jump to upstream (P) - move cursor if parent is in list, else fetch and show in Info modal
     if (input && input.toUpperCase() === 'P') {
       const repo = visibleItems[cursor];
@@ -2253,7 +2274,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
 
   const lowRate = (rateLimit && rateLimit.remaining <= Math.ceil(rateLimit.limit * 0.1)) || 
                    (restRateLimit && restRateLimit.core.remaining <= Math.ceil(restRateLimit.core.limit * 0.1));
-  const modalOpen = deleteMode || archiveMode || syncMode || logoutMode || infoMode || visibilityMode || archiveFilterMode || sortMode || sortDirectionMode || changeVisibilityMode || copyUrlMode || renameMode || bulkIntentKind !== null || bulkVisibilityOpen || bulkReviewOpen || bulkConfirmOpen || bulkDeleteCodeOpen || bulkTransferDestinationOpen || bulkTransferCodeOpen || bulkProgressOpen || openInBrowserMode || createMode || transferMode;
+  const modalOpen = deleteMode || archiveMode || syncMode || logoutMode || infoMode || visibilityMode || archiveFilterMode || sortMode || sortDirectionMode || changeVisibilityMode || copyUrlMode || renameMode || bulkIntentKind !== null || bulkVisibilityOpen || bulkReviewOpen || bulkConfirmOpen || bulkDeleteCodeOpen || bulkTransferDestinationOpen || bulkTransferCodeOpen || bulkProgressOpen || openInBrowserMode || openLinksMode || createMode || transferMode;
 
   // Display metadata for the in-flight bulk action (label/colour/verbs).
   const bulkMeta = bulkAction ? bulkActionMeta(bulkAction, bulkVisibilityTarget ?? undefined) : null;
@@ -3055,6 +3076,22 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               theme={theme}
             />
           </Box>
+        ) : openLinksMode && openLinksTarget ? (
+          <Box height={contentHeight} alignItems="center" justifyContent="center">
+            <OpenPRsIssuesModal
+              repo={openLinksTarget}
+              onOpen={(url) => {
+                openInBrowser(url);
+                setOpenLinksMode(false);
+                setOpenLinksTarget(null);
+              }}
+              onCancel={() => {
+                setOpenLinksMode(false);
+                setOpenLinksTarget(null);
+              }}
+              theme={theme}
+            />
+          </Box>
         ) : (
           <>
             {/* Context/Filter/sort status */}
@@ -3201,8 +3238,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         <Box width={terminalWidth} justifyContent="center">
           <Text color={theme.muted} dimColor={modalOpen ? true : undefined}>
             {starsMode ?
-              'Shift+S My Repos • I Info • C Copy URL • U Unstar Repository' :
-              `${ownerContext === 'personal' ? 'Shift+S Starred • ' : ''}I Info • C Copy URL • Ctrl+S Un/Star • Ctrl+R Rename • Shift+M Transfer • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+F Sync Fork • P Jump to upstream`
+              'Shift+S My Repos • I Info • C Copy URL • L PRs/Issues • U Unstar Repository' :
+              `${ownerContext === 'personal' ? 'Shift+S Starred • ' : ''}I Info • C Copy URL • L PRs/Issues • Ctrl+S Un/Star • Ctrl+R Rename • Shift+M Transfer • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+F Sync Fork • P Jump to upstream`
             }
           </Text>
         </Box>

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -10,7 +10,7 @@ vi.mock('../src/lib/logger', () => ({
   }
 }));
 
-import { makeClient, getViewerLogin, fetchViewerOrganizations } from '../src/services/github';
+import { makeClient, getViewerLogin, fetchViewerOrganizations, normalizeRepoNode } from '../src/services/github';
 
 // Mock @octokit/graphql
 vi.mock('@octokit/graphql', () => ({
@@ -209,6 +209,96 @@ describe('github', () => {
       expect(orgs).toHaveLength(1);
       expect(orgs[0].name).toBeNull();
       expect(orgs[0].login).toBe('org-without-name');
+    });
+  });
+
+  describe('normalizeRepoNode (SWR-357)', () => {
+    it('flattens openPullRequests { totalCount } onto the node as a number', () => {
+      const raw = {
+        id: 'R_1',
+        nameWithOwner: 'octocat/hello',
+        openPullRequests: { totalCount: 5 },
+        openIssues: { totalCount: 12 },
+      };
+      const node = normalizeRepoNode(raw);
+      expect(node.openPullRequests).toBe(5);
+      expect(node.openIssues).toBe(12);
+    });
+
+    it('preserves all other fields untouched', () => {
+      const raw = {
+        id: 'R_1',
+        nameWithOwner: 'octocat/hello',
+        stargazerCount: 99,
+        description: 'desc',
+        openPullRequests: { totalCount: 0 },
+        openIssues: { totalCount: 0 },
+        primaryLanguage: { name: 'Go', color: '#00ADD8' },
+      };
+      const node = normalizeRepoNode(raw);
+      expect(node.id).toBe('R_1');
+      expect(node.nameWithOwner).toBe('octocat/hello');
+      expect(node.stargazerCount).toBe(99);
+      expect(node.description).toBe('desc');
+      expect(node.primaryLanguage).toEqual({ name: 'Go', color: '#00ADD8' });
+    });
+
+    it('coerces zero counts correctly (not falsy-skipped)', () => {
+      const node = normalizeRepoNode({
+        openPullRequests: { totalCount: 0 },
+        openIssues: { totalCount: 0 },
+      });
+      expect(node.openPullRequests).toBe(0);
+      expect(node.openIssues).toBe(0);
+    });
+
+    it('leaves nodes without the connection fields alone', () => {
+      const raw = { id: 'R_2', nameWithOwner: 'octocat/old-cache' };
+      const node = normalizeRepoNode(raw);
+      expect(node.openPullRequests).toBeUndefined();
+      expect(node.openIssues).toBeUndefined();
+      expect(node.id).toBe('R_2');
+    });
+
+    it('handles null nodes defensively', () => {
+      expect(normalizeRepoNode(null as any)).toBeNull();
+    });
+  });
+
+  describe('GraphQL query shape (SWR-357)', () => {
+    it('list queries include the openPullRequests / openIssues alias selections', async () => {
+      // Verify the raw query template strings on the fallback Octokit path —
+      // those are the strings that actually hit GitHub when Apollo is unavailable,
+      // so they must always carry the SWR-357 fields.
+      const { fetchViewerReposPage } = await import('../src/services/github');
+      const captured: string[] = [];
+      const mockClient: any = vi.fn(async (query: string) => {
+        captured.push(query);
+        return {
+          rateLimit: { limit: 5000, remaining: 4999, resetAt: new Date().toISOString() },
+          viewer: {
+            repositories: {
+              nodes: [],
+              pageInfo: { endCursor: null, hasNextPage: false },
+              totalCount: 0,
+            },
+          },
+          organization: {
+            repositories: {
+              nodes: [],
+              pageInfo: { endCursor: null, hasNextPage: false },
+              totalCount: 0,
+            },
+          },
+        };
+      });
+
+      await fetchViewerReposPage(mockClient, 100);
+      await fetchViewerReposPage(mockClient, 100, null, undefined, true, ['OWNER'], 'my-org');
+
+      const all = captured.join('\n');
+      expect(all).toMatch(/openPullRequests:\s*pullRequests\(states:\s*OPEN\)\s*\{\s*totalCount\s*\}/);
+      expect(all).toMatch(/openIssues:\s*issues\(states:\s*OPEN\)\s*\{\s*totalCount\s*\}/);
     });
   });
 });

--- a/tests/ui/OpenPRsIssuesModal.test.tsx
+++ b/tests/ui/OpenPRsIssuesModal.test.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from 'ink-testing-library';
+
+// Capture useInput callback so we can drive it from tests.
+const inputCallbacks: Array<(input: string, key: any) => void> = [];
+
+vi.mock('ink', async () => {
+  const actual = await vi.importActual<any>('ink');
+  return {
+    ...actual,
+    useInput: vi.fn((cb: any) => {
+      inputCallbacks.push(cb);
+    }),
+  };
+});
+
+import OpenPRsIssuesModal from '../../src/ui/components/modals/OpenPRsIssuesModal';
+
+const repoStub: any = {
+  id: 'R_1',
+  nameWithOwner: 'octocat/Hello-World',
+  description: 'A test repo',
+  stargazerCount: 5,
+  forkCount: 2,
+  openPullRequests: 4,
+  openIssues: 11,
+  isPrivate: false,
+  isArchived: false,
+  isFork: false,
+  primaryLanguage: { name: 'TypeScript', color: '#3178c6' },
+  updatedAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+  pushedAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+  diskUsage: 100,
+};
+
+const fireKey = (input: string, key: Partial<Record<string, boolean>> = {}) => {
+  const cb = inputCallbacks[inputCallbacks.length - 1];
+  cb(input, {
+    return: false,
+    escape: false,
+    leftArrow: false,
+    rightArrow: false,
+    ctrl: false,
+    shift: false,
+    ...key,
+  });
+};
+
+describe('OpenPRsIssuesModal (SWR-357)', () => {
+  beforeEach(() => {
+    inputCallbacks.length = 0;
+  });
+
+  it('renders chooser with PR and issue counts in the labels', () => {
+    const { lastFrame, unmount } = render(
+      <OpenPRsIssuesModal repo={repoStub} onOpen={() => {}} onCancel={() => {}} />
+    );
+    const output = lastFrame() || '';
+    expect(output).toContain('octocat/Hello-World');
+    expect(output).toContain('Pull Requests (4)');
+    expect(output).toContain('Issues (11)');
+    unmount();
+  });
+
+  it('omits the counts when the fields are undefined (older cache reads)', () => {
+    const repo = { ...repoStub };
+    delete (repo as any).openPullRequests;
+    delete (repo as any).openIssues;
+    const { lastFrame, unmount } = render(
+      <OpenPRsIssuesModal repo={repo} onOpen={() => {}} onCancel={() => {}} />
+    );
+    const output = lastFrame() || '';
+    expect(output).toContain('Pull Requests');
+    expect(output).toContain('Issues');
+    // No parenthesised count when missing
+    expect(output).not.toMatch(/Pull Requests\s*\(/);
+    expect(output).not.toMatch(/Issues\s*\(/);
+    unmount();
+  });
+
+  it('Enter on the default (PRs) focus opens the /pulls URL', () => {
+    const onOpen = vi.fn();
+    const onCancel = vi.fn();
+    const { unmount } = render(
+      <OpenPRsIssuesModal repo={repoStub} onOpen={onOpen} onCancel={onCancel} />
+    );
+
+    fireKey('', { return: true });
+    expect(onOpen).toHaveBeenCalledWith('https://github.com/octocat/Hello-World/pulls');
+    expect(onCancel).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('right arrow then Enter switches focus to Issues and opens /issues', async () => {
+    const onOpen = vi.fn();
+    const { unmount } = render(
+      <OpenPRsIssuesModal repo={repoStub} onOpen={onOpen} onCancel={() => {}} />
+    );
+
+    fireKey('', { rightArrow: true });
+    // Flush React's re-render so the next useInput closure sees focus='issues'.
+    // The mock pushes the new callback on re-mount; without this flush we'd
+    // re-enter the original closure that still reads focus='prs'.
+    await new Promise(r => setTimeout(r, 0));
+    fireKey('', { return: true });
+    expect(onOpen).toHaveBeenCalledWith('https://github.com/octocat/Hello-World/issues');
+    unmount();
+  });
+
+  it('P shortcut opens /pulls regardless of focus', async () => {
+    const onOpen = vi.fn();
+    const { unmount } = render(
+      <OpenPRsIssuesModal repo={repoStub} onOpen={onOpen} onCancel={() => {}} />
+    );
+    // Move focus to issues, then press P — should still go to /pulls.
+    fireKey('', { rightArrow: true });
+    await new Promise(r => setTimeout(r, 0));
+    fireKey('p');
+    expect(onOpen).toHaveBeenCalledWith('https://github.com/octocat/Hello-World/pulls');
+    unmount();
+  });
+
+  it('I shortcut opens /issues regardless of focus', () => {
+    const onOpen = vi.fn();
+    const { unmount } = render(
+      <OpenPRsIssuesModal repo={repoStub} onOpen={onOpen} onCancel={() => {}} />
+    );
+    fireKey('i');
+    expect(onOpen).toHaveBeenCalledWith('https://github.com/octocat/Hello-World/issues');
+    unmount();
+  });
+
+  it('Esc cancels without opening', () => {
+    const onOpen = vi.fn();
+    const onCancel = vi.fn();
+    const { unmount } = render(
+      <OpenPRsIssuesModal repo={repoStub} onOpen={onOpen} onCancel={onCancel} />
+    );
+    fireKey('', { escape: true });
+    expect(onCancel).toHaveBeenCalled();
+    expect(onOpen).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('C cancels without opening', () => {
+    const onOpen = vi.fn();
+    const onCancel = vi.fn();
+    const { unmount } = render(
+      <OpenPRsIssuesModal repo={repoStub} onOpen={onOpen} onCancel={onCancel} />
+    );
+    fireKey('c');
+    expect(onCancel).toHaveBeenCalled();
+    expect(onOpen).not.toHaveBeenCalled();
+    unmount();
+  });
+});

--- a/tests/ui/RepoRow.test.tsx
+++ b/tests/ui/RepoRow.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeAll } from 'vitest';
 import { render } from 'ink-testing-library';
+import chalk from 'chalk';
 import RepoRow from '../../src/ui/components/repo/RepoRow';
 
 const repoStub: any = {
@@ -98,6 +99,147 @@ describe('RepoRow', () => {
     const output = lastFrame() || '';
     expect(output).toContain('[✓]');
     unmount();
+  });
+
+  describe('open PR / issue counts (SWR-357)', () => {
+    // Strip ANSI escapes so threshold-colour assertions can target the raw
+    // glyphs rather than colour codes the renderer might inject.
+    const stripAnsi = (s: string) => s.replace(/\u001b\[[0-9;]*m/g, '');
+
+    it('renders inline ⇄ PR and ◇ issue counts when defined', () => {
+      const repo = { ...repoStub, openPullRequests: 3, openIssues: 7 };
+      const { lastFrame, unmount } = render(
+        <RepoRow
+          repo={repo}
+          selected={false}
+          index={1}
+          maxWidth={80}
+          spacingLines={0}
+          forkTracking={false}
+        />
+      );
+
+      const output = stripAnsi(lastFrame() || '');
+      expect(output).toContain('⇄ 3 PRs');
+      expect(output).toContain('◇ 7 issues');
+      unmount();
+    });
+
+    it('singularises the labels at exactly 1', () => {
+      const repo = { ...repoStub, openPullRequests: 1, openIssues: 1 };
+      const { lastFrame, unmount } = render(
+        <RepoRow
+          repo={repo}
+          selected={false}
+          index={1}
+          maxWidth={80}
+          spacingLines={0}
+          forkTracking={false}
+        />
+      );
+
+      const output = stripAnsi(lastFrame() || '');
+      expect(output).toContain('⇄ 1 PR ');
+      expect(output).toContain('◇ 1 issue ');
+      // And NOT the plural forms
+      expect(output).not.toContain('⇄ 1 PRs');
+      expect(output).not.toContain('◇ 1 issues');
+      unmount();
+    });
+
+    it('renders both as 0 when counts are zero (muted, not omitted)', () => {
+      const repo = { ...repoStub, openPullRequests: 0, openIssues: 0 };
+      const { lastFrame, unmount } = render(
+        <RepoRow
+          repo={repo}
+          selected={false}
+          index={1}
+          maxWidth={80}
+          spacingLines={0}
+          forkTracking={false}
+        />
+      );
+
+      const output = stripAnsi(lastFrame() || '');
+      expect(output).toContain('⇄ 0 PRs');
+      expect(output).toContain('◇ 0 issues');
+      unmount();
+    });
+
+    it('omits the counts entirely when undefined (older cache reads)', () => {
+      const repo = { ...repoStub };
+      delete (repo as any).openPullRequests;
+      delete (repo as any).openIssues;
+      const { lastFrame, unmount } = render(
+        <RepoRow
+          repo={repo}
+          selected={false}
+          index={1}
+          maxWidth={80}
+          spacingLines={0}
+          forkTracking={false}
+        />
+      );
+
+      const output = stripAnsi(lastFrame() || '');
+      expect(output).not.toContain('PRs');
+      expect(output).not.toContain('PR ');
+      expect(output).not.toContain('issues');
+      expect(output).not.toContain('issue ');
+      // The rest of the metadata line still renders.
+      expect(output).toMatch(/Updated/);
+      unmount();
+    });
+
+    it('applies threshold colours: 0 muted, 1-9 default, 10-29 warning, 30+ error', () => {
+      // Force chalk to emit truecolour escape codes regardless of the test
+      // runner's TTY detection — vitest's stdout isn't a TTY, so chalk would
+      // otherwise strip everything and the band assertions would pass vacuously.
+      const prevLevel = chalk.level;
+      chalk.level = 3;
+      try {
+        function renderFrame(prCount: number): string {
+          const { lastFrame, unmount } = render(
+            <RepoRow
+              repo={{ ...repoStub, openPullRequests: prCount, openIssues: 0 }}
+              selected={false}
+              index={1}
+              maxWidth={80}
+              spacingLines={0}
+              forkTracking={false}
+            />
+          );
+          const out = lastFrame() || '';
+          unmount();
+          return out;
+        }
+
+        // Default theme maps: c.muted=gray (`[90m`), c.text=white (`[37m`),
+        // c.warning=yellow (`[33m`), c.error=red (`[31m`). The 1-9, 10-29 and
+        // 30+ bands each wrap the count chunk in their own chalk call, so the
+        // expected escape sits immediately before `⇄`. The 0 band collapses
+        // into the surrounding metaColor (gray) — there's no separate escape
+        // because it's the same colour, which is itself the assertion.
+        const out0 = renderFrame(0);
+        const out5 = renderFrame(5);
+        const out15 = renderFrame(15);
+        const out50 = renderFrame(50);
+
+        // Each non-zero band emits its expected ANSI escape directly before the
+        // PR glyph — proves the threshold function picked the right chalk.
+        expect(out5).toContain('\u001b[37m⇄ 5 PRs');
+        expect(out15).toContain('\u001b[33m⇄ 15 PRs');
+        expect(out50).toContain('\u001b[31m⇄ 50 PRs');
+
+        // Zero collapses into the gray metaColor run — the lack of a colour
+        // switch before `⇄ 0 PRs` proves the muted branch fired rather than
+        // accidentally promoting the count to text/warning/error.
+        expect(out0).not.toMatch(/\u001b\[3[1-7]m⇄ 0 PRs/);
+        expect(out0).toContain('⇄ 0 PRs');
+      } finally {
+        chalk.level = prevLevel;
+      }
+    });
   });
 
   describe('refreshTick relative-label refresh (SWR-377)', () => {


### PR DESCRIPTION
## Summary

- Fetch open PR and open issue counts for every repository row inline in the main list/org/search/starred queries (always on, no toggle, no enrichment pass) — see [SWR-357](https://linear.app/stealths/issue/SWR-357/show-open-pr-issue-counts-inline-on-repo-rows) and [upstream issue #37](https://github.com/wiiiimm/gh-manager-cli/issues/37).
- Render the counts on every `RepoRow` as `⇄ N PRs ◇ M issues` with threshold colour coding (muted at 0, default text 1–9, amber 10–29, red 30+).
- Add a new `L` keybinding ("Links") that opens a chooser modal for the selected repo's `/pulls` or `/issues` page on github.com.

## Why this is *not* like fork tracking

`pullRequests(states: OPEN) { totalCount }` and `issues(states: OPEN) { totalCount }` request only `totalCount` — no `first`/`last`, no `nodes`. Under GitHub's GraphQL cost formula (cost ∝ product of `first`/`last` across connections, ÷100, min 1), `totalCount`-only connections add ~0 node cost, so a 100-repo page stays at cost ~1. That's fundamentally cheaper than `history.totalCount` (the field that forced fork tracking into an opt-in toggle + batched enrichment in SWR-360/SWR-362 because it 502s across 100 repos/page).

Net: always-on adds negligible rate-limit cost, shows counts instantly with each page, and is the simplest code path.

## Changes

**GraphQL query (`src/services/github.ts`)** — `OrgRepos`, `ViewerRepos`, search, and starred queries all gain:
```graphql
openPullRequests: pullRequests(states: OPEN) { totalCount }
openIssues: issues(states: OPEN) { totalCount }
```
Both Octokit and Apollo paths are covered. A new `normalizeRepoNode` helper flattens `{ totalCount: N }` → `RepoNode.openPullRequests` / `openIssues` so renderers see plain numbers.

**Types (`src/types.ts`)** — `RepoNode` gets `openPullRequests?: number` and `openIssues?: number` (optional so older cache reads don't break).

**Render (`src/ui/components/repo/RepoRow.tsx`)** — counts are appended to line 2 with threshold colours documented in code. Memoization is preserved (the new fields ride on the `repo` reference).

**Navigation (`src/ui/views/RepoList.tsx`, new `OpenPRsIssuesModal.tsx`)** — `L` opens a chooser (Pull Requests / Issues) that mirrors the inline counts in the labels. `Enter` opens the focused option; `P` / `I` are direct shortcuts; `C` / `Esc` cancels.

**Docs** — `README.md`, `AGENTS.md` updated with the new keybinding and the query-cost rationale.

## Test plan

- [x] Vitest: query mapping (PR/issue counts parsed onto `RepoNode`, GraphQL templates carry the alias selections)
- [x] Vitest: `RepoRow` renders counts inline including singular/plural, zero, undefined, and threshold-colour bands
- [x] Vitest: `OpenPRsIssuesModal` opens the right URL for Enter/arrow keys and the direct `P` / `I` shortcuts; Esc/C cancels
- [x] `npx tsup` build succeeds; `tsc --noEmit` shows only pre-existing errors in unrelated files
- [ ] Manual: run a 100-repo page with `rateLimit { cost }` added temporarily and confirm cost stays ~1 with no 502 (pre-implementation check noted in the issue)
- [ ] Manual: verify counts render correctly across the four themes (Default / Ocean / Forest / Monochrome) and at all three density modes

## Out of scope

- "Assigned to me" filtered counts (#5) — would need a separate search query; split into a follow-up issue if requested.

---

<div align="center">
<sub>
Created by <b>William Li</b> (william@stealths.works) with <a href="https://tryreplicas.com">Replicas</a><br>
<a href="https://tryreplicas.com/workspaces/bb7c82bd-5d66-4d62-9195-664f2485eb84">Workspace</a> &nbsp;·&nbsp; <a href="https://linear.app/stealths/issue/SWR-357/show-open-pr-issue-counts-inline-on-repo-rows">SWR-357</a>
</sub>
</div>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only GraphQL fields and UI/navigation only; no auth, writes, or bulk API cost changes beyond slightly wider list queries.
> 
> **Overview**
> Adds **always-on open PR and issue counts** to repository list data and surfaces them in the UI (SWR-357).
> 
> **Data layer:** List, org, search, and starred GraphQL queries now request `pullRequests(states: OPEN) { totalCount }` and `issues(states: OPEN) { totalCount }`. New `normalizeRepoNode` flattens `{ totalCount }` into optional `RepoNode.openPullRequests` / `openIssues` numbers (older cache entries without these fields are unchanged).
> 
> **UI:** `RepoRow` shows inline `⇄ N PRs` and `◇ M issues` on line 2 with threshold colours (0 muted, 1–9 neutral, 10–29 warning, 30+ red). **`L`** opens a new `OpenPRsIssuesModal` chooser to jump to `/pulls` or `/issues` in the browser (Enter, `P`/`I` shortcuts; Esc/`C` cancel). Footer hints and **README** / **AGENTS.md** document the binding and query-cost rationale.
> 
> **Tests:** Coverage for normalization, query shape, row rendering, and modal keyboard behaviour.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0c13d52a8607f88c1aa02efc7e0d606fa6eddb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->