### PR TITLE
feat: transfer destination picker for single + bulk flows (SWR-381) [semantic pr title]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ See the living roadmap in [TODOs.md](./TODOs.md) for the canonical, up-to-date l
 - `I`: repository info modal
 - `K`: cache inspection
 - `Ctrl+N`: create a new repository in the current context (prompts for name with the personal/organisation slug shown in front; `Tab` cycles visibility; GitHub errors surfaced inline). Disabled in starred mode.
-- `Shift+M`: transfer (move) selected repo to another owner (prompts for destination owner, then requires typing a randomly generated verification code — like delete — followed by a final confirmation step; GitHub errors surfaced inline; transferred repo is removed from the list). Disabled in starred mode.
+- `Shift+M`: transfer (move) selected repo to another owner. Opens a destination picker (personal account + organisations the token can see) with a manual-entry fallback for owners the token can't list, then requires typing a randomly generated verification code — like delete — followed by a final confirmation step; GitHub errors surfaced inline; transferred repo is removed from the list. Disabled in starred mode.
 - `Del` or `Backspace`: delete selected repo (two-stage confirmation)
 - `Ctrl+A`: archive/unarchive selected repo
 - `Ctrl+V`: change repository visibility
@@ -169,7 +169,7 @@ Bulk actions reuse the same global shortcuts as single-repo mode and require at 
    - Star and archive are toggles. If all selected repos share the same state, the opposite state is applied directly. If the selection is mixed, an intent modal asks the explicit target (e.g. "Archive all" vs "Unarchive all", "Star all" vs "Unstar all").
    - Visibility always shows a target picker (Public / Private / Internal — Internal only for enterprise orgs).
 1. Review list (Confirmation 1) — scrollable list of all selected repos; `Space` to unselect; Tab/Enter to proceed. Dismisses on Esc/Cancel or when the list empties.
-2. Destination owner (Transfer only) — after review, prompts for a destination owner/org (must differ from the current owner).
+2. Destination owner (Transfer only) — after review, opens a destination picker (personal account + organisations the token can see) with a manual-entry fallback; the chosen destination must differ from the current owner.
 3. Count prompt (Confirmation 2) — "About to {action} {N} repos" (transfer also shows "to {owner}"); Cancel/Proceed, Esc cancels.
 4. Delete and Transfer only — a separate verification-code modal (type a 4-character code).
 5. Sequential execution with per-repo progress; partial-failure reporting at the end.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ On first run, you'll be prompted to authenticate with GitHub (OAuth recommended)
   - Jump to upstream (`P`) — moves cursor to the parent if loaded; otherwise fetches and shows it
   - Create new repository (`Ctrl+N`) — prompts for a name (with the personal/organisation slug shown in front), choose visibility with `Tab`, and surfaces GitHub errors inline
   - Rename repository (`Ctrl+R`) with inline validation and automatic cache update
-  - Transfer repository to another owner (`Shift+M`) — prompts for the destination owner, requires a verification code, shows a final confirmation, and surfaces GitHub errors inline
+  - Transfer repository to another owner (`Shift+M`) — destination picker (personal account + visible organisations) with a manual-entry fallback for owners the token can't list, then requires a verification code, shows a final confirmation, and surfaces GitHub errors inline
   - Copy repository URL to clipboard (`C`) with SSH/HTTPS options
   - Delete repository (`Del` or `Backspace`) with secure two-step confirmation
   - Archive/unarchive repositories (`Ctrl+A`) with confirmation prompts
@@ -97,7 +97,7 @@ On first run, you'll be prompted to authenticate with GitHub (OAuth recommended)
 - **Bulk Operations** (`B` to enter Bulk Select mode):
   - Select multiple repositories with `Space`; `X` unselects all (while every other shortcut is disabled in bulk mode)
   - Bulk actions reuse the global shortcuts: `Ctrl+S` star/unstar, `Ctrl+A` archive/unarchive, `Ctrl+V` visibility, `Del` delete, `Shift+M` transfer (move) to another owner/org
-  - Star and archive auto-detect a safe toggle; if the selection is mixed, an intent modal asks the explicit target. Visibility always prompts for the destination (Public / Private / Internal for enterprise orgs). Transfer always prompts for a destination owner
+  - Star and archive auto-detect a safe toggle; if the selection is mixed, an intent modal asks the explicit target. Visibility always prompts for the destination (Public / Private / Internal for enterprise orgs). Transfer opens a destination picker (personal account + visible orgs, plus manual-entry fallback)
   - Selections persist across search, filter, and sort changes (select from different searches, then bulk-act)
   - Confirmation flow: review list with ability to unselect → count prompt → (delete and transfer) a 4-character verification code
   - Per-repo progress reporting with partial-failure summary; transferred repos are removed from the current list
@@ -314,11 +314,11 @@ Launch the app, then use the keys below:
 - **Sync fork**: `Ctrl+F` (for forks only, shows ahead/behind counts and handles conflicts)
 - **Rename repository**: `Ctrl+R` with inline validation
 - **Transfer repository**: `Shift+M` (Move) to transfer ownership to another user or organisation
-  - Prompts for the destination owner (`new-owner/<repo>` preview)
+  - Destination picker lists the personal account + organisations the token can see; pick with ↑/↓ + Enter, press `M` (or select "Enter a different owner…") to switch to manual entry for owners the token can't list
   - Requires typing a randomly generated verification code (like delete), then a final confirmation before transferring
   - GitHub errors (e.g. insufficient permissions) are shown inline
 - **Bulk Transfer (Bulk Select mode)**: `Shift+M` within Bulk Select mode to move multiple repos at once
-  - Flow: review list (unselect) → destination owner prompt → count prompt → 4-character verification code → sequential execution with per-repo progress
+  - Flow: review list (unselect) → destination picker (same as the single-repo flow, with manual fallback) → count prompt → 4-character verification code → sequential execution with per-repo progress
   - Transferred repos are removed from the current list; partial-failure report shown at completion
 - **Copy URL**: `C` to copy repository URL to clipboard (SSH/HTTPS options)
 

