### PR TITLE
refactor: TypeScript hardening — replace `any` with typed GraphQL responses (GMC-27)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,7 @@ First run prompts for a PAT if not provided via env vars. The token is validated
 - **Terminal colours:** Use chalk for pre-colouring to avoid nested Text issues
 - **Error handling:** Try-catch blocks for API calls and network operations
 - **Language:** British English for all user-facing text (e.g., organisation, authorisation, colour)
+- **No `any`:** GraphQL response paths use dedicated response interfaces (e.g. `ViewerLoginResponse`, `OrgReposResponse`). Error catch clauses use `catch (e: unknown)` with narrowing via `(e instanceof Error ? e.message : null) || fallback`. For logger calls, `context?: unknown` is the correct type. Dynamic chalk property access uses `(chalk as unknown as Record<string, ChalkInstance | undefined>)[key]`. The one permitted `any` is `persistCache(... as any)` which is a workaround for an incomplete third-party type definition in `apollo3-cache-persist`.
 
 ### Testing Protocol
 1. **Terminal Testing:** Test in multiple terminals (iTerm2, Terminal.app, Termius)

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -78,7 +78,7 @@ export function storeToken(token: string, source: TokenSource = 'pat') {
 export function clearStoredToken() {
   const existing = readConfig();
   // Preserve other settings like ui prefs
-  const { token, tokenVersion, tokenSource, ...rest } = existing as any;
+  const { token: _token, tokenVersion: _tv, tokenSource: _ts, ...rest } = existing;
   writeConfig({ ...rest });
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,14 +41,12 @@ const getShortFlagValue = (short: string): string | undefined => {
 };
 if (argv.includes('--version') || argv.includes('-v')) {
   // Print semantic version without network
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const version = (pkg as any)?.version || '0.0.0';
+  const version = (pkg as { version?: string })?.version || '0.0.0';
   process.stdout.write(`${version}\n`);
   process.exit(0);
 }
 if (argv.includes('--help') || argv.includes('-h')) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const version = (pkg as any)?.version || '0.0.0';
+  const version = (pkg as { version?: string })?.version || '0.0.0';
   process.stdout.write(`gh-manager-cli v${version}\n\n` +
     `GitHub repo manager (Ink TUI)\n\n` +
     `Usage:\n` +
@@ -70,7 +68,7 @@ if (process.env.GH_MANAGER_DEBUG === '1') {
 }
 
 logger.info('Starting gh-manager-cli', { 
-  version: (pkg as any)?.version || '0.0.0',
+  version: (pkg as { version?: string })?.version || '0.0.0',
   node: process.version
 });
 
@@ -124,9 +122,10 @@ process.on('uncaughtException', (err) => {
   console.error('Unhandled error:', err.message || err);
   process.exit(1);
 });
-process.on('unhandledRejection', (reason: any) => {
-  logger.fatal('Unhandled rejection', { error: reason?.message || reason, stack: reason?.stack });
-  console.error('Unhandled rejection:', reason?.message || reason);
+process.on('unhandledRejection', (reason: unknown) => {
+  const reasonErr = reason instanceof Error ? reason : null;
+  logger.fatal('Unhandled rejection', { error: reasonErr?.message || String(reason), stack: reasonErr?.stack });
+  console.error('Unhandled rejection:', reasonErr?.message || reason);
   process.exit(1);
 });
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -132,7 +132,7 @@ class Logger {
     return names[level] || 'UNKNOWN';
   }
 
-  private formatMessage(level: LogLevel, message: string, context?: any): string {
+  private formatMessage(level: LogLevel, message: string, context?: unknown): string {
     const timestamp = this.formatTimestamp();
     const levelName = this.getLevelName(level);
     const paddedLevel = levelName.padEnd(5);
@@ -153,7 +153,7 @@ class Logger {
     return formattedMessage;
   }
 
-  private log(level: LogLevel, message: string, context?: any): void {
+  private log(level: LogLevel, message: string, context?: unknown): void {
     // Check if we should log this level
     if (level < this.logLevel) {
       return;
@@ -180,23 +180,23 @@ class Logger {
     }
   }
 
-  debug(message: string, context?: any): void {
+  debug(message: string, context?: unknown): void {
     this.log(LogLevel.DEBUG, message, context);
   }
 
-  info(message: string, context?: any): void {
+  info(message: string, context?: unknown): void {
     this.log(LogLevel.INFO, message, context);
   }
 
-  warn(message: string, context?: any): void {
+  warn(message: string, context?: unknown): void {
     this.log(LogLevel.WARN, message, context);
   }
 
-  error(message: string, context?: any): void {
+  error(message: string, context?: unknown): void {
     this.log(LogLevel.ERROR, message, context);
   }
 
-  fatal(message: string, context?: any): void {
+  fatal(message: string, context?: unknown): void {
     this.log(LogLevel.FATAL, message, context);
   }
 

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -1,11 +1,16 @@
 import { graphql as makeGraphQL } from '@octokit/graphql';
-import { ApolloClient, InMemoryCache, HttpLink, gql } from '@apollo/client/core/index.js';
+import { ApolloClient, InMemoryCache, HttpLink, gql, type NormalizedCacheObject } from '@apollo/client/core/index.js';
 import { persistCache } from 'apollo3-cache-persist';
 import fs from 'fs';
 import path from 'path';
 import envPaths from 'env-paths';
 import type { RepoNode, RateLimitInfo, RestRateLimitInfo, CombinedRateLimitInfo } from '../types';
 import { logger } from '../lib/logger';
+
+/** Narrow an unknown catch value to an Error, preserving the message. */
+function toError(e: unknown): Error {
+  return e instanceof Error ? e : new Error(String(e));
+}
 
 export function makeClient(token: string) {
   return makeGraphQL.defaults({
@@ -44,11 +49,85 @@ interface RestRateLimitResponse {
   };
 }
 
+// GraphQL response shapes for Octokit client calls — keeps `const res: any` out
+// of the response-handling paths without littering the call sites with generics.
+
+interface ViewerLoginResponse {
+  viewer: { login: string };
+}
+
+interface ViewerOrganizationsResponse {
+  viewer: {
+    organizations: {
+      nodes: Organization[];
+    };
+  };
+}
+
+interface CheckOrgEnterpriseResponse {
+  organization?: {
+    enterpriseOwners?: {
+      totalCount: number;
+    };
+  };
+}
+
+interface RepositoryConnectionData {
+  totalCount: number;
+  pageInfo: { endCursor: string | null; hasNextPage: boolean };
+  nodes: RepoNode[];
+}
+
+interface OrgReposResponse {
+  rateLimit: RateLimitInfo;
+  organization: {
+    repositories: RepositoryConnectionData;
+  };
+}
+
+interface ViewerReposResponse {
+  rateLimit: RateLimitInfo;
+  viewer: {
+    repositories: RepositoryConnectionData;
+  };
+}
+
+interface StarredReposResponse {
+  rateLimit: RateLimitInfo;
+  viewer: {
+    starredRepositories: RepositoryConnectionData;
+  };
+}
+
+interface FetchRepositoryByIdResponse {
+  node: RepoNode | null;
+}
+
+interface FetchRepositoryByOwnerNameResponse {
+  repository: RepoNode | null;
+}
+
+// Dynamic alias keys produced by enrichForksWithAheadBehind (fork0, parent0, …)
+type EnrichForksResponse = Record<string, {
+  id?: string;
+  defaultBranchRef?: {
+    target?: {
+      history?: { totalCount: number };
+    };
+  };
+} | null>;
+
+/** Bundled Apollo client + gql tag shared across all calls. */
+interface ApolloClientBundle {
+  client: ApolloClient<NormalizedCacheObject>;
+  gql: typeof gql;
+}
+
 // Singleton Apollo client instance
-let apolloClientInstance: { client: ApolloClient<any>, gql: any } | null = null;
+let apolloClientInstance: ApolloClientBundle | null = null;
 
 // Apollo Client with persisted cache (default for all queries)
-async function makeApolloClient(token: string): Promise<any> {
+async function makeApolloClient(token: string): Promise<ApolloClientBundle> {
   // Return existing instance if available
   if (apolloClientInstance) {
     return apolloClientInstance;
@@ -91,28 +170,30 @@ async function makeApolloClient(token: string): Promise<any> {
         } catch {}
       }
     };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await persistCache({ cache, storage, debounce: 500, maxSize: 5 * 1024 * 1024 } as any);
-    const link = new (HttpLink as any)({
+    const link = new HttpLink({
       uri: 'https://api.github.com/graphql',
-      fetch: (globalThis as any).fetch,
+      fetch: globalThis.fetch,
       headers: { authorization: `Bearer ${token}` }
     });
     const client = new ApolloClient({ cache, link });
     apolloClientInstance = { client, gql };
     return apolloClientInstance;
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const err = toError(error);
     logger.error('Failed to initialize Apollo Client', { 
-      error: error.message, 
-      stack: error.stack 
+      error: err.message, 
+      stack: err.stack 
     });
     const debug = process.env.GH_MANAGER_DEBUG === '1';
     if (debug) {
-      process.stderr.write(`\n❌ Failed to initialize Apollo Client: ${error.message}\n`);
-      if (error.stack) {
-        process.stderr.write(`Stack: ${error.stack}\n`);
+      process.stderr.write(`\n❌ Failed to initialize Apollo Client: ${err.message}\n`);
+      if (err.stack) {
+        process.stderr.write(`Stack: ${err.stack}\n`);
       }
     }
-    throw new Error(`Apollo Client initialization failed: ${error.message}`);
+    throw new Error(`Apollo Client initialization failed: ${err.message}`);
   }
 }
 
@@ -128,11 +209,12 @@ export async function getViewerLogin(
   `;
   try {
     logger.debug('Fetching viewer login');
-    const res: any = await client(query);
+    const res = await client<ViewerLoginResponse>(query);
     logger.info(`Successfully fetched viewer login: ${res.viewer.login}`);
-    return res.viewer.login as string;
-  } catch (error: any) {
-    logger.error('Failed to fetch viewer login', { error: error.message, stack: error.stack });
+    return res.viewer.login;
+  } catch (error: unknown) {
+    const err = toError(error);
+    logger.error('Failed to fetch viewer login', { error: err.message, stack: err.stack });
     throw error;
   }
 }
@@ -162,8 +244,8 @@ export async function fetchViewerOrganizations(
       }
     }
   `;
-  const res: any = await client(query);
-  return res.viewer.organizations.nodes as Organization[];
+  const res = await client<ViewerOrganizationsResponse>(query);
+  return res.viewer.organizations.nodes;
 }
 
 // Check if an organization is enterprise by checking enterpriseOwners field
@@ -187,11 +269,11 @@ export async function checkOrganizationIsEnterprise(
         }
       }
     `;
-    const res: any = await client(query, { orgLogin });
+    const res = await client<CheckOrgEnterpriseResponse>(query, { orgLogin });
     
     // If the organization has enterprise owners, it's part of an enterprise
     // The field will return null or throw an error for non-enterprise orgs
-    const isEnterprise = res.organization?.enterpriseOwners?.totalCount > 0;
+    const isEnterprise = (res.organization?.enterpriseOwners?.totalCount ?? 0) > 0;
     
     logger.info('Organization enterprise status checked', {
       orgLogin,
@@ -224,22 +306,23 @@ export interface ReposPageResult {
  * include the connections (older cache reads, fragments without the fields)
  * fall through untouched.
  */
-export function normalizeRepoNode<T extends Record<string, any>>(node: T): T {
+export function normalizeRepoNode<T extends object>(node: T): T {
   if (!node) return node;
-  const result: any = { ...node };
-  const pr = (node as any).openPullRequests;
+  const raw = node as Record<string, unknown>;
+  const result: Record<string, unknown> = { ...raw };
+  const pr = raw.openPullRequests;
   if (pr && typeof pr === 'object' && 'totalCount' in pr) {
-    result.openPullRequests = pr.totalCount as number;
+    result.openPullRequests = (pr as { totalCount: number }).totalCount;
   }
-  const iss = (node as any).openIssues;
+  const iss = raw.openIssues;
   if (iss && typeof iss === 'object' && 'totalCount' in iss) {
-    result.openIssues = iss.totalCount as number;
+    result.openIssues = (iss as { totalCount: number }).totalCount;
   }
-  return result as T;
+  return result as unknown as T;
 }
 
-function normalizeRepoNodes(nodes: any[]): RepoNode[] {
-  return (nodes || []).map(n => normalizeRepoNode(n)) as RepoNode[];
+function normalizeRepoNodes(nodes: unknown[]): RepoNode[] {
+  return (nodes || []).map(n => normalizeRepoNode(n as object)) as RepoNode[];
 }
 
 export type OwnerAffiliation = 'OWNER' | 'COLLABORATOR' | 'ORGANIZATION_MEMBER';
@@ -351,7 +434,7 @@ export async function fetchViewerReposPage(
       }
     `;
     
-    const res: any = await client(query, {
+    const res = await client<OrgReposResponse>(query, {
       first,
       after: after ?? null,
       sortField,
@@ -361,11 +444,11 @@ export async function fetchViewerReposPage(
     
     const data = res.organization.repositories;
     return {
-      nodes: normalizeRepoNodes(data.nodes),
+      nodes: normalizeRepoNodes(data.nodes as unknown[]),
       endCursor: data.pageInfo.endCursor,
       hasNextPage: data.pageInfo.hasNextPage,
       totalCount: data.totalCount,
-      rateLimit: res.rateLimit as RateLimitInfo,
+      rateLimit: res.rateLimit,
     };
   }
 
@@ -451,7 +534,7 @@ export async function fetchViewerReposPage(
   `;
   
   try {
-    const res: any = await client(query, {
+    const res = await client<ViewerReposResponse>(query, {
       first,
       after: after ?? null,
       sortField,
@@ -462,18 +545,17 @@ export async function fetchViewerReposPage(
     const data = res.viewer.repositories;
     logger.info(`Octokit successfully fetched ${data.nodes.length} repositories`);
     return {
-      nodes: normalizeRepoNodes(data.nodes),
+      nodes: normalizeRepoNodes(data.nodes as unknown[]),
       endCursor: data.pageInfo.endCursor,
       hasNextPage: data.pageInfo.hasNextPage,
       totalCount: data.totalCount,
-      rateLimit: res.rateLimit as RateLimitInfo,
+      rateLimit: res.rateLimit,
     };
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const err = toError(error);
     logger.error('Octokit query failed', {
-      error: error.message,
-      stack: error.stack,
-      status: error.status,
-      response: error.response
+      error: err.message,
+      stack: err.stack,
     });
     throw error;
   }
@@ -517,12 +599,12 @@ export async function fetchViewerReposPageUnified(
       
       // Different query based on context (personal vs organization)
       let q;
-      let variables: any = { first, after: after ?? null, sortField, sortDirection };
+      let variables: Record<string, unknown> = { first, after: after ?? null, sortField, sortDirection };
       
       if (isOrgContext) {
         // Organization context
-        variables.orgLogin = organizationLogin;
-        q = (ap.gql as any)`
+        variables = { ...variables, orgLogin: organizationLogin };
+        q = ap.gql`
           query OrgRepos($first: Int!, $after: String, $sortField: RepositoryOrderField!, $sortDirection: OrderDirection!, $orgLogin: String!) {
             rateLimit { limit remaining resetAt }
             organization(login: $orgLogin) {
@@ -557,8 +639,8 @@ export async function fetchViewerReposPageUnified(
         `;
       } else {
         // Personal context
-        variables.affiliations = ownerAffiliations;
-        q = (ap.gql as any)`
+        variables = { ...variables, affiliations: ownerAffiliations };
+        q = ap.gql`
           query ViewerRepos($first: Int!, $after: String, $sortField: RepositoryOrderField!, $sortDirection: OrderDirection!, $affiliations: [RepositoryAffiliation!]!) {
             rateLimit { limit remaining resetAt }
             viewer {
@@ -632,14 +714,13 @@ export async function fetchViewerReposPageUnified(
         rateLimit: res.data.rateLimit as RateLimitInfo,
       };
     }
-  } catch (e: any) {
+  } catch (e: unknown) {
+    const err = toError(e);
     logger.error('Apollo query failed', {
-      error: e.message, 
-      stack: e.stack,
-      graphQLErrors: e.graphQLErrors,
-      networkError: e.networkError
+      error: err.message, 
+      stack: err.stack,
     });
-    if (debug) console.log(`❌ Apollo failed, falling back to Octokit:`, e.message);
+    if (debug) console.log(`❌ Apollo failed, falling back to Octokit:`, err.message);
     // Fallback to Octokit path if Apollo not available
   }
   
@@ -671,7 +752,7 @@ export async function searchRepositoriesUnified(
   
   try {
     const ap = await makeApolloClient(token);
-    const queryDoc = (ap.gql as any)`
+    const queryDoc = ap.gql`
       query SearchRepos($q: String!, $first: Int!, $after: String) {
         rateLimit { limit remaining resetAt }
         search(query: $q, type: REPOSITORY, first: $first, after: $after) {
@@ -717,17 +798,12 @@ export async function searchRepositoriesUnified(
       totalCount: data.repositoryCount,
       rateLimit: res.data.rateLimit as RateLimitInfo,
     };
-  } catch (e: any) {
+  } catch (e: unknown) {
     // Log errors to stderr only in debug mode
     const debug = process.env.GH_MANAGER_DEBUG === '1';
     if (debug) {
-      process.stderr.write(`\n❌ Search failed: ${e.message}\n`);
-      if (e.graphQLErrors) {
-        process.stderr.write(`GraphQL errors: ${JSON.stringify(e.graphQLErrors, null, 2)}\n`);
-      }
-      if (e.networkError) {
-        process.stderr.write(`Network error: ${e.networkError.message}\n`);
-      }
+      const err = toError(e);
+      process.stderr.write(`\n❌ Search failed: ${err.message}\n`);
     }
     // Re-throw the error so we can see it in the UI
     throw e;
@@ -755,7 +831,7 @@ export async function deleteRepositoryRest(
       'Accept': 'application/vnd.github+json',
       'User-Agent': 'gh-manager-cli'
     }
-  } as any);
+  });
   
   if (res.status === 204) {
     logger.info('Successfully deleted repository', {
@@ -841,7 +917,7 @@ export async function createRepositoryRest(
     ? `https://api.github.com/orgs/${org}/repos`
     : `https://api.github.com/user/repos`;
 
-  const body: Record<string, any> = { name };
+  const body: Record<string, unknown> = { name };
   if (visibility === 'INTERNAL') {
     // Internal visibility is only valid for org repos within an enterprise
     body.visibility = 'internal';
@@ -863,10 +939,11 @@ export async function createRepositoryRest(
         'User-Agent': 'gh-manager-cli'
       },
       body: JSON.stringify(body)
-    } as any);
-  } catch (networkError: any) {
-    logger.error('Network error during repository creation', { error: networkError.message, name, org: org ?? null });
-    throw new Error(`Network error whilst creating repository: ${networkError.message}`);
+    });
+  } catch (networkError: unknown) {
+    const err = toError(networkError);
+    logger.error('Network error during repository creation', { error: err.message, name, org: org ?? null });
+    throw new Error(`Network error whilst creating repository: ${err.message}`);
   }
 
   if (res.status === 201) {
@@ -921,10 +998,11 @@ export async function transferRepositoryRest(
         'User-Agent': 'gh-manager-cli'
       },
       body: JSON.stringify({ new_owner: newOwner })
-    } as any);
-  } catch (networkError: any) {
-    logger.error('Network error during repository transfer', { error: networkError.message, owner, repo, newOwner });
-    throw new Error(`Network error whilst transferring repository: ${networkError.message}`);
+    });
+  } catch (networkError: unknown) {
+    const err = toError(networkError);
+    logger.error('Network error during repository transfer', { error: err.message, owner, repo, newOwner });
+    throw new Error(`Network error whilst transferring repository: ${err.message}`);
   }
 
   // 202 Accepted = transfer initiated. Some responses may also return 200.
@@ -1010,7 +1088,7 @@ export async function getStarredRepositories(
   `;
 
   try {
-    const res: any = await client(query, {
+    const res = await client<StarredReposResponse>(query, {
       first,
       after: after ?? null,
     });
@@ -1023,16 +1101,17 @@ export async function getStarredRepositories(
     });
 
     return {
-      nodes: normalizeRepoNodes(data.nodes),
-      endCursor: data.pageInfo.endCursor,
+      nodes: normalizeRepoNodes(data.nodes as unknown[]),
+      endCursor: data.pageInfo.endCursor ?? undefined,
       hasNextPage: data.pageInfo.hasNextPage,
       totalCount: data.totalCount,
-      rateLimit: res.rateLimit as RateLimitInfo,
+      rateLimit: res.rateLimit,
     };
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const err = toError(error);
     logger.error('Failed to fetch starred repositories', {
-      error: error.message,
-      stack: error.stack
+      error: err.message,
+      stack: err.stack
     });
     throw error;
   }
@@ -1060,11 +1139,12 @@ export async function starRepository(
     logger.info('Successfully starred repository', {
       starrableId
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const err = toError(error);
     logger.error('Failed to star repository', {
       starrableId,
-      error: error.message,
-      stack: error.stack
+      error: err.message,
+      stack: err.stack
     });
     throw error;
   }
@@ -1092,11 +1172,12 @@ export async function unstarRepository(
     logger.info('Successfully unstarred repository', {
       starrableId
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const err = toError(error);
     logger.error('Failed to unstar repository', {
       starrableId,
-      error: error.message,
-      stack: error.stack
+      error: err.message,
+      stack: err.stack
     });
     throw error;
   }
@@ -1123,11 +1204,12 @@ export async function archiveRepositoryById(
     logger.info('Successfully archived repository', {
       repositoryId
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const err = toError(error);
     logger.error('Failed to archive repository', {
       repositoryId,
-      error: error.message,
-      stack: error.stack
+      error: err.message,
+      stack: err.stack
     });
     throw error;
   }
@@ -1154,11 +1236,12 @@ export async function unarchiveRepositoryById(
     logger.info('Successfully unarchived repository', {
       repositoryId
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const err = toError(error);
     logger.error('Failed to unarchive repository', {
       repositoryId,
-      error: error.message,
-      stack: error.stack
+      error: err.message,
+      stack: err.stack
     });
     throw error;
   }
@@ -1344,7 +1427,7 @@ export async function fetchRepositoryById(
     }
   `;
   
-  const result: any = await client(query, { 
+  const result = await client<FetchRepositoryByIdResponse>(query, { 
     id: repositoryId,
     includeForkTracking 
   });
@@ -1375,7 +1458,7 @@ export async function syncForkWithUpstream(
       'User-Agent': 'gh-manager-cli'
     },
     body: JSON.stringify({ branch })
-  } as any);
+  });
   
   if (res.status === 204) {
     // Already up to date
@@ -1586,10 +1669,11 @@ export async function fetchRestRateLimits(token: string): Promise<RestRateLimitI
       core: data.resources?.core || { limit: 0, remaining: 0, reset: 0 },
       graphql: data.resources?.graphql || { limit: 0, remaining: 0, reset: 0 }
     };
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const err = toError(error);
     logger.error('Error fetching REST rate limits', {
-      error: error.message,
-      stack: error.stack
+      error: err.message,
+      stack: err.stack
     });
     return null;
   }
@@ -1645,11 +1729,12 @@ export async function renameRepositoryById(
       repositoryId,
       newName: result?.updateRepository?.repository?.name
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const err = toError(error);
     logger.error('Failed to rename repository', {
       repositoryId,
       newName,
-      error: error.message
+      error: err.message
     });
     throw error;
   }
@@ -1693,8 +1778,9 @@ export async function inspectCacheStatus(): Promise<void> {
       process.stderr.write(`📊 Meta file: NOT FOUND\n`);
     }
     process.stderr.write('\n');
-  } catch (e: any) {
-    process.stderr.write(`❌ Cache inspection failed: ${e.message}\n`);
+  } catch (e: unknown) {
+    const err = toError(e);
+    process.stderr.write(`❌ Cache inspection failed: ${err.message}\n`);
   }
 }
 
@@ -1772,7 +1858,7 @@ export async function enrichForksWithAheadBehind(
     const query = `query EnrichForks(${varDefs}) { ${queryParts.join('\n')} }`;
 
     try {
-      const res: any = await client(query, variables);
+      const res = await client<EnrichForksResponse>(query, variables);
 
       batch.forEach((fork, i) => {
         const forkNode = res[`fork${i}`];
@@ -1785,9 +1871,10 @@ export async function enrichForksWithAheadBehind(
 
         results.push({ id: fork.id, forkHistoryCount, parentHistoryCount });
       });
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const e = toError(err);
       logger.error('enrichForksWithAheadBehind batch failed', {
-        error: err.message,
+        error: e.message,
         batchSize: batch.length,
       });
       // Push nulls for this batch so callers know they weren't enriched
@@ -1845,10 +1932,11 @@ export async function fetchRepositoryByOwnerAndName(
   `;
 
   try {
-    const result: any = await client(query, { owner, name });
-    return result.repository as RepoNode | null;
-  } catch (err: any) {
-    logger.error('fetchRepositoryByOwnerAndName failed', { owner, name, error: err.message });
+    const result = await client<FetchRepositoryByOwnerNameResponse>(query, { owner, name });
+    return result.repository;
+  } catch (err: unknown) {
+    const e = toError(err);
+    logger.error('fetchRepositoryByOwnerAndName failed', { owner, name, error: e.message });
     return null;
   }
 }

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -244,8 +244,14 @@ export async function fetchViewerOrganizations(
       }
     }
   `;
-  const res = await client<ViewerOrganizationsResponse>(query);
-  return res.viewer.organizations.nodes;
+  try {
+    const res = await client<ViewerOrganizationsResponse>(query);
+    return res.viewer.organizations.nodes;
+  } catch (error: unknown) {
+    const err = toError(error);
+    logger.error('Failed to fetch viewer organisations', { error: err.message, stack: err.stack });
+    throw error;
+  }
 }
 
 // Check if an organization is enterprise by checking enterpriseOwners field

--- a/src/services/oauth.ts
+++ b/src/services/oauth.ts
@@ -56,10 +56,10 @@ export async function startOAuthFlow(): Promise<OAuthResult> {
         verification_uri: deviceCodeResponse.verification_uri
       }
     };
-  } catch (error: any) {
+  } catch (error: unknown) {
     return {
       success: false,
-      error: `OAuth flow failed: ${error.message}`
+      error: `OAuth flow failed: ${error instanceof Error ? error.message : String(error)}`
     };
   }
 }
@@ -82,10 +82,10 @@ export async function pollForAccessToken(deviceCodeResponse: DeviceCodeResponse)
           token,
           login
         };
-      } catch (error: any) {
+      } catch (error: unknown) {
         return {
           success: false,
-          error: `Token validation failed: ${error.message}`
+          error: `Token validation failed: ${error instanceof Error ? error.message : String(error)}`
         };
       }
     }
@@ -94,10 +94,10 @@ export async function pollForAccessToken(deviceCodeResponse: DeviceCodeResponse)
       success: false,
       error: 'Failed to obtain access token'
     };
-  } catch (error: any) {
+  } catch (error: unknown) {
     return {
       success: false,
-      error: `Polling failed: ${error.message}`
+      error: `Polling failed: ${error instanceof Error ? error.message : String(error)}`
     };
   }
 }
@@ -234,13 +234,14 @@ async function pollForToken(deviceCodeResponse: DeviceCodeResponse): Promise<str
         console.log('🤔 Unexpected response format, continuing to poll...');
       }
       
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const errMsg = error instanceof Error ? error.message : String(error);
       if (process.env.GH_MANAGER_DEBUG) {
-        console.log('❌ Polling error:', error.message);
+        console.log('❌ Polling error:', errMsg);
       }
       
       // Only throw error if it's not a network/temporary issue
-      if (error.message.includes('access_denied') || error.message.includes('expired_token')) {
+      if (errMsg.includes('access_denied') || errMsg.includes('expired_token')) {
         throw error;
       }
       
@@ -279,10 +280,10 @@ export async function reauthorizeForOrganizations(): Promise<OAuthResult> {
     // Use the same device flow as initial auth
     // GitHub will recognise the app and show which orgs need authorisation
     return await startOAuthFlow();
-  } catch (error: any) {
+  } catch (error: unknown) {
     return {
       success: false,
-      error: `Reauthorisation failed: ${error.message}`
+      error: `Reauthorisation failed: ${error instanceof Error ? error.message : String(error)}`
     };
   }
 }

--- a/src/services/oauth.ts
+++ b/src/services/oauth.ts
@@ -59,7 +59,7 @@ export async function startOAuthFlow(): Promise<OAuthResult> {
   } catch (error: unknown) {
     return {
       success: false,
-      error: `OAuth flow failed: ${error instanceof Error ? error.message : String(error)}`
+      error: `OAuth flow failed: ${(error instanceof Error ? error.message : null) || 'Unknown error'}`
     };
   }
 }
@@ -85,7 +85,7 @@ export async function pollForAccessToken(deviceCodeResponse: DeviceCodeResponse)
       } catch (error: unknown) {
         return {
           success: false,
-          error: `Token validation failed: ${error instanceof Error ? error.message : String(error)}`
+          error: `Token validation failed: ${(error instanceof Error ? error.message : null) || 'Unknown error'}`
         };
       }
     }
@@ -97,7 +97,7 @@ export async function pollForAccessToken(deviceCodeResponse: DeviceCodeResponse)
   } catch (error: unknown) {
     return {
       success: false,
-      error: `Polling failed: ${error instanceof Error ? error.message : String(error)}`
+      error: `Polling failed: ${(error instanceof Error ? error.message : null) || 'Unknown error'}`
     };
   }
 }
@@ -283,7 +283,7 @@ export async function reauthorizeForOrganizations(): Promise<OAuthResult> {
   } catch (error: unknown) {
     return {
       success: false,
-      error: `Reauthorisation failed: ${error instanceof Error ? error.message : String(error)}`
+      error: `Reauthorisation failed: ${(error instanceof Error ? error.message : null) || 'Unknown error'}`
     };
   }
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -47,7 +47,7 @@ export default function App({ initialOrgSlug, inlineToken, inlineTokenEphemeral 
     };
     stdout.on('resize', onResize);
     return () => {
-      stdout.off?.('resize', onResize as any);
+      stdout.off?.('resize', onResize);
     };
   }, [stdout]);
 
@@ -144,9 +144,9 @@ export default function App({ initialOrgSlug, inlineToken, inlineTokenEphemeral 
         } else {
           throw new Error(tokenResult.error || 'Failed to obtain access token');
         }
-      } catch (error: any) {
+      } catch (error: unknown) {
         setOAuthStatus('error');
-        setError(error.message);
+        setError(error instanceof Error ? error.message : String(error));
       }
     })();
   }, [mode]);