--- a/src/ui/components/modals/BulkTransferDestinationModal.tsx
+++ b/src/ui/components/modals/BulkTransferDestinationModal.tsx
@@ -1,59 +1,48 @@
-import React, { useState, useRef } from 'react';
-import { Box, Text, useInput } from 'ink';
-import TextInput from 'ink-text-input';
+import React, { useRef } from 'react';
+import { Box, Text } from 'ink';
+import type { OrganizationNode } from '../../../types';
+import TransferDestinationPicker from './TransferDestinationPicker';
 
 interface BulkTransferDestinationModalProps {
   count: number;
   /** Login of the current context owner — destination must differ. */
   currentOwner: string;
+  /** Viewer's personal login — surfaced as a picker entry when it differs from the current owner. */
+  viewerLogin?: string;
+  /** Async loader for the destination picker's org list (host injects to share a session cache). */
+  loadOrganizations?: () => Promise<OrganizationNode[]>;
   onChoose: (destination: string) => void;
   onCancel: () => void;
   terminalWidth?: number;
 }
 
 /**
- * Step 0 of the bulk transfer flow: collects and validates the destination
- * owner/org. Input is sanitised to alphanumeric + hyphens; the destination
- * must differ from the current owner. Modelled on single-repo TransferModal
- * stage 1 and BulkVisibilityModal.
+ * Step 0 of the bulk transfer flow: collects and validates the destination owner/org.
+ *
+ * Wraps the shared {@link TransferDestinationPicker} (personal account + visible orgs, with a
+ * manual-entry fallback). Input is sanitised inside the picker; the destination must differ
+ * from the current owner. The synchronous `submittingRef` guard mirrors the single-repo
+ * TransferModal so a key arriving in the same tick as Enter doesn't fire onChoose twice.
  */
 export default function BulkTransferDestinationModal({
   count,
   currentOwner,
+  viewerLogin,
+  loadOrganizations,
   onChoose,
   onCancel,
   terminalWidth = 80,
 }: BulkTransferDestinationModalProps) {
-  const [destination, setDestination] = useState('');
-  const [error, setError] = useState<string | null>(null);
   const submittingRef = useRef(false);
 
-  useInput((_input, key) => {
+  const handleChoose = (dest: string) => {
     if (submittingRef.current) return;
-    if (key.escape) { onCancel(); return; }
-    if (key.return) {
-      const dest = destination.trim();
-      if (!dest) {
-        setError('Please enter a destination owner.');
-        return;
-      }
-      if (dest.toLowerCase() === currentOwner.toLowerCase()) {
-        setError(`Destination must differ from the current owner (${currentOwner}).`);
-        return;
-      }
-      submittingRef.current = true;
-      onChoose(dest);
-    }
-  });
-
-  const handleChange = (value: string) => {
-    // Strip invalid chars and leading hyphens (matches single-repo TransferModal)
-    setDestination(value.replace(/[^a-zA-Z0-9-]/g, '').replace(/^-+/, ''));
-    setError(null);
+    submittingRef.current = true;
+    onChoose(dest);
   };
 
-  const isValid = destination.trim() && destination.trim().toLowerCase() !== currentOwner.toLowerCase();
   const modalWidth = Math.min(terminalWidth - 4, 72);
+  const orgLoader = loadOrganizations ?? (async () => []);
 
   return (
     <Box
@@ -70,29 +59,13 @@ export default function BulkTransferDestinationModal({
         Move <Text bold>{count}</Text> repositor{count === 1 ? 'y' : 'ies'} to a new owner.
       </Text>
       <Box height={1}><Text> </Text></Box>
-      <Text>Destination owner (username or organisation):</Text>
-      <Box marginTop={1} flexDirection="row" alignItems="center">
-        <TextInput
-          value={destination}
-          onChange={handleChange}
-          placeholder="new-owner"
-        />
-      </Box>
-      {error && (
-        <Box marginTop={1}>
-          <Text color="red">{error}</Text>
-        </Box>
-      )}
-      <Box marginTop={1}>
-        <Text color={isValid ? 'gray' : 'gray'}>
-          {isValid
-            ? `Press Enter to continue → ${destination}`
-            : 'Enter a different owner to continue'}
-        </Text>
-      </Box>
-      <Box marginTop={1}>
-        <Text color="gray">Press Esc to cancel</Text>
-      </Box>
+      <TransferDestinationPicker
+        currentOwner={currentOwner}
+        viewerLogin={viewerLogin}
+        loadOrganizations={orgLoader}
+        onChoose={handleChoose}
+        onCancel={onCancel}
+      />
     </Box>
   );
 }

--- a/src/ui/components/modals/TransferDestinationPicker.tsx
+++ b/src/ui/components/modals/TransferDestinationPicker.tsx
@@ -1,0 +1,271 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import TextInput from 'ink-text-input';
+import chalk from 'chalk';
+import type { OrganizationNode } from '../../../types';
+import type { Theme } from '../../../config/themes';
+import { useTheme } from '../../hooks/useTheme';
+
+export interface TransferDestinationPickerProps {
+  /** Login of the current owner — must differ from any selected destination. */
+  currentOwner: string;
+  /** Viewer's personal login. The personal entry is shown unless it equals currentOwner. */
+  viewerLogin?: string;
+  /** Async loader for the org list — injected so the host can share a session cache. */
+  loadOrganizations: () => Promise<OrganizationNode[]>;
+  onChoose: (destination: string) => void;
+  onCancel: () => void;
+  /** When true the host is processing a submission; the picker swallows input. */
+  busy?: boolean;
+  theme?: Theme;
+}
+
+type Mode = 'list' | 'manual';
+
+interface PersonalItem { kind: 'personal'; login: string }
+interface OrgItem { kind: 'org'; login: string; name: string | null }
+interface ManualItem { kind: 'manual' }
+type PickerItem = PersonalItem | OrgItem | ManualItem;
+
+const sanitiseOwner = (value: string): string =>
+  value.replace(/[^a-zA-Z0-9-]/g, '').replace(/^-+/, '');
+
+/**
+ * Reusable destination picker for repository transfer flows.
+ *
+ * Lists the destinations the current session can reach — the viewer's personal account and
+ * the orgs returned by `loadOrganizations` — plus an always-available manual-entry fallback
+ * for destinations the token cannot see. The current owner is excluded so the destination
+ * must differ. If the fetch fails or returns no candidates, the picker auto-switches to
+ * manual mode so the user is never blocked. Host owns the surrounding modal frame; this
+ * component only renders the picker body and handles its own keyboard input.
+ */
+export default function TransferDestinationPicker({
+  currentOwner,
+  viewerLogin,
+  loadOrganizations,
+  onChoose,
+  onCancel,
+  busy,
+  theme: themeProp,
+}: TransferDestinationPickerProps) {
+  const { theme } = useTheme(themeProp?.name ?? 'default');
+
+  const [orgs, setOrgs] = useState<OrganizationNode[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [mode, setMode] = useState<Mode>('list');
+  const [cursor, setCursor] = useState(0);
+  const [manualValue, setManualValue] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  // Picker items derived from orgs + viewerLogin, with the current owner excluded.
+  // The manual-entry option is always last so users can fall back to free-text.
+  const items = useMemo<PickerItem[]>(() => {
+    const list: PickerItem[] = [];
+    const lower = currentOwner.toLowerCase();
+    if (viewerLogin && viewerLogin.toLowerCase() !== lower) {
+      list.push({ kind: 'personal', login: viewerLogin });
+    }
+    for (const org of orgs) {
+      if (org.login.toLowerCase() === lower) continue;
+      list.push({ kind: 'org', login: org.login, name: org.name });
+    }
+    list.push({ kind: 'manual' });
+    return list;
+  }, [orgs, viewerLogin, currentOwner]);
+
+  // Auto-fall-back to manual mode when there are no real candidates (loader failed,
+  // returned empty, or every option matches the current owner). The "Enter different
+  // owner…" row is the only remaining list item in that case, so manual is the only
+  // useful surface — skip the extra Enter press.
+  useEffect(() => {
+    if (loading) return;
+    const hasCandidate = items.some(i => i.kind !== 'manual');
+    if (!hasCandidate && mode !== 'manual') setMode('manual');
+  }, [loading, items, mode]);
+
+  // Clamp cursor whenever items shrink (e.g. after fetch resolves with fewer entries).
+  useEffect(() => {
+    if (cursor > items.length - 1) setCursor(Math.max(0, items.length - 1));
+  }, [items.length, cursor]);
+
+  // Fetch orgs once on mount. Errors are caught and reflected in `loadError` —
+  // the picker then falls back to manual entry rather than blocking the user.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const list = await loadOrganizations();
+        if (cancelled) return;
+        setOrgs(list);
+      } catch (e: unknown) {
+        if (cancelled) return;
+        setLoadError(e instanceof Error ? e.message : 'Failed to load organisations');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [loadOrganizations]);
+
+  const submitDestination = (dest: string) => {
+    const trimmed = dest.trim();
+    if (!trimmed) {
+      setError('Please enter a destination owner.');
+      return;
+    }
+    if (trimmed.toLowerCase() === currentOwner.toLowerCase()) {
+      setError(`Destination must differ from the current owner (${currentOwner}).`);
+      return;
+    }
+    setError(null);
+    onChoose(trimmed);
+  };
+
+  useInput((input, key) => {
+    if (busy) return;
+
+    if (key.escape) {
+      // Esc inside manual mode returns to the list when a list is available;
+      // otherwise it cancels the host modal.
+      if (mode === 'manual' && items.some(i => i.kind !== 'manual')) {
+        setMode('list');
+        setError(null);
+        return;
+      }
+      onCancel();
+      return;
+    }
+
+    if (mode === 'list') {
+      if (key.upArrow) {
+        setCursor(c => Math.max(0, c - 1));
+        return;
+      }
+      if (key.downArrow) {
+        setCursor(c => Math.min(items.length - 1, c + 1));
+        return;
+      }
+      if (input === 'm' || input === 'M') {
+        setMode('manual');
+        setError(null);
+        return;
+      }
+      if (key.return) {
+        const item = items[cursor];
+        if (!item) return;
+        if (item.kind === 'manual') {
+          setMode('manual');
+          setError(null);
+          return;
+        }
+        submitDestination(item.login);
+        return;
+      }
+      return;
+    }
+
+    // Manual mode — TextInput handles character entry + onSubmit; we only handle
+    // navigation away from it (Esc above, ↑ back into the list).
+    if (key.upArrow && items.some(i => i.kind !== 'manual')) {
+      setMode('list');
+      setError(null);
+      setCursor(Math.max(0, items.length - 2));
+    }
+  });
+
+  const handleManualChange = (value: string) => {
+    setManualValue(sanitiseOwner(value));
+    if (error) setError(null);
+  };
+
+  const handleManualSubmit = () => submitDestination(manualValue);
+
+  const showSpinner = loading;
+
+  return (
+    <Box flexDirection="column">
+      <Text>Choose destination owner:</Text>
+      <Box height={1}><Text> </Text></Box>
+
+      {showSpinner && (
+        <Text color={theme.muted}>Loading organisations…</Text>
+      )}
+
+      {!showSpinner && loadError && (
+        <Box flexDirection="column" marginBottom={1}>
+          <Text color={theme.warning}>Couldn't load organisations: {loadError}</Text>
+          <Text color={theme.muted}>You can still enter a destination manually below.</Text>
+        </Box>
+      )}
+
+      {!showSpinner && mode === 'list' && (
+        <Box flexDirection="column">
+          {items.map((item, index) => {
+            const isFocused = cursor === index;
+            const prefix = isFocused ? chalk.bgCyan.black(' → ') + ' ' : '   ';
+            if (item.kind === 'personal') {
+              const label = `${item.login} ${chalk.gray('(personal)')}`;
+              return (
+                <Box key="personal">
+                  <Text>{prefix}{isFocused ? chalk.bold(label) : chalk.gray(label)}</Text>
+                </Box>
+              );
+            }
+            if (item.kind === 'org') {
+              const display = item.name ? `${item.name} ${chalk.gray(`(@${item.login})`)}` : `@${item.login}`;
+              return (
+                <Box key={`org-${item.login}`}>
+                  <Text>{prefix}{isFocused ? chalk.bold(display) : chalk.gray(display)}</Text>
+                </Box>
+              );
+            }
+            return (
+              <Box key="manual">
+                <Text>{prefix}{isFocused ? chalk.bold('Enter a different owner…') : chalk.gray('Enter a different owner…')}</Text>
+              </Box>
+            );
+          })}
+        </Box>
+      )}
+
+      {!showSpinner && mode === 'manual' && (
+        <Box flexDirection="column">
+          <Text color={theme.muted}>Destination owner (username or organisation):</Text>
+          <Box marginTop={1} flexDirection="row" alignItems="center">
+            <TextInput
+              value={manualValue}
+              onChange={handleManualChange}
+              onSubmit={handleManualSubmit}
+              placeholder="new-owner"
+              focus={!busy}
+            />
+          </Box>
+        </Box>
+      )}
+
+      {error && (
+        <Box marginTop={1}>
+          <Text color={theme.error}>{error}</Text>
+        </Box>
+      )}
+
+      <Box marginTop={1} flexDirection="column">
+        {mode === 'list' && !showSpinner && (
+          <Text color={theme.muted}>↑↓ Navigate • Enter Select • M Manual entry • Esc Cancel</Text>
+        )}
+        {mode === 'manual' && !showSpinner && (
+          <Text color={theme.muted}>
+            {items.some(i => i.kind !== 'manual')
+              ? 'Enter to submit • ↑ Back to list • Esc Cancel'
+              : 'Enter to submit • Esc Cancel'}
+          </Text>
+        )}
+        <Text color={theme.muted} dimColor>
+          Orgs the token cannot see won't appear — use manual entry.
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/components/modals/TransferDestinationPicker.tsx
+++ b/src/ui/components/modals/TransferDestinationPicker.tsx
@@ -138,6 +138,12 @@ export default function TransferDestinationPicker({
       return;
     }
 
+    // While the org list is still loading the picker shows only a spinner.
+    // Swallow navigation/select keys so a stray Enter can't submit the focused
+    // row (often the personal account) the user can't actually see yet. Esc
+    // above remains the one allowed key so a stuck loader can still be cancelled.
+    if (loading) return;
+
     if (mode === 'list') {
       if (key.upArrow) {
         setCursor(c => Math.max(0, c - 1));

--- a/src/ui/components/modals/TransferModal.tsx
+++ b/src/ui/components/modals/TransferModal.tsx
@@ -1,28 +1,34 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import TextInput from 'ink-text-input';
-import type { RepoNode } from '../../../types';
+import type { OrganizationNode, RepoNode } from '../../../types';
 import type { Theme } from '../../../config/themes';
 import { useTheme } from '../../hooks/useTheme';
 import { SlowSpinner } from '../common';
+import TransferDestinationPicker from './TransferDestinationPicker';
 
 interface TransferModalProps {
   repo: RepoNode | null;
   onTransfer: (repo: RepoNode, newOwner: string) => Promise<void>;
   onCancel: () => void;
+  /** Viewer's personal login — surfaced as a picker entry when it differs from the current owner. */
+  viewerLogin?: string;
+  /** Async loader for the destination picker's org list (host injects to share session cache). */
+  loadOrganizations?: () => Promise<OrganizationNode[]>;
   theme?: Theme;
 }
 
 /**
  * Three-stage modal for transferring a repository to another owner.
  *
- * Stage one collects a sanitised destination owner (username or organisation); stage two
- * requires the user to type a randomly generated verification code (mirroring the delete
- * flow) to guard against accidental transfers; stage three shows a final confirmation
- * (Cancel focused by default) before initiating the transfer. GitHub errors are surfaced
- * inline. Esc cancels at any point. Guards against double-submit.
+ * Stage one runs a {@link TransferDestinationPicker} (personal account + visible orgs, with a
+ * manual-entry fallback for owners the token can't see); stage two requires the user to type a
+ * randomly generated verification code (mirroring the delete flow) to guard against accidental
+ * transfers; stage three shows a final confirmation (Cancel focused by default) before initiating
+ * the transfer. GitHub errors are surfaced inline. Esc cancels at any point. Guards against
+ * double-submit.
  */
-export default function TransferModal({ repo, onTransfer, onCancel, theme: themeProp }: TransferModalProps) {
+export default function TransferModal({ repo, onTransfer, onCancel, viewerLogin, loadOrganizations, theme: themeProp }: TransferModalProps) {
   const { theme, c } = useTheme(themeProp?.name ?? 'default');
   const [newOwner, setNewOwner] = useState('');
   const [stage, setStage] = useState<'input' | 'code' | 'confirm'>('input');
@@ -52,6 +58,7 @@ export default function TransferModal({ repo, onTransfer, onCancel, theme: theme
       setStage('input');
       setFocus('cancel');
       setError(null);
+      setNewOwner('');
     }
   }, [repo]);
 
@@ -60,20 +67,12 @@ export default function TransferModal({ repo, onTransfer, onCancel, theme: theme
     // guarded in the same tick as submit — before `transferring` state re-renders.
     if (submittingRef.current || !repo) return;
 
+    // Stage 1 input is fully owned by the picker (escape + arrows + enter). The
+    // picker calls onCancel directly when the user backs out of it.
+    if (stage === 'input') return;
+
     if (key.escape) {
       onCancel();
-      return;
-    }
-
-    if (stage === 'input') {
-      if (key.return) {
-        const target = newOwner.trim();
-        if (target && target.toLowerCase() !== owner.toLowerCase()) {
-          setError(null);
-          setTypedCode('');
-          setStage('code');
-        }
-      }
       return;
     }
 
@@ -143,17 +142,18 @@ export default function TransferModal({ repo, onTransfer, onCancel, theme: theme
     }
   };
 
-  // GitHub owner logins allow alphanumeric characters and single hyphens, and
-  // cannot start with a hyphen — strip invalid chars and any leading hyphens.
-  // (We intentionally don't strip trailing hyphens here: doing so on every
-  // keystroke would prevent typing hyphenated names like "my-org".)
-  const handleOwnerChange = (value: string) => {
-    setNewOwner(value.replace(/[^a-zA-Z0-9-]/g, '').replace(/^-+/, ''));
+  const handlePickerChoose = (destination: string) => {
+    setNewOwner(destination);
+    setError(null);
+    setTypedCode('');
+    setStage('code');
   };
 
-  const isInputDisabled = !newOwner.trim() || newOwner.trim().toLowerCase() === owner.toLowerCase();
-
   if (!repo) return null;
+
+  // Default loader: if no org loader is provided, surface an empty list so the
+  // picker degrades gracefully to manual-only entry (matches the previous behaviour).
+  const orgLoader = loadOrganizations ?? (async () => []);
 
   return (
     <Box
@@ -172,28 +172,14 @@ export default function TransferModal({ repo, onTransfer, onCancel, theme: theme
       {stage === 'input' && (
         <>
           <Box height={1}><Text> </Text></Box>
-          <Text>New owner (username or organisation):</Text>
-          <Box flexDirection="row" alignItems="center">
-            <TextInput
-              value={newOwner}
-              onChange={handleOwnerChange}
-              placeholder="new-owner"
-              focus={!transferring}
-            />
-            <Text>/{repo.name}</Text>
-          </Box>
-
-          <Box marginTop={2}>
-            <Text color={theme.muted}>
-              {isInputDisabled ?
-                'Enter a different owner to continue' :
-                `Press Enter to review the transfer to "${newOwner}/${repo.name}"`
-              }
-            </Text>
-          </Box>
-          <Box marginTop={1}>
-            <Text color={theme.muted}>Press Esc to cancel</Text>
-          </Box>
+          <TransferDestinationPicker
+            currentOwner={owner}
+            viewerLogin={viewerLogin}
+            loadOrganizations={orgLoader}
+            onChoose={handlePickerChoose}
+            onCancel={onCancel}
+            theme={theme}
+          />
         </>
       )}
 

--- a/src/ui/components/modals/index.ts
+++ b/src/ui/components/modals/index.ts
@@ -26,3 +26,4 @@ export { default as OpenInBrowserModal } from './OpenInBrowserModal';
 export { default as OpenPRsIssuesModal } from './OpenPRsIssuesModal';
 export { default as CreateRepoModal } from './CreateRepoModal';
 export { default as TransferModal } from './TransferModal';
+export { default as TransferDestinationPicker } from './TransferDestinationPicker';

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -251,6 +251,30 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   const [enrichingForks, setEnrichingForks] = useState(false);
   const enrichmentDoneRef = useRef<Set<string>>(new Set()); // ids already enriched
 
+  // Session-level cache of the viewer's organisations for the transfer destination
+  // picker (single + bulk). The fetch is cheap, but caching it avoids a refetch on
+  // every transfer attempt; the in-flight promise is reused if a second picker
+  // mounts before the first resolves. Cleared whenever the token (and therefore
+  // viewer/scope) changes — `useMemo([token])` recreates the entire pair.
+  type TransferOrg = Awaited<ReturnType<typeof fetchViewerOrganizations>>[number];
+  const transferOrgCache = useMemo<{
+    ref: { current: TransferOrg[] | null };
+    inflight: { current: Promise<TransferOrg[]> | null };
+  }>(() => ({ ref: { current: null }, inflight: { current: null } }), [token]);
+
+  const loadTransferDestinationOrgs = useCallback(async () => {
+    if (transferOrgCache.ref.current) return transferOrgCache.ref.current;
+    if (transferOrgCache.inflight.current) return transferOrgCache.inflight.current;
+    const promise = fetchViewerOrganizations(client)
+      .then(orgs => {
+        transferOrgCache.ref.current = orgs;
+        return orgs;
+      })
+      .finally(() => { transferOrgCache.inflight.current = null; });
+    transferOrgCache.inflight.current = promise;
+    return promise;
+  }, [client, transferOrgCache]);
+
   // Apply initial --org flag once (if provided)
   const appliedInitialOrg = useRef(false);
   useEffect(() => {
@@ -2896,6 +2920,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               repo={transferTarget}
               onTransfer={executeTransfer}
               onCancel={closeTransferModal}
+              viewerLogin={viewerLogin}
+              loadOrganizations={loadTransferDestinationOrgs}
               theme={theme}
             />
           </Box>
@@ -3037,6 +3063,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
             <BulkTransferDestinationModal
               count={bulkFinalSelection.size}
               currentOwner={ownerContext !== 'personal' ? ownerContext.login : (viewerLogin ?? '')}
+              viewerLogin={viewerLogin}
+              loadOrganizations={loadTransferDestinationOrgs}
               terminalWidth={terminalWidth}
               onChoose={(dest) => {
                 setBulkTransferDest(dest);

--- a/tests/ui/BulkTransferDestinationModal.test.tsx
+++ b/tests/ui/BulkTransferDestinationModal.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { render } from 'ink-testing-library';
 import type { Key } from 'ink';
 import BulkTransferDestinationModal from '../../src/ui/components/modals/BulkTransferDestinationModal';
+import type { OrganizationNode } from '../../src/types';
 
 type InkInputHandler = (input: string, key: Partial<Key>) => void;
 
@@ -11,7 +12,7 @@ vi.mock('ink', async () => {
   return { ...actual, useInput: vi.fn() };
 });
 
-// Capture the latest TextInput props so tests can drive onChange directly.
+// Capture the latest TextInput props so tests can drive onChange/onSubmit directly.
 const h = vi.hoisted(() => ({
   textInputProps: null as { onChange?: (v: string) => void; onSubmit?: () => void } | null,
 }));
@@ -21,6 +22,11 @@ vi.mock('ink-text-input', () => ({
     return null;
   },
 }));
+
+const mockOrgs: OrganizationNode[] = [
+  { id: 'o1', login: 'acme', name: 'Acme Inc', avatarUrl: '' },
+  { id: 'o2', login: 'globex', name: 'Globex', avatarUrl: '' },
+];
 
 describe('BulkTransferDestinationModal', () => {
   let mockUseInput: Mock;
@@ -32,36 +38,47 @@ describe('BulkTransferDestinationModal', () => {
     mockUseInput.mockReset();
   });
 
-  it('renders the destination prompt with repo count', () => {
+  it('renders the destination prompt with repo count and the picker list', async () => {
     mockUseInput.mockImplementation(() => {});
 
     const { lastFrame, unmount } = render(
       <BulkTransferDestinationModal
         count={3}
         currentOwner="myorg"
+        viewerLogin="myuser"
+        loadOrganizations={async () => mockOrgs}
         onChoose={() => {}}
         onCancel={() => {}}
       />,
     );
 
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
     const out = lastFrame() || '';
     expect(out).toContain('Bulk Transfer Repositories');
     expect(out).toContain('3');
-    expect(out).toContain('Destination owner');
+    expect(out).toContain('Choose destination owner');
+    expect(out).toContain('myuser');
+    expect(out).toContain('Acme Inc');
     unmount();
   });
 
-  it('uses singular "repository" for count=1', () => {
+  it('uses singular "repository" for count=1', async () => {
     mockUseInput.mockImplementation(() => {});
 
     const { lastFrame, unmount } = render(
       <BulkTransferDestinationModal
         count={1}
         currentOwner="myorg"
+        viewerLogin="myuser"
+        loadOrganizations={async () => mockOrgs}
         onChoose={() => {}}
         onCancel={() => {}}
       />,
     );
+
+    await new Promise(r => setTimeout(r, 0));
 
     const out = lastFrame() || '';
     expect(out).toContain('repository');
@@ -69,7 +86,7 @@ describe('BulkTransferDestinationModal', () => {
     unmount();
   });
 
-  it('calls onCancel on Esc', () => {
+  it('calls onCancel on Esc from the picker', async () => {
     const onCancel = vi.fn();
     let inputCallback!: InkInputHandler;
     mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
@@ -78,17 +95,20 @@ describe('BulkTransferDestinationModal', () => {
       <BulkTransferDestinationModal
         count={2}
         currentOwner="myorg"
+        viewerLogin="myuser"
+        loadOrganizations={async () => mockOrgs}
         onChoose={() => {}}
         onCancel={onCancel}
       />,
     );
 
+    await new Promise(r => setTimeout(r, 0));
     inputCallback('', { escape: true });
     expect(onCancel).toHaveBeenCalledTimes(1);
     unmount();
   });
 
-  it('calls onChoose with the entered destination on Enter', async () => {
+  it('calls onChoose with the selected org login on Enter', async () => {
     const onChoose = vi.fn();
     let inputCallback!: InkInputHandler;
     mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
@@ -97,97 +117,23 @@ describe('BulkTransferDestinationModal', () => {
       <BulkTransferDestinationModal
         count={2}
         currentOwner="myorg"
+        viewerLogin="myuser"
+        loadOrganizations={async () => mockOrgs}
         onChoose={onChoose}
         onCancel={() => {}}
       />,
     );
 
-    h.textInputProps?.onChange?.('new-org');
-    await new Promise(r => setTimeout(r, 0)); // flush state → re-render → fresh callback
-    inputCallback('', { return: true });
-
-    expect(onChoose).toHaveBeenCalledWith('new-org');
-    unmount();
-  });
-
-  it('does not call onChoose when destination equals currentOwner (case-insensitive)', async () => {
-    const onChoose = vi.fn();
-    let inputCallback!: InkInputHandler;
-    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
-
-    const { lastFrame, unmount } = render(
-      <BulkTransferDestinationModal
-        count={2}
-        currentOwner="MyOrg"
-        onChoose={onChoose}
-        onCancel={() => {}}
-      />,
-    );
-
-    h.textInputProps?.onChange?.('myorg'); // same owner (different case)
-    await new Promise(r => setTimeout(r, 0)); // flush → fresh callback with updated destination
-    inputCallback('', { return: true });
-    await new Promise(r => setTimeout(r, 0)); // flush error state
-
-    expect(onChoose).not.toHaveBeenCalled();
-    const out = lastFrame() || '';
-    expect(out).toContain('Destination must differ');
-    unmount();
-  });
-
-  it('does not call onChoose when destination is empty', async () => {
-    const onChoose = vi.fn();
-    let inputCallback!: InkInputHandler;
-    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
-
-    const { lastFrame, unmount } = render(
-      <BulkTransferDestinationModal
-        count={2}
-        currentOwner="myorg"
-        onChoose={onChoose}
-        onCancel={() => {}}
-      />,
-    );
-
-    // Press Enter without typing anything
-    inputCallback('', { return: true });
-    await new Promise(r => setTimeout(r, 0)); // flush error state
-
-    expect(onChoose).not.toHaveBeenCalled();
-    const out = lastFrame() || '';
-    expect(out).toContain('Please enter a destination owner');
-    unmount();
-  });
-
-  // Sanitisation is applied inside the component's onChange handler before
-  // the value reaches `destination` state. These tests verify the regex logic
-  // by comparing input → state → onChoose call.
-  it('strips invalid characters before passing to onChoose', async () => {
-    const onChoose = vi.fn();
-    let inputCallback!: InkInputHandler;
-    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
-
-    const { unmount } = render(
-      <BulkTransferDestinationModal
-        count={2}
-        currentOwner="oldorg"
-        onChoose={onChoose}
-        onCancel={() => {}}
-      />,
-    );
-
-    // Simulate the modal's handleChange already having sanitised the input —
-    // as if the user typed chars one by one and only valid chars were kept.
-    // We call onChange with the post-sanitisation value directly.
-    h.textInputProps?.onChange?.('neworg20'); // pre-sanitised (spaces/underscores/dots stripped)
     await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+    // cursor 0 = personal (myuser)
     inputCallback('', { return: true });
 
-    expect(onChoose).toHaveBeenCalledWith('neworg20');
+    expect(onChoose).toHaveBeenCalledWith('myuser');
     unmount();
   });
 
-  it('strips leading hyphens before passing to onChoose', async () => {
+  it('calls onChoose with a manually entered destination', async () => {
     const onChoose = vi.fn();
     let inputCallback!: InkInputHandler;
     mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
@@ -196,17 +142,114 @@ describe('BulkTransferDestinationModal', () => {
       <BulkTransferDestinationModal
         count={1}
         currentOwner="oldorg"
+        viewerLogin="myuser"
+        loadOrganizations={async () => []}
         onChoose={onChoose}
         onCancel={() => {}}
       />,
     );
 
-    // Simulate post-sanitisation value (leading hyphens already stripped by handleChange)
-    h.textInputProps?.onChange?.('new-org'); // '--new-org' with leading hyphens stripped
     await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+    // No orgs returned: list = [personal, manual]. Press M to jump to manual.
+    inputCallback('m', {});
+    await new Promise(r => setTimeout(r, 0));
+
+    h.textInputProps?.onChange?.('new-target');
+    await new Promise(r => setTimeout(r, 0));
+    h.textInputProps?.onSubmit?.();
+
+    expect(onChoose).toHaveBeenCalledWith('new-target');
+    unmount();
+  });
+
+  it('does not call onChoose when manual destination equals currentOwner (case-insensitive)', async () => {
+    const onChoose = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const { lastFrame, unmount } = render(
+      <BulkTransferDestinationModal
+        count={2}
+        currentOwner="MyOrg"
+        viewerLogin="myuser"
+        loadOrganizations={async () => []}
+        onChoose={onChoose}
+        onCancel={() => {}}
+      />,
+    );
+
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+    inputCallback('m', {});
+    await new Promise(r => setTimeout(r, 0));
+
+    h.textInputProps?.onChange?.('myorg');
+    await new Promise(r => setTimeout(r, 0));
+    h.textInputProps?.onSubmit?.();
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(onChoose).not.toHaveBeenCalled();
+    expect(lastFrame() || '').toContain('must differ');
+    unmount();
+  });
+
+  it('falls back to manual entry when the org loader fails', async () => {
+    const onChoose = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const { lastFrame, unmount } = render(
+      <BulkTransferDestinationModal
+        count={2}
+        currentOwner="myuser"
+        viewerLogin="myuser"
+        loadOrganizations={async () => { throw new Error('fetch failed'); }}
+        onChoose={onChoose}
+        onCancel={() => {}}
+      />,
+    );
+
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    const out = lastFrame() || '';
+    expect(out).toContain("Couldn't load organisations");
+    expect(out).toContain('Destination owner');
+
+    h.textInputProps?.onChange?.('safe-org');
+    await new Promise(r => setTimeout(r, 0));
+    h.textInputProps?.onSubmit?.();
+    expect(onChoose).toHaveBeenCalledWith('safe-org');
+    unmount();
+  });
+
+  it('does not call onChoose twice when Enter fires in the same tick as submit (in-flight guard)', async () => {
+    const onChoose = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const { unmount } = render(
+      <BulkTransferDestinationModal
+        count={2}
+        currentOwner="myorg"
+        viewerLogin="myuser"
+        loadOrganizations={async () => mockOrgs}
+        onChoose={onChoose}
+        onCancel={() => {}}
+      />,
+    );
+
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    inputCallback('', { return: true });
+    // Second Enter in the same tick — the submittingRef guard inside the bulk modal
+    // must swallow it before the host has a chance to handle a follow-up.
     inputCallback('', { return: true });
 
-    expect(onChoose).toHaveBeenCalledWith('new-org');
+    expect(onChoose).toHaveBeenCalledTimes(1);
+    expect(onChoose).toHaveBeenCalledWith('myuser');
     unmount();
   });
 

--- a/tests/ui/TransferDestinationPicker.test.tsx
+++ b/tests/ui/TransferDestinationPicker.test.tsx
@@ -1,0 +1,338 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { render } from 'ink-testing-library';
+import type { Key } from 'ink';
+import TransferDestinationPicker from '../../src/ui/components/modals/TransferDestinationPicker';
+import type { OrganizationNode } from '../../src/types';
+
+type InkInputHandler = (input: string, key: Partial<Key>) => void;
+
+// Stub `useInput` so we can capture the latest input callback and drive key
+// events deterministically (avoids stdin.ref errors under ink-testing-library).
+vi.mock('ink', async () => {
+  const actual = await vi.importActual('ink');
+  return { ...actual, useInput: vi.fn() };
+});
+
+// Stub ink-text-input — the real one needs raw stdin. Capturing onChange/onSubmit
+// via vi.hoisted lets the manual-mode tests "type" without a real input.
+const h = vi.hoisted(() => ({
+  textInputProps: null as { onChange?: (v: string) => void; onSubmit?: () => void } | null,
+}));
+vi.mock('ink-text-input', () => ({
+  default: (props: { onChange?: (v: string) => void; onSubmit?: () => void }) => {
+    h.textInputProps = props;
+    return null;
+  },
+}));
+
+const orgs = (): OrganizationNode[] => [
+  { id: 'o1', login: 'acme', name: 'Acme Inc', avatarUrl: '' },
+  { id: 'o2', login: 'globex', name: 'Globex Corp', avatarUrl: '' },
+];
+
+describe('TransferDestinationPicker', () => {
+  let mockUseInput: Mock;
+
+  beforeEach(async () => {
+    h.textInputProps = null;
+    const ink = await import('ink');
+    mockUseInput = (ink as unknown as { useInput: Mock }).useInput;
+    mockUseInput.mockReset();
+  });
+
+  it('renders the personal account and visible orgs after the loader resolves', async () => {
+    mockUseInput.mockImplementation(() => {});
+
+    const { lastFrame, unmount } = render(
+      <TransferDestinationPicker
+        currentOwner="myuser"
+        viewerLogin="myviewer"
+        loadOrganizations={async () => orgs()}
+        onChoose={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    const out = lastFrame() || '';
+    expect(out).toContain('Choose destination owner');
+    expect(out).toContain('myviewer');
+    expect(out).toContain('Acme Inc');
+    expect(out).toContain('Globex Corp');
+    expect(out).toContain('Enter a different owner');
+    unmount();
+  });
+
+  it('excludes the current owner from the picker list', async () => {
+    mockUseInput.mockImplementation(() => {});
+
+    const { lastFrame, unmount } = render(
+      <TransferDestinationPicker
+        currentOwner="acme"
+        viewerLogin="myviewer"
+        loadOrganizations={async () => orgs()}
+        onChoose={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    const out = lastFrame() || '';
+    expect(out).toContain('myviewer');
+    expect(out).toContain('Globex');
+    expect(out).not.toContain('Acme Inc');
+    unmount();
+  });
+
+  it('also excludes the personal entry when it matches the current owner', async () => {
+    mockUseInput.mockImplementation(() => {});
+
+    const { lastFrame, unmount } = render(
+      <TransferDestinationPicker
+        currentOwner="myviewer"
+        viewerLogin="MyViewer"
+        loadOrganizations={async () => orgs()}
+        onChoose={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    const out = lastFrame() || '';
+    expect(out).toContain('Acme');
+    expect(out).toContain('Globex');
+    expect(out).not.toContain('(personal)');
+    unmount();
+  });
+
+  it('selects the focused org on Enter and calls onChoose with its login', async () => {
+    const onChoose = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const { unmount } = render(
+      <TransferDestinationPicker
+        currentOwner="someone"
+        viewerLogin="myviewer"
+        loadOrganizations={async () => orgs()}
+        onChoose={onChoose}
+        onCancel={() => {}}
+      />,
+    );
+
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    // Cursor starts at 0 → personal. ↓ once → acme.
+    inputCallback('', { downArrow: true });
+    await new Promise(r => setTimeout(r, 0));
+    inputCallback('', { return: true });
+
+    expect(onChoose).toHaveBeenCalledWith('acme');
+    unmount();
+  });
+
+  it('cancels on Esc from the list view', async () => {
+    const onCancel = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const { unmount } = render(
+      <TransferDestinationPicker
+        currentOwner="someone"
+        viewerLogin="myviewer"
+        loadOrganizations={async () => orgs()}
+        onChoose={() => {}}
+        onCancel={onCancel}
+      />,
+    );
+
+    await new Promise(r => setTimeout(r, 0));
+    inputCallback('', { escape: true });
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('switches to manual mode on M and submits the typed destination', async () => {
+    const onChoose = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const { lastFrame, unmount } = render(
+      <TransferDestinationPicker
+        currentOwner="someone"
+        viewerLogin="myviewer"
+        loadOrganizations={async () => orgs()}
+        onChoose={onChoose}
+        onCancel={() => {}}
+      />,
+    );
+
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    inputCallback('m', {});
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(lastFrame() || '').toContain('Destination owner');
+    h.textInputProps?.onChange?.('hidden-org');
+    await new Promise(r => setTimeout(r, 0)); // flush → fresh onSubmit closes over new state
+    h.textInputProps?.onSubmit?.();
+
+    expect(onChoose).toHaveBeenCalledWith('hidden-org');
+    unmount();
+  });
+
+  it('blocks submission of the current owner in manual mode', async () => {
+    const onChoose = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const { lastFrame, unmount } = render(
+      <TransferDestinationPicker
+        currentOwner="myorg"
+        viewerLogin="myviewer"
+        loadOrganizations={async () => orgs()}
+        onChoose={onChoose}
+        onCancel={() => {}}
+      />,
+    );
+
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    inputCallback('m', {});
+    await new Promise(r => setTimeout(r, 0));
+
+    h.textInputProps?.onChange?.('MYORG');
+    await new Promise(r => setTimeout(r, 0));
+    h.textInputProps?.onSubmit?.();
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(onChoose).not.toHaveBeenCalled();
+    expect(lastFrame() || '').toContain('must differ');
+    unmount();
+  });
+
+  it('falls back to manual mode when the loader fails', async () => {
+    mockUseInput.mockImplementation(() => {});
+
+    const { lastFrame, unmount } = render(
+      <TransferDestinationPicker
+        currentOwner="myviewer"
+        // No personal/list entries possible → manual is the only useful surface.
+        viewerLogin="myviewer"
+        loadOrganizations={async () => { throw new Error('GraphQL boom'); }}
+        onChoose={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    const out = lastFrame() || '';
+    expect(out).toContain("Couldn't load organisations");
+    expect(out).toContain('GraphQL boom');
+    expect(out).toContain('Destination owner');
+    unmount();
+  });
+
+  it('renders the manual fallback when the org list is empty and personal is excluded', async () => {
+    const onChoose = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const { lastFrame, unmount } = render(
+      <TransferDestinationPicker
+        currentOwner="myviewer"
+        viewerLogin="myviewer"
+        loadOrganizations={async () => []}
+        onChoose={onChoose}
+        onCancel={() => {}}
+      />,
+    );
+
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(lastFrame() || '').toContain('Destination owner');
+
+    h.textInputProps?.onChange?.('new-target');
+    await new Promise(r => setTimeout(r, 0));
+    h.textInputProps?.onSubmit?.();
+    expect(onChoose).toHaveBeenCalledWith('new-target');
+    unmount();
+  });
+
+  it('sanitises invalid characters and leading hyphens before submission', async () => {
+    const onChoose = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const { unmount } = render(
+      <TransferDestinationPicker
+        currentOwner="someone"
+        viewerLogin="myviewer"
+        loadOrganizations={async () => []}
+        onChoose={onChoose}
+        onCancel={() => {}}
+      />,
+    );
+
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    // Already in manual mode (no orgs + personal excluded earlier test pattern).
+    // For this case viewer is "myviewer" and current owner is "someone" so personal
+    // remains. We still want to test manual sanitisation — switch to manual first.
+    inputCallback('m', {});
+    await new Promise(r => setTimeout(r, 0));
+
+    // The picker's onChange normalises the value. After typing the messy string
+    // the modal's internal `manualValue` should be 'newowner1'.
+    h.textInputProps?.onChange?.('--new owner_1!');
+    await new Promise(r => setTimeout(r, 0));
+    h.textInputProps?.onSubmit?.();
+
+    expect(onChoose).toHaveBeenCalledWith('newowner1');
+    unmount();
+  });
+
+  it('swallows input while the host marks the picker as busy', async () => {
+    const onChoose = vi.fn();
+    const onCancel = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    const { unmount } = render(
+      <TransferDestinationPicker
+        currentOwner="someone"
+        viewerLogin="myviewer"
+        loadOrganizations={async () => orgs()}
+        onChoose={onChoose}
+        onCancel={onCancel}
+        busy
+      />,
+    );
+
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    inputCallback('', { return: true });
+    inputCallback('', { escape: true });
+    inputCallback('m', {});
+
+    expect(onChoose).not.toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+    unmount();
+  });
+});

--- a/tests/ui/TransferDestinationPicker.test.tsx
+++ b/tests/ui/TransferDestinationPicker.test.tsx
@@ -307,6 +307,43 @@ describe('TransferDestinationPicker', () => {
     unmount();
   });
 
+  it('ignores Enter/arrows/M while the org list is still loading', async () => {
+    const onChoose = vi.fn();
+    const onCancel = vi.fn();
+    let inputCallback!: InkInputHandler;
+    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
+
+    // Loader that never resolves — the picker stays in the loading state.
+    const { lastFrame, unmount } = render(
+      <TransferDestinationPicker
+        currentOwner="someone"
+        viewerLogin="myviewer"
+        loadOrganizations={() => new Promise(() => {})}
+        onChoose={onChoose}
+        onCancel={onCancel}
+      />,
+    );
+
+    await new Promise(r => setTimeout(r, 0));
+
+    // List is hidden — only the spinner is shown. Pressing Enter must NOT
+    // submit the (invisible) focused row.
+    const out = lastFrame() || '';
+    expect(out).toContain('Loading organisations');
+    expect(out).not.toContain('Enter a different owner');
+
+    inputCallback('', { return: true });
+    inputCallback('', { downArrow: true });
+    inputCallback('m', {});
+
+    expect(onChoose).not.toHaveBeenCalled();
+
+    // Esc should still cancel even during loading.
+    inputCallback('', { escape: true });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
   it('swallows input while the host marks the picker as busy', async () => {
     const onChoose = vi.fn();
     const onCancel = vi.fn();

--- a/tests/ui/TransferModal.test.tsx
+++ b/tests/ui/TransferModal.test.tsx
@@ -3,16 +3,15 @@ import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vite
 import { render } from 'ink-testing-library';
 import type { Key } from 'ink';
 import TransferModal from '../../src/ui/components/modals/TransferModal';
-import type { RepoNode } from '../../src/types';
+import type { OrganizationNode, RepoNode } from '../../src/types';
 
 // Signature of the callback Ink passes to useInput
 type InkInputHandler = (input: string, key: Partial<Key>) => void;
 
 // Mock the useInput hook to avoid stdin.ref issues and to drive key events.
-// Note: this also stubs the useInput used internally by ink-text-input, so the
-// destination-owner / verification-code TextInputs cannot receive typed
-// characters in this harness. Tests therefore exercise the drivable surface
-// (rendering, Esc-to-cancel, guards) plus the code logic directly.
+// Multiple components inside the modal (TransferModal itself + the picker child)
+// can register useInput. `latestInputCallback` always points at the most recent
+// registration — that is what tests should drive.
 vi.mock('ink', async () => {
   const actual = await vi.importActual('ink');
   return {
@@ -24,10 +23,10 @@ vi.mock('ink', async () => {
 // ink-text-input internally calls the real ink useInput (which enables raw mode
 // and throws `stdin.ref is not a function` under the test stdin). Stub it so the
 // surrounding modal can render, and capture the latest props so tests can drive
-// the destination-owner / verification-code inputs via onChange.
-const h = vi.hoisted(() => ({ textInputProps: null as { onChange?: (v: string) => void } | null }));
+// the destination/code inputs via onChange + onSubmit.
+const h = vi.hoisted(() => ({ textInputProps: null as { onChange?: (v: string) => void; onSubmit?: () => void } | null }));
 vi.mock('ink-text-input', () => ({
-  default: (props: { onChange?: (v: string) => void }) => { h.textInputProps = props; return null; }
+  default: (props: { onChange?: (v: string) => void; onSubmit?: () => void }) => { h.textInputProps = props; return null; }
 }));
 
 describe('TransferModal', () => {
@@ -50,23 +49,38 @@ describe('TransferModal', () => {
     visibility: 'PUBLIC'
   } as RepoNode;
 
+  const mockOrgs: OrganizationNode[] = [
+    { id: 'o1', login: 'acme', name: 'Acme Inc', avatarUrl: '' },
+  ];
+
   beforeEach(async () => {
+    h.textInputProps = null;
     const ink = await import('ink');
     mockUseInput = (ink as unknown as { useInput: Mock }).useInput;
     mockUseInput.mockReset();
   });
 
-  it('renders the destination-owner input stage', () => {
+  it('renders the destination picker on stage 1', async () => {
     mockUseInput.mockImplementation(() => {});
 
     const { lastFrame, unmount } = render(
-      <TransferModal repo={mockRepo} onTransfer={async () => {}} onCancel={() => {}} />
+      <TransferModal
+        repo={mockRepo}
+        onTransfer={async () => {}}
+        onCancel={() => {}}
+        viewerLogin="me"
+        loadOrganizations={async () => mockOrgs}
+      />
     );
+
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
 
     const output = lastFrame() || '';
     expect(output).toContain('Transfer Repository');
     expect(output).toContain('user/test-repo');
-    expect(output).toContain('New owner');
+    expect(output).toContain('Choose destination owner');
+    expect(output).toContain('Acme Inc');
     unmount();
   });
 
@@ -81,37 +95,24 @@ describe('TransferModal', () => {
     unmount();
   });
 
-  it('cancels on Esc', () => {
+  it('cancels on Esc from the picker', async () => {
     const onCancel = vi.fn();
     let inputCallback!: InkInputHandler;
     mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
 
     const { unmount } = render(
-      <TransferModal repo={mockRepo} onTransfer={async () => {}} onCancel={onCancel} />
+      <TransferModal
+        repo={mockRepo}
+        onTransfer={async () => {}}
+        onCancel={onCancel}
+        viewerLogin="me"
+        loadOrganizations={async () => mockOrgs}
+      />
     );
 
+    await new Promise(r => setTimeout(r, 0));
     inputCallback('', { escape: true });
     expect(onCancel).toHaveBeenCalledTimes(1);
-    unmount();
-  });
-
-  it('does not advance past the owner stage when no owner has been entered', () => {
-    const onTransfer = vi.fn(async () => {});
-    const onCancel = vi.fn();
-    let inputCallback!: InkInputHandler;
-    mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
-
-    const { lastFrame, unmount } = render(
-      <TransferModal repo={mockRepo} onTransfer={onTransfer} onCancel={onCancel} />
-    );
-
-    // Pressing Enter with an empty owner must not move to the code stage…
-    inputCallback('', { return: true });
-
-    const output = lastFrame() || '';
-    expect(output).toContain('New owner');           // still on input stage
-    expect(output).not.toContain('Verification code');
-    expect(onTransfer).not.toHaveBeenCalled();        // …and never starts a transfer
     unmount();
   });
 
@@ -136,8 +137,9 @@ describe('TransferModal', () => {
     expect('zzzz'.toUpperCase() === code).toBe(false);
   });
 
-  // Drive the full input -> code -> confirm flow by simulating typing through the
-  // captured TextInput. Math.random -> 0 makes the verification code 'AAAA'.
+  // Drive the full picker → code → confirm flow. The picker selects the lone
+  // org on Enter, then the verification code is typed via the captured TextInput.
+  // Math.random -> 0 makes the verification code 'AAAA'.
   describe('staged flow', () => {
     let randomSpy: ReturnType<typeof vi.spyOn>;
     const CODE = 'AAAA';
@@ -151,17 +153,20 @@ describe('TransferModal', () => {
       randomSpy.mockRestore();
     });
 
-    // Walk the modal from the owner-input stage to the final confirmation stage.
-    // `getCb` returns the latest input callback — Ink hands useInput a fresh
-    // closure on every re-render, so capturing it by value here would go stale.
+    // Walk the modal from the picker stage to the final confirmation stage.
+    // `getCb` returns the latest input callback — multiple useInput hooks register
+    // (TransferModal + picker) so the latest is the picker; that's what we drive.
     const advanceToConfirm = async (getCb: () => InkInputHandler) => {
-      // Let the mount effect generate the verification code (deterministically 'AAAA').
+      // Let the mount effect generate the verification code (deterministically 'AAAA')
+      // AND the picker's org loader to resolve.
       await new Promise(resolve => setTimeout(resolve, 0));
-      h.textInputProps?.onChange?.('neworg');           // destination owner
       await new Promise(resolve => setTimeout(resolve, 0));
-      getCb()('', { return: true });                     // input -> code stage
+      // Picker list: cursor 0 = 'acme' (the only candidate — viewerLogin matches owner)
+      // Enter → submitDestination('acme') → stage transitions to 'code'.
+      getCb()('', { return: true });
       await new Promise(resolve => setTimeout(resolve, 0));
-      h.textInputProps?.onChange?.(CODE);                // type the verification code
+      // Verification-code TextInput is now mounted — type the code via captured props.
+      h.textInputProps?.onChange?.(CODE);
       await new Promise(resolve => setTimeout(resolve, 0));
     };
 
@@ -170,7 +175,13 @@ describe('TransferModal', () => {
       mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
 
       const { lastFrame, unmount } = render(
-        <TransferModal repo={mockRepo} onTransfer={async () => {}} onCancel={() => {}} />
+        <TransferModal
+          repo={mockRepo}
+          onTransfer={async () => {}}
+          onCancel={() => {}}
+          viewerLogin="user"
+          loadOrganizations={async () => mockOrgs}
+        />
       );
 
       await advanceToConfirm(() => inputCallback);
@@ -186,7 +197,13 @@ describe('TransferModal', () => {
       mockUseInput.mockImplementation((cb: InkInputHandler) => { inputCallback = cb; });
 
       const { unmount } = render(
-        <TransferModal repo={mockRepo} onTransfer={onTransfer} onCancel={onCancel} />
+        <TransferModal
+          repo={mockRepo}
+          onTransfer={onTransfer}
+          onCancel={onCancel}
+          viewerLogin="user"
+          loadOrganizations={async () => mockOrgs}
+        />
       );
 
       await advanceToConfirm(() => inputCallback);
@@ -200,7 +217,7 @@ describe('TransferModal', () => {
 
       expect(onCancel).not.toHaveBeenCalled();
       expect(onTransfer).toHaveBeenCalledTimes(1);
-      expect(onTransfer).toHaveBeenCalledWith(mockRepo, 'neworg');
+      expect(onTransfer).toHaveBeenCalledWith(mockRepo, 'acme');
       unmount();
     });
   });


### PR DESCRIPTION
## Summary

Replaces the bare destination text input in both transfer flows with a shared **TransferDestinationPicker**:

- Lists the viewer's personal account + organisations returned by `fetchViewerOrganizations` (same call as the `W` org switcher), with the current owner excluded.
- Always-available manual-entry fallback (press `M` or pick "Enter a different owner…") for owners the token can't list.
- Loading / empty / error handling: if the org fetch fails or returns no candidates, the picker auto-switches to manual mode so the flow is never blocked.
- Sanitisation and "must differ from current owner" validation preserved; `submittingRef` guards remain so a key arriving in the same tick as Enter can't fire twice.
- `RepoList` caches the org list for the session (per token) so single + bulk transfers don't refetch.

## Files touched

- New: `src/ui/components/modals/TransferDestinationPicker.tsx` (shared picker)
- Updated: `src/ui/components/modals/TransferModal.tsx` (single-repo stage 1 uses the picker)
- Updated: `src/ui/components/modals/BulkTransferDestinationModal.tsx` (bulk modal wraps the picker)
- Updated: `src/ui/views/RepoList.tsx` (wires `viewerLogin` + cached `loadOrganizations` into both modals)
- Updated: `AGENTS.md` + `README.md` (Shift+M descriptions)
- Tests: new `tests/ui/TransferDestinationPicker.test.tsx`, refreshed `tests/ui/TransferModal.test.tsx` + `tests/ui/BulkTransferDestinationModal.test.tsx`

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `npx vitest run` — 27/27 new + updated tests pass; existing in-flight-guard tests still pass for both modals (2 pre-existing failures in `BulkReviewModal.test.tsx` on `main` are unrelated)
- [x] `npx tsup` build success
- [ ] Manual verification across iTerm2, Terminal.app, Termius (not exercised in this workspace)

### Manual checks the reviewer should run
- [ ] Single transfer: open `Shift+M` on a repo, navigate the picker, pick an org → verification code → confirm
- [ ] Single transfer: press `M` to enter manual mode, type an org the token can't see, submit
- [ ] Bulk transfer: same picker + manual fallback after the review/confirm stages
- [ ] Disconnect / use a token without `read:org` to verify the picker degrades gracefully to manual entry
- [ ] Current owner is excluded from the list in both flows

---

<div align="center">
<sub>
Created by <b>William Li</b> (william@stealths.works) with <a href="https://tryreplicas.com">Replicas</a><br>
<a href="https://tryreplicas.com/workspaces/ffb88a83-774f-4391-a716-8b897660b432">Workspace</a> &nbsp;·&nbsp; <a href="https://linear.app/stealths/issue/SWR-381/transfer-destination-picker-list-connected-scopes-personal-orgs-with">SWR-381</a>
</sub>
</div>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ownership-transfer UX and validation paths for single and bulk moves; mistakes still gated by verification code, but wrong destination selection is easier than mistyping a name.
> 
> **Overview**
> **Single and bulk repository transfer** no longer ask for a free-text destination owner first. Both flows now use a shared **`TransferDestinationPicker`** that lists the viewer’s personal account (when it isn’t the current owner) plus organisations from the same **`fetchViewerOrganizations`** call as the org switcher, with **↑/↓ + Enter** selection and **`M`** or “Enter a different owner…” for manual entry when the token can’t list a target.
> 
> The picker **excludes the current owner**, **sanitises** manual input, **blocks stray Enter while orgs load**, and **falls back to manual mode** on fetch failure or empty lists. **`RepoList`** adds a **per-token session cache** (with in-flight deduping) for orgs and passes **`viewerLogin`** + **`loadOrganizations`** into **`TransferModal`** and **`BulkTransferDestinationModal`**. Verification-code and confirmation stages are unchanged.
> 
> Docs (**`AGENTS.md`**, **`README.md`**) describe the new **`Shift+M`** UX. Tests cover the picker and updated modal flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcf43ba4c6fd1c8484497d5a9ab244f0591cffca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->