@@ -198,19 +198,26 @@ export default function App({ initialOrgSlug, inlineToken, inlineTokenEphemeral 
         });
         setInput(''); // Clear the input after successful authentication
         setMode('ready');
-      } catch (e: any) {
+      } catch (e: unknown) {
         clearTimeout(timeoutId);
         let errorMessage = 'Invalid or unauthorized token. Please enter a valid Personal Access Token.';
         let isRateLimit = false;
         let resetTime: string | null = null;
         
+        // Narrow to an object so we can safely probe GitHub-specific fields
+        const apiErr = e instanceof Error ? e : null;
+        // Octokit errors carry extra fields (errors[], response) — access via a
+        // safe cast after confirming the value is object-shaped.
+        const errObj = e != null && typeof e === 'object' ? (e as Record<string, unknown>) : null;
+        
         // Parse GitHub API error responses
-        if (e.message) {
-          const msg = e.message.toLowerCase();
+        const errMessage = apiErr?.message ?? '';
+        if (errMessage) {
+          const msg = errMessage.toLowerCase();
           if (msg.includes('rate limit') || msg.includes('rate-limit') || msg.includes('abuse')) {
             isRateLimit = true;
             // Try to extract rate limit reset time from error message
-            const resetMatch = e.message.match(/resets? at (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)/i);
+            const resetMatch = errMessage.match(/resets? at (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)/i);
             if (resetMatch) {
               resetTime = resetMatch[1];
             }
@@ -225,26 +232,32 @@ export default function App({ initialOrgSlug, inlineToken, inlineTokenEphemeral 
           }
         }
         
-        // Check for GraphQL specific errors and rate limit info
-        if (e.errors && Array.isArray(e.errors)) {
-          const firstError = e.errors[0];
-          if (firstError?.type === 'RATE_LIMITED') {
+        // Check for GraphQL specific errors and rate limit info (Octokit error shape)
+        const errors = errObj?.['errors'];
+        if (Array.isArray(errors)) {
+          const firstError = errors[0] as Record<string, unknown> | undefined;
+          if (firstError?.['type'] === 'RATE_LIMITED') {
             isRateLimit = true;
-          } else if (firstError?.type === 'FORBIDDEN') {
+          } else if (firstError?.['type'] === 'FORBIDDEN') {
             errorMessage = 'Token lacks required permissions. Please ensure your token has "repo" scope.';
           }
         }
         
-        // Check for rate limit headers in HTTP response
-        if (e.response?.headers) {
-          const rateLimitRemaining = e.response.headers['x-ratelimit-remaining'];
-          const rateLimitReset = e.response.headers['x-ratelimit-reset'];
+        // Check for rate limit headers in HTTP response (Octokit error shape)
+        const response = errObj?.['response'];
+        const responseHeaders = response != null && typeof response === 'object'
+          ? (response as Record<string, unknown>)['headers']
+          : null;
+        if (responseHeaders != null && typeof responseHeaders === 'object') {
+          const headers = responseHeaders as Record<string, unknown>;
+          const rateLimitRemaining = headers['x-ratelimit-remaining'];
+          const rateLimitResetVal = headers['x-ratelimit-reset'];
           
           if (rateLimitRemaining === '0' || rateLimitRemaining === 0) {
             isRateLimit = true;
-            if (rateLimitReset) {
+            if (rateLimitResetVal) {
               // Convert Unix timestamp to ISO string
-              const resetDate = new Date(parseInt(rateLimitReset) * 1000);
+              const resetDate = new Date(parseInt(String(rateLimitResetVal)) * 1000);
               resetTime = resetDate.toISOString();
             }
           }

--- a/src/ui/OrgSwitcher.tsx
+++ b/src/ui/OrgSwitcher.tsx
@@ -45,7 +45,7 @@ export default function OrgSwitcher({ token, currentContext, onSelect, onClose }
       setEnterpriseOrgs(entOrgs);
       
       // Set initial cursor position based on current context
-      if (!isPersonalContext && typeof currentContext === 'object') {
+      if (currentContext !== 'personal' && currentContext !== null) {
         const orgLogin = currentContext.login;
         const index = orgs.findIndex(org => org.login === orgLogin);
         if (index !== -1) {
@@ -144,7 +144,7 @@ export default function OrgSwitcher({ token, currentContext, onSelect, onClose }
           {organizations.map((org, index) => {
             const isEnterprise = enterpriseOrgs.has(org.login);
             const isCurrent = cursor === index + 1;
-            const isActiveContext = !isPersonalContext && typeof currentContext === 'object' && currentContext.login === org.login;
+            const isActiveContext = currentContext !== 'personal' && currentContext !== null && currentContext.login === org.login;
             
             return (
               <Box key={org.id}>

--- a/src/ui/OrgSwitcher.tsx
+++ b/src/ui/OrgSwitcher.tsx
@@ -45,15 +45,15 @@ export default function OrgSwitcher({ token, currentContext, onSelect, onClose }
       setEnterpriseOrgs(entOrgs);
       
       // Set initial cursor position based on current context
-      if (!isPersonalContext) {
-        const orgLogin = (currentContext as any).login;
+      if (!isPersonalContext && typeof currentContext === 'object') {
+        const orgLogin = currentContext.login;
         const index = orgs.findIndex(org => org.login === orgLogin);
         if (index !== -1) {
           setCursor(index + 1); // +1 because personal account is at index 0
         }
       }
-    } catch (e: any) {
-      setError(e.message || 'Failed to load organisations');
+    } catch (e: unknown) {
+      setError((e instanceof Error ? e.message : null) || 'Failed to load organisations');
     } finally {
       setLoading(false);
       setRefreshing(false);
@@ -144,7 +144,7 @@ export default function OrgSwitcher({ token, currentContext, onSelect, onClose }
           {organizations.map((org, index) => {
             const isEnterprise = enterpriseOrgs.has(org.login);
             const isCurrent = cursor === index + 1;
-            const isActiveContext = !isPersonalContext && (currentContext as any).login === org.login;
+            const isActiveContext = !isPersonalContext && typeof currentContext === 'object' && currentContext.login === org.login;
             
             return (
               <Box key={org.id}>

--- a/src/ui/components/modals/ArchiveModal.tsx
+++ b/src/ui/components/modals/ArchiveModal.tsx
@@ -56,8 +56,8 @@ export default function ArchiveModal({ repo, onArchive, onCancel }: ArchiveModal
       setArchiving(true);
       setArchiveError(null);
       await onArchive(repo);
-    } catch (e: any) {
-      setArchiveError(e.message || `Failed to ${repo.isArchived ? 'unarchive' : 'archive'} repository`);
+    } catch (e: unknown) {
+      setArchiveError((e instanceof Error ? e.message : null) || `Failed to ${repo.isArchived ? 'unarchive' : 'archive'} repository`);
       archivingRef.current = false;
       setArchiving(false);
     }

--- a/src/ui/components/modals/DeleteModal.tsx
+++ b/src/ui/components/modals/DeleteModal.tsx
@@ -77,8 +77,8 @@ export default function DeleteModal({ repo, onDelete, onCancel }: DeleteModalPro
       setDeleting(true);
       setDeleteError(null);
       await onDelete(repo);
-    } catch (e: any) {
-      setDeleteError(e.message || 'Failed to delete repository');
+    } catch (e: unknown) {
+      setDeleteError((e instanceof Error ? e.message : null) || 'Failed to delete repository');
       deletingRef.current = false;
       setDeleting(false);
     }

--- a/src/ui/components/modals/LogoutModal.tsx
+++ b/src/ui/components/modals/LogoutModal.tsx
@@ -41,8 +41,8 @@ export default function LogoutModal({ onLogout, onCancel }: LogoutModalProps) {
   const handleLogout = () => {
     try {
       onLogout();
-    } catch (e: any) {
-      setLogoutError(e.message || 'Failed to logout');
+    } catch (e: unknown) {
+      setLogoutError((e instanceof Error ? e.message : null) || 'Failed to logout');
     }
   };
 

--- a/src/ui/components/modals/RenameModal.tsx
+++ b/src/ui/components/modals/RenameModal.tsx
@@ -56,8 +56,8 @@ export default function RenameModal({ repo, onRename, onCancel, theme: themeProp
       setRenaming(true);
       setRenameError(null);
       await onRename(repo, newName.trim());
-    } catch (e: any) {
-      setRenameError(e.message || 'Failed to rename repository');
+    } catch (e: unknown) {
+      setRenameError((e instanceof Error ? e.message : null) || 'Failed to rename repository');
       renamingRef.current = false;
       setRenaming(false);
     }

--- a/src/ui/components/modals/SyncModal.tsx
+++ b/src/ui/components/modals/SyncModal.tsx
@@ -55,8 +55,8 @@ export default function SyncModal({ repo, onSync, onCancel }: SyncModalProps) {
       setSyncing(true);
       setSyncError(null);
       await onSync(repo);
-    } catch (e: any) {
-      setSyncError(e.message || 'Failed to sync fork with upstream');
+    } catch (e: unknown) {
+      setSyncError((e instanceof Error ? e.message : null) || 'Failed to sync fork with upstream');
       syncingRef.current = false;
       setSyncing(false);
     }

--- a/src/ui/hooks/useTheme.ts
+++ b/src/ui/hooks/useTheme.ts
@@ -32,12 +32,12 @@ export interface UseThemeResult {
 }
 
 function chalkFor(color: string): ChalkInstance {
-  return (chalk as any)[color] ?? chalk.white;
+  return (chalk as unknown as Record<string, ChalkInstance | undefined>)[color] ?? chalk.white;
 }
 
 function bgChalkFor(color: string): ChalkInstance {
   const bgKey = 'bg' + color.charAt(0).toUpperCase() + color.slice(1);
-  return (chalk as any)[bgKey] ?? chalk.bgWhite;
+  return (chalk as unknown as Record<string, ChalkInstance | undefined>)[bgKey] ?? chalk.bgWhite;
 }
 
 export function useTheme(name: ThemeName): UseThemeResult {

--- a/src/ui/views/RepoList.main.tsx
+++ b/src/ui/views/RepoList.main.tsx
@@ -252,7 +252,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       const [owner, repo] = (deleteTarget.nameWithOwner || '').split('/');
       await deleteRepositoryRest(token, owner, repo);
       // Remove from items and update counts
-      setItems((prev) => prev.filter((r: any) => r.id !== (deleteTarget as any).id));
+      setItems((prev) => prev.filter(r => r.id !== deleteTarget.id));
       setTotalCount((c) => Math.max(0, c - 1));
       setDeleteMode(false);
       setDeleteTarget(null);
@@ -262,7 +262,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       setDeleteConfirmStage(false);
       // Keep cursor in range
       setCursor((c) => Math.max(0, Math.min(c, visibleItems.length - 2)));
-    } catch (e: any) {
+    } catch (e: unknown) {
       setDeleting(false);
       setDeleteError('Failed to delete repository. Ensure delete_repo scope and admin permissions.');
     }
@@ -351,7 +351,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       }
       setRateLimit(page.rateLimit);
       setError(null);
-    } catch (e: any) {
+    } catch (e: unknown) {
       setError('Failed to load repositories. Check network or token.');
     } finally {
       setLoading(false);
@@ -412,12 +412,10 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         } catch {}
       }
       setError(null);
-    } catch (e: any) {
-      const errorMsg = `Failed to search: ${e.message || e}`;
-      addDebugMessage(`❌ Search error: ${e.message || e}`);
-      if (e.stack) {
-        addDebugMessage(`Stack: ${e.stack.split('\n')[0]}`);
-      }
+    } catch (e: unknown) {
+      const errMsg = e instanceof Error ? e.message : String(e);
+      const errorMsg = `Failed to search: ${errMsg}`;
+      addDebugMessage(`❌ Search error: ${errMsg}`);
       setError(errorMsg);
     } finally {
       setSearchLoading(false);
@@ -557,8 +555,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       if (input && input.toUpperCase() === 'Q') {
         try {
           const seq = '\x1b[2J\x1b[3J\x1b[H';
-          if (stdout && typeof (stdout as any).write === 'function') (stdout as any).write(seq);
-          else if (typeof process.stdout.write === 'function') process.stdout.write(seq);
+          if (stdout) stdout.write(seq);
+          else process.stdout.write(seq);
         } catch {}
         exit();
         return;
@@ -643,10 +641,10 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
           try {
             setArchiving(true);
             const isArchived = archiveTarget.isArchived;
-            const id = (archiveTarget as any).id;
+            const id = archiveTarget.id;
             if (isArchived) await unarchiveRepositoryById(client, id);
             else await archiveRepositoryById(client, id);
-              setItems(prev => prev.map(r => (r.id === (archiveTarget as any).id ? { ...r, isArchived: !isArchived } : r)));
+              setItems(prev => prev.map(r => (r.id === archiveTarget.id ? { ...r, isArchived: !isArchived } : r)));
             closeArchiveModal();
           } catch (e) {
             setArchiving(false);
@@ -688,7 +686,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
             
             // Update the repository state to show 0 behind
             setItems(prev => prev.map(r => {
-              if (r.id === (syncTarget as any).id && r.parent && r.defaultBranchRef?.target?.history && r.parent.defaultBranchRef?.target?.history) {
+              if (r.id === syncTarget.id && r.parent && r.defaultBranchRef?.target?.history && r.parent.defaultBranchRef?.target?.history) {
                 return {
                   ...r,
                   defaultBranchRef: {
@@ -705,9 +703,9 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
               return r;
             }));
             closeSyncModal();
-          } catch (e: any) {
+          } catch (e: unknown) {
             setSyncing(false);
-            setSyncError(e.message || 'Failed to sync fork. Check permissions and network.');
+            setSyncError((e instanceof Error ? e.message : null) || 'Failed to sync fork. Check permissions and network.');
           }
         })();
         return;
@@ -728,7 +726,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       if (key.rightArrow) { setLogoutFocus('cancel'); return; }
       if (key.return || (input && input.toUpperCase() === 'Y')) {
         if (logoutFocus === 'cancel') { setLogoutMode(false); return; }
-        try { onLogout && onLogout(); } catch (e: any) { setLogoutError(e?.message || 'Failed to logout.'); }
+        try { onLogout && onLogout(); } catch (e: unknown) { setLogoutError((e instanceof Error ? e.message : null) || 'Failed to logout.'); }
         return;
       }
       return;
@@ -784,8 +782,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     if (input && input.toUpperCase() === 'Q') {
       try {
         const seq = '\x1b[2J\x1b[3J\x1b[H';
-        if (stdout && typeof (stdout as any).write === 'function') (stdout as any).write(seq);
-        else if (typeof process.stdout.write === 'function') process.stdout.write(seq);
+        if (stdout) stdout.write(seq);
+        else process.stdout.write(seq);
       } catch {}
       exit();
       return;
@@ -888,8 +886,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       (async () => {
         try {
           await inspectCacheStatus();
-        } catch (e: any) {
-          process.stderr.write(`❌ Failed to inspect cache: ${e.message}\n`);
+        } catch (e: unknown) {
+          process.stderr.write(`❌ Failed to inspect cache: ${e instanceof Error ? e.message : String(e)}\n`);
         }
       })();
       return;
@@ -1360,10 +1358,10 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                         try {
                           setArchiving(true);
                           const isArchived = archiveTarget.isArchived;
-                          const id = (archiveTarget as any).id;
+                          const id = archiveTarget.id;
                           if (isArchived) await unarchiveRepositoryById(client, id);
                           else await archiveRepositoryById(client, id);
-                          setItems(prev => prev.map(r => (r.id === (archiveTarget as any).id ? { ...r, isArchived: !isArchived } : r)));
+                          setItems(prev => prev.map(r => (r.id === archiveTarget.id ? { ...r, isArchived: !isArchived } : r)));
                           closeArchiveModal();
                         } catch (e) {
                           setArchiving(false);
@@ -1454,7 +1452,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                           
                           // Update the repository state to show 0 behind
                           setItems(prev => prev.map(r => {
-                            if (r.id === (syncTarget as any).id && r.parent && r.defaultBranchRef?.target?.history && r.parent.defaultBranchRef?.target?.history) {
+                            if (r.id === syncTarget.id && r.parent && r.defaultBranchRef?.target?.history && r.parent.defaultBranchRef?.target?.history) {
                               return {
                                 ...r,
                                 defaultBranchRef: {
@@ -1471,9 +1469,9 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
                             return r;
                           }));
                           closeSyncModal();
-                        } catch (e: any) {
+                        } catch (e: unknown) {
                           setSyncing(false);
-                          setSyncError(e.message || 'Failed to sync fork. Check permissions and network.');
+                          setSyncError((e instanceof Error ? e.message : null) || 'Failed to sync fork. Check permissions and network.');
                         }
                       })();
                     } else {

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -299,8 +299,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         } else {
           addDebugMessage(`[--org] No access to org @${slug}, ignoring flag`);
         }
-      } catch (e: any) {
-        addDebugMessage(`[--org] Failed to apply org flag: ${e.message || e}`);
+      } catch (e: unknown) {
+        addDebugMessage(`[--org] Failed to apply org flag: ${e instanceof Error ? e.message : String(e)}`);
       }
     })();
   }, [initialOrgSlug, token, prefsLoaded, client, addDebugMessage]);
@@ -375,9 +375,9 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       }
       
       setStarredLoading(false);
-    } catch (e: any) {
+    } catch (e: unknown) {
       setStarredLoading(false);
-      setError(e.message || 'Failed to fetch starred repositories');
+      setError((e instanceof Error ? e.message : null) || 'Failed to fetch starred repositories');
     }
   }
   
@@ -387,12 +387,12 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     
     try {
       setUnstarring(true);
-      const targetId = (unstarTarget as any).id;
+      const targetId = unstarTarget.id;
       
       await unstarRepository(client, targetId);
 
       // Remove from starred items list
-      setStarredItems(prev => prev.filter((r: any) => r.id !== targetId));
+      setStarredItems(prev => prev.filter(r => r.id !== targetId));
       setStarredTotalCount(c => Math.max(0, c - 1));
 
       // Adjust cursor if needed
@@ -406,11 +406,11 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       setUnstarTarget(null);
       setUnstarError(null);
       setUnstarring(false);
-    } catch (e: any) {
+    } catch (e: unknown) {
       setUnstarring(false);
       
       // Check for OAuth access restriction error
-      const errorMsg = e.message || 'Failed to unstar repository';
+      const errorMsg = (e instanceof Error ? e.message : null) || 'Failed to unstar repository';
       if (errorMsg.includes('OAuth App access restrictions')) {
         // Extract org name from the error or use the repo owner
         const orgMatch = errorMsg.match(/`([^`]+)` organization/);
@@ -442,7 +442,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     
     try {
       setStarring(true);
-      const targetId = (starTarget as any).id;
+      const targetId = starTarget.id;
       
       if (isStarred) {
         await unstarRepository(client, targetId);
@@ -451,7 +451,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       }
       
       // Update the repo in the list
-      const updateRepo = (r: any) => {
+      const updateRepo = (r: RepoNode) => {
         if (r.id === targetId) {
           return { ...r, viewerHasStarred: !isStarred, stargazerCount: r.stargazerCount + (isStarred ? -1 : 1) };
         }
@@ -468,11 +468,11 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       setStarTarget(null);
       setStarError(null);
       setStarring(false);
-    } catch (e: any) {
+    } catch (e: unknown) {
       setStarring(false);
       
       // Check for OAuth access restriction error
-      const errorMsg = e.message || `Failed to ${isStarred ? 'unstar' : 'star'} repository`;
+      const errorMsg = (e instanceof Error ? e.message : null) || `Failed to ${isStarred ? 'unstar' : 'star'} repository`;
       if (errorMsg.includes('OAuth access restrictions')) {
         const orgMatch = errorMsg.match(/`([^`]+)` organization/);
         const orgName = orgMatch ? orgMatch[1] : starTarget?.nameWithOwner.split('/')[0];
@@ -528,8 +528,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       await updateCacheWithRepository(token, updatedRepo);
       
       // Update items with the locally updated data
-      const updateSyncedRepo = (r: any) => {
-        if (r.id === (syncTarget as any).id) {
+      const updateSyncedRepo = (r: RepoNode) => {
+        if (r.id === syncTarget.id) {
           return updatedRepo;
         }
         return r;
@@ -538,9 +538,9 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       trackOperation('syncFork');
       trackSuccessfulOperation();
       closeSyncModal();
-    } catch (e: any) {
+    } catch (e: unknown) {
       setSyncing(false);
-      setSyncError(e.message || 'Failed to sync fork. Check permissions and network.');
+      setSyncError((e instanceof Error ? e.message : null) || 'Failed to sync fork. Check permissions and network.');
       // Keep modal open on error so user can see the error message
     }
   }
@@ -552,7 +552,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     try {
       setArchiving(true);
       const isArchived = archiveTarget.isArchived;
-      const id = (archiveTarget as any).id;
+      const id = archiveTarget.id;
       
       if (isArchived) {
         await unarchiveRepositoryById(client, id);
@@ -563,7 +563,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       // Update Apollo cache
       await updateCacheAfterArchive(token, id, !isArchived);
       
-      const updateRepo = (r: any) => (r.id === id ? { ...r, isArchived: !isArchived } : r);
+      const updateRepo = (r: RepoNode) => (r.id === id ? { ...r, isArchived: !isArchived } : r);
       setItems(prev => prev.map(updateRepo));
 
       trackOperation(isArchived ? 'unarchive' : 'archive');
@@ -668,8 +668,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         }
         trackOperation(bulkActionToOperation(action));
         trackSuccessfulOperation();
-      } catch (e: any) {
-        failed.push({ repo, error: e.message || 'Unknown error' });
+      } catch (e: unknown) {
+        failed.push({ repo, error: (e instanceof Error ? e.message : null) || 'Unknown error' });
       }
 
       setBulkProgress(prev => ({ ...prev, completed: i + 1, failed: [...failed] }));
@@ -755,7 +755,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     if (!repo || !newName.trim()) return;
     
     try {
-      const id = (repo as any).id;
+      const id = repo.id;
       const owner = repo.nameWithOwner.split('/')[0];
       const newNameWithOwner = `${owner}/${newName}`;
       
@@ -764,13 +764,13 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       // Update Apollo cache
       await updateCacheAfterRename(token, id, newName, newNameWithOwner);
       
-      const updateRepo = (r: any) => (r.id === id ? { ...r, name: newName, nameWithOwner: newNameWithOwner } : r);
+      const updateRepo = (r: RepoNode) => (r.id === id ? { ...r, name: newName, nameWithOwner: newNameWithOwner } : r);
       setItems(prev => prev.map(updateRepo));
 
       trackOperation('rename');
       trackSuccessfulOperation();
       closeRenameModal();
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw error; // Let the modal handle the error
     }
   }
@@ -833,9 +833,9 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         await new Promise(resolve => setTimeout(resolve, 600));
         created = await fetchRepositoryByOwnerAndName(client, owner, repoName);
       }
-    } catch (err: any) {
+    } catch (err: unknown) {
       logger.warn('Created repository lookup failed; falling back to refresh', {
-        error: err?.message,
+        error: err instanceof Error ? err.message : String(err),
         nameWithOwner
       });
     }
@@ -848,8 +848,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
 
     if (created) {
       await updateCacheWithRepository(token, created);
-      const createdId = (created as any).id;
-      setItems(prev => (prev.some((r: any) => r.id === createdId) ? prev : [created, ...prev]));
+      const createdId = created.id;
+      setItems(prev => (prev.some(r => r.id === createdId) ? prev : [created, ...prev]));
       setTotalCount(c => c + 1);
     } else {
       // Couldn't resolve the new node — refresh from the network so it still appears.
@@ -873,7 +873,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     if (!repo || !newOwner.trim()) return;
 
     const [owner, name] = (repo.nameWithOwner || '').split('/');
-    const targetId = (repo as any).id;
+    const targetId = repo.id;
 
     // Throws on failure so the modal can surface the GitHub error message
     await transferRepositoryRest(token, owner, name, newOwner.trim());
@@ -884,7 +884,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     // the brief processing window could still return the repo under the current owner
     // and make it flicker back. It stays removed until the user manually refreshes.
     await updateCacheAfterDelete(token, targetId);
-    setItems(prev => prev.filter((r: any) => r.id !== targetId));
+    setItems(prev => prev.filter(r => r.id !== targetId));
     setTotalCount(c => Math.max(0, c - 1));
     setCursor(c => Math.max(0, Math.min(c, visibleItems.length - 2)));
 
@@ -947,7 +947,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     
     try {
       setChangingVisibility(true);
-      const id = (changeVisibilityTarget as any).id;
+      const id = changeVisibilityTarget.id;
       
       await changeRepositoryVisibility(client, id, newVisibility as 'PUBLIC' | 'PRIVATE' | 'INTERNAL', token);
       
@@ -960,15 +960,15 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       // reappears when the filter changes — never prune it here (cursor is clamped
       // by the visibleItems effect).
       const isPrivate = newVisibility === 'PRIVATE';
-      const updateRepo = (r: any) => (r.id === id ? { ...r, visibility: newVisibility, isPrivate } : r);
+      const updateRepo = (r: RepoNode) => (r.id === id ? { ...r, visibility: newVisibility as 'PUBLIC' | 'PRIVATE' | 'INTERNAL', isPrivate } : r);
       setItems(prev => prev.map(updateRepo));
 
       trackOperation('visibilityChange');
       trackSuccessfulOperation();
       closeChangeVisibilityModal();
-    } catch (e: any) {
+    } catch (e: unknown) {
       setChangingVisibility(false);
-      setChangeVisibilityError(e.message || 'Failed to change visibility. Check permissions.');
+      setChangeVisibilityError((e instanceof Error ? e.message : null) || 'Failed to change visibility. Check permissions.');
       // Keep modal open on error
     }
   }
@@ -1060,11 +1060,11 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       await deleteRepositoryRest(token, owner, repo);
       
       // Update Apollo cache
-      const targetId = (deleteTarget as any).id;
+      const targetId = deleteTarget.id;
       await updateCacheAfterDelete(token, targetId);
       
       // Remove from items list
-      setItems((prev) => prev.filter((r: any) => r.id !== targetId));
+      setItems((prev) => prev.filter(r => r.id !== targetId));
 
       // Update counts
       setTotalCount((c) => Math.max(0, c - 1));
@@ -1079,7 +1079,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       setDeleteConfirmStage(false);
       // Keep cursor in range
       setCursor((c) => Math.max(0, Math.min(c, visibleItems.length - 2)));
-    } catch (e: any) {
+    } catch (e: unknown) {
       setDeleting(false);
       setDeleteError('Failed to delete repository. Ensure delete_repo scope and admin permissions.');
       // Keep modal open on error so user can see the error message
@@ -1176,8 +1176,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
             await new Promise(resolve => setTimeout(resolve, BATCH_DELAY_MS));
           }
         }
-      } catch (err: any) {
-        logger.error('Fork enrichment failed', { error: err.message });
+      } catch (err: unknown) {
+        logger.error('Fork enrichment failed', { error: err instanceof Error ? err.message : String(err) });
       } finally {
         // Only clear when this pass wasn't torn down; a cancelled pass has the
         // flag reset by the cleanup below so it can never stick `true`.
@@ -1199,8 +1199,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         setInfoRepo(repo);
         setInfoMode(true);
       }
-    } catch (err: any) {
-      logger.error('Failed to fetch upstream repository', { error: err?.message, parentNameWithOwner });
+    } catch (err: unknown) {
+      logger.error('Failed to fetch upstream repository', { error: err instanceof Error ? err.message : String(err), parentNameWithOwner });
     }
   }
 
@@ -1331,14 +1331,11 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         }
       });
       setError(null);
-    } catch (e: any) {
+    } catch (e: unknown) {
+      const apiErr = e instanceof Error ? e : null;
       logger.error('Failed to fetch repositories in RepoList', {
-        error: e.message,
-        stack: e.stack,
-        graphQLErrors: e.graphQLErrors,
-        networkError: e.networkError,
-        statusCode: e.statusCode,
-        response: e.response
+        error: apiErr?.message,
+        stack: apiErr?.stack,
       });
       setError('Failed to load repositories. Check network or token.');
     } finally {
@@ -1497,8 +1494,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       if (input && input.toUpperCase() === 'Q') {
         try {
           const seq = '\x1b[2J\x1b[3J\x1b[H';
-          if (stdout && typeof (stdout as any).write === 'function') (stdout as any).write(seq);
-          else if (typeof process.stdout.write === 'function') process.stdout.write(seq);
+          if (stdout) stdout.write(seq);
+          else process.stdout.write(seq);
         } catch {}
         exit();
         return;
@@ -1645,7 +1642,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       if (key.rightArrow) { setLogoutFocus('cancel'); return; }
       if (key.return || (input && input.toUpperCase() === 'Y')) {
         if (logoutFocus === 'cancel') { setLogoutMode(false); return; }
-        try { onLogout && onLogout(); } catch (e: any) { setLogoutError(e?.message || 'Failed to logout.'); }
+        try { onLogout && onLogout(); } catch (e: unknown) { setLogoutError((e instanceof Error ? e.message : null) || 'Failed to logout.'); }
         return;
       }
       return;
@@ -1805,8 +1802,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     if (input && input.toUpperCase() === 'Q') {
       try {
         const seq = '\x1b[2J\x1b[3J\x1b[H';
-        if (stdout && typeof (stdout as any).write === 'function') (stdout as any).write(seq);
-        else if (typeof process.stdout.write === 'function') process.stdout.write(seq);
+        if (stdout) stdout.write(seq);
+        else process.stdout.write(seq);
       } catch {}
       exit();
       return;
@@ -1926,8 +1923,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
       (async () => {
         try {
           await inspectCacheStatus();
-        } catch (e: any) {
-          process.stderr.write(`❌ Failed to inspect cache: ${e.message}\n`);
+        } catch (e: unknown) {
+          process.stderr.write(`❌ Failed to inspect cache: ${e instanceof Error ? e.message : String(e)}\n`);
         }
       })();
       return;

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -11,6 +11,7 @@ vi.mock('../src/lib/logger', () => ({
 }));
 
 import { makeClient, getViewerLogin, fetchViewerOrganizations, normalizeRepoNode } from '../src/services/github';
+import { logger } from '../src/lib/logger';
 
 // Mock @octokit/graphql
 vi.mock('@octokit/graphql', () => ({
@@ -209,6 +210,19 @@ describe('github', () => {
       expect(orgs).toHaveLength(1);
       expect(orgs[0].name).toBeNull();
       expect(orgs[0].login).toBe('org-without-name');
+    });
+
+    it('logs and re-throws on network/API failure', async () => {
+      const failure = new Error('GraphQL boom');
+      const mockClient = vi.fn(async () => {
+        throw failure;
+      });
+
+      await expect(fetchViewerOrganizations(mockClient)).rejects.toThrow('GraphQL boom');
+      expect(logger.error).toHaveBeenCalledWith(
+        'Failed to fetch viewer organisations',
+        expect.objectContaining({ error: 'GraphQL boom' })
+      );
     });
   });
 

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -114,6 +114,28 @@ describe('OAuth', () => {
   //   The actual implementation works but test mocks need proper setup
   // });
 
+  describe('startOAuthFlow error normalisation', () => {
+    it('uses the Error message when the failure is an Error', async () => {
+      (global.fetch as any).mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await startOAuthFlow();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('OAuth flow failed: Network error');
+    });
+
+    it('falls back to "Unknown error" for non-Error throws (no [object Object] leak)', async () => {
+      // A non-Error rejection must not leak String(value) like "[object Object]".
+      (global.fetch as any).mockRejectedValueOnce({ weird: true });
+
+      const result = await startOAuthFlow();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('OAuth flow failed: Unknown error');
+      expect(result.error).not.toContain('[object Object]');
+    });
+  });
+
   describe('openGitHubAuthorizationPage', () => {
     it('opens GitHub OAuth app settings page', async () => {
       const open = (await import('open')).default;

--- a/tests/ui/OrgSwitcher.test.tsx
+++ b/tests/ui/OrgSwitcher.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from 'ink-testing-library';
+import OrgSwitcher from '../../src/ui/OrgSwitcher';
+
+// Keep Box/Text real, stub useInput (raw mode is unavailable under the test stdin)
+vi.mock('ink', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('ink')>();
+  return { ...actual, useInput: vi.fn() };
+});
+
+// Mock logger
+vi.mock('../../src/lib/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() }
+}));
+
+const mockOrgs = [
+  { id: 'org-1', login: 'my-org', name: 'My Organisation', avatarUrl: '' },
+  { id: 'org-2', login: 'another-org', name: 'Another', avatarUrl: '' }
+];
+
+vi.mock('../../src/services/github', () => ({
+  makeClient: vi.fn(() => ({})),
+  fetchViewerOrganizations: vi.fn(async () => mockOrgs),
+  checkOrganizationIsEnterprise: vi.fn(async () => false)
+}));
+
+vi.mock('../../src/services/oauth', () => ({
+  openGitHubAuthorizationPage: vi.fn()
+}));
+
+const flush = async () => {
+  // Allow the mount effect's async loadOrgs() chain to settle.
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 0));
+};
+
+describe('OrgSwitcher', () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.clearAllMocks());
+
+  it('renders the organisation list for a personal context', async () => {
+    const { lastFrame } = render(
+      <OrgSwitcher token="t" currentContext="personal" onSelect={vi.fn()} onClose={vi.fn()} />
+    );
+    await flush();
+    expect(lastFrame()).toContain('my-org');
+  });
+
+  it('does not crash when the persisted context is null/malformed', async () => {
+    // `typeof null === "object"` would previously slip past the guard and throw
+    // on `currentContext.login` while computing isActiveContext during render.
+    const { lastFrame } = render(
+      <OrgSwitcher token="t" currentContext={null as any} onSelect={vi.fn()} onClose={vi.fn()} />
+    );
+    await flush();
+    const frame = lastFrame() || '';
+    expect(frame).toContain('my-org');
+    expect(frame).toContain('another-org');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves GMC-27. Replaces untyped `any` usage with proper TypeScript types across the GraphQL response handling paths and error handling, reducing the `any` count in `src/` from ~52 to 1 (the `persistCache as any` workaround for an incomplete third-party type definition).

## Changes

### New type interfaces
- **`ApolloClientBundle`** — typed singleton wrapper for `ApolloClient<NormalizedCacheObject>` + `gql`
- **GraphQL response interfaces** in `github.ts`:
  - `ViewerLoginResponse`, `ViewerOrganizationsResponse`, `CheckOrgEnterpriseResponse`
  - `RepositoryConnectionData`, `OrgReposResponse`, `ViewerReposResponse`, `StarredReposResponse`
  - `FetchRepositoryByIdResponse`, `FetchRepositoryByOwnerNameResponse`, `EnrichForksResponse`
- **`toError(e: unknown): Error`** — narrow utility used throughout catch blocks in `github.ts`

### `src/services/github.ts`
- All `const res: any = await client(...)` → typed Octokit generics (e.g. `client<ViewerLoginResponse>(query)`)
- All `catch (error: any)` → `catch (error: unknown)` + `toError()` narrowing
- `(ap.gql as any)` → `ap.gql` (typed as `typeof gql`)
- `variables: any` → `Record<string, unknown>`
- `body: Record<string, any>` → `Record<string, unknown>`
- Removed `} as any` on `fetch()` calls (RequestInit is fully typed)
- `normalizeRepoNode<T extends object>` — removes `Record<string,any>` bound

### `src/lib/logger.ts`
- `context?: any` on all log methods → `context?: unknown`

### `src/services/oauth.ts`
- All `catch (error: any)` → `catch (error: unknown)` with inline narrowing

### `src/ui/App.tsx`
- `catch (error: any)` → `catch (error: unknown)` with proper object narrowing for Octokit error fields
- `onResize as any` → `onResize` (NodeJS.WriteStream handles the type correctly)

### `src/ui/OrgSwitcher.tsx`
- `(currentContext as any).login` → proper type narrowing via `typeof currentContext === 'object'`
- `catch (e: any)` → `catch (e: unknown)` with narrowing

### `src/config/config.ts`
- `existing as any` in `clearStoredToken()` → proper destructuring with `_token` etc.

### `src/ui/hooks/useTheme.ts`
- `(chalk as any)[color]` → `(chalk as unknown as Record<string, ChalkInstance | undefined>)[color]`

### `src/ui/views/RepoList.tsx` and `RepoList.main.tsx`
- All `(target as any).id` casts (deleteTarget, archiveTarget, syncTarget, etc.) → `target.id` (all are typed `RepoNode`)
- All `(r: any) =>` in filter/map callbacks → properly typed `r: RepoNode` (inferred from `items: RepoNode[]`)
- `(stdout as any).write` → `stdout.write` (NodeJS.WriteStream)
- All `catch (e: any)` → `catch (e: unknown)` with narrowing

### Modal components
- `ArchiveModal`, `DeleteModal`, `LogoutModal`, `RenameModal`, `SyncModal`: all `catch (e: any)` → `catch (e: unknown)` with `(e instanceof Error ? e.message : null) || fallback` pattern to preserve the original "fallback on empty message" behaviour

### `src/index.tsx`
- `(pkg as any).version` → `(pkg as { version?: string }).version`
- `reason: any` on `unhandledRejection` → `reason: unknown` with narrowing

## Acceptance criteria
- [x] No `any` in GraphQL response handling paths (1 permitted: `persistCache as any` — third-party type gap)
- [x] `tsc --noEmit` passes with zero new suppressions
- [x] No behavioural change; all tests pass (2 pre-existing `BulkReviewModal` failures unrelated to this PR)

## AGENTS.md
Updated Code Standards section to document the `any`-avoidance conventions.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [GMC-27](https://linear.app/stealths/issue/GMC-27/typescript-hardening-replace-any-with-typed-graphql-responses)

<div><a href="https://cursor.com/agents/bc-682d9e7c-a088-470c-b4d9-e0253f079931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-682d9e7c-a088-470c-b4d9-e0253f079931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced error handling and type safety across configuration management, backend services, and user interface components.
  * Strengthened internal type definitions and comprehensive error reporting to improve overall application stability.
  * Updated logging infrastructure with more consistent and robust error message handling.
  * Improved OAuth and GitHub API integration error resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->