### PR TITLE
fix: lower default page size to 30 to avoid GitHub gateway timeouts (GMC-40) [semantic pr title]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ See the living roadmap in [TODOs.md](./TODOs.md) for the canonical, up-to-date l
 ## GitHub API Details
 
 - GraphQL query against `viewer.repositories` with `ownerAffiliations: OWNER` and `orderBy: UPDATED_AT DESC`.
-- Page size: 100 per request (default; configurable 1-100 via `REPOS_PER_FETCH`).
+- Page size: **30 per request** (default; configurable 1-100 via `REPOS_PER_FETCH`). Lowered from 100 in GMC-40 — a 100-repo first page with the inline open PR/issue counts (SWR-357) ran ~8-10s and intermittently tripped GitHub's gateway timeout (HTTP 502/504); 30 keeps the first page ~3s (with headroom for slower networks) and the rest still streams in via background fetch-all.
 - **Single pagination model — background fetch-all:** the first page renders immediately, then a background loop fetches every remaining page until `hasNextPage` is false, appending into the persisted cache. There is no scroll-position prefetch trigger for the owned/starred lists; the load is continuous and driven by the effect re-running as the list grows.
 - Because the full set is cached, **sorting is client-side** (`filteredAndSorted`) with no server refetch on sort change; archive/visibility (private) filtering is also client-side.
 - On each page fetch, also read `totalCount` to reflect newly created repos and to show background-load progress (`loaded/total`).

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -21,7 +21,7 @@ import { SlowSpinner } from '../components/common';
 import { truncate, formatDate, copyToClipboard, computeWindow, matchesVisibilityFilter, matchesForkFilter, type VisibilityFilter } from '../../lib/utils';
 import { trackOperation, bulkActionToOperation } from '../../lib/session';
 
-// Allow customizable repos per fetch via env var (1-50, default 15)
+// Allow customizable repos per fetch via env var (1-100, default 30).
 const getPageSize = () => {
   const envValue = process.env.REPOS_PER_FETCH;
   if (envValue) {
@@ -30,7 +30,12 @@ const getPageSize = () => {
       return parsed;
     }
   }
-  return 100; // Default — large pages for background fetch-all (GitHub max is 100)
+  // Default 30 (GMC-40). A 100-repo first page with the inline open PR/issue
+  // counts (SWR-357) runs ~8–10s and intermittently trips GitHub's gateway
+  // timeout (HTTP 502/504). 30 keeps the first page ~3s — with headroom for
+  // slower networks — and the rest still streams in via the background
+  // fetch-all loop. Raise via REPOS_PER_FETCH if desired.
+  return 30;
 };
 
 const PAGE_SIZE = getPageSize();


### PR DESCRIPTION
## Problem

The repo list intermittently fails to load — it stalls on the loading screen, then shows "Failed to load repositories. Check network or token." Reproducible on a 164-repo account.

## Root cause (measured)

GitHub's GraphQL API is operational, but the first-page query is too slow and intermittently trips GitHub's **gateway timeout (HTTP 502/504, nginx Bad Gateway)**. The driver is the always-on per-repo `openPullRequests`/`openIssues` `totalCount` counts (SWR-357) across a large page.

Measured against `viewer.repositories` for a 164-repo account:

| Query | Result |
|---|---|
| `viewer { login }` | 200 · 0.3s |
| repos `first:5` (no counts) | 200 · 0.4s |
| repos `first:30` + counts | 200 · ~3s (4/4) |
| repos `first:50` + counts | 200 · ~4.5s (5/5) |
| repos **`first:100`** + counts | **1/4 = 502** · 8–10s |

This is pre-existing in the published CLI — unrelated to the GMC-28 refactor.

## Fix

Lower the default `REPOS_PER_FETCH` from **100 → 30**. The first page renders in ~3s (with headroom for slower networks) and the rest still streams in via the background fetch-all loop. The env var override (1–100) is unchanged, and the open PR/issue counts feature is kept intact (smaller page rather than disabling it).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 376/376
- [x] `pnpm build` clean
- [x] Manual: `node dist/index.js` loads the list reliably on the 164-repo account

## Follow-ups
- Consider 502/503/504 retry-with-backoff for the repos query (separate hardening).
- GMC-41: loading "..." dots should trail the label, not lead it.

Closes GMC-40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single default constant and docs change; pagination behavior and env override are unchanged aside from smaller first-page queries.
> 
> **Overview**
> Fixes intermittent **"Failed to load repositories"** on large accounts by lowering the default GraphQL page size from **100 to 30** repos per request (**GMC-40**).
> 
> Large first pages with inline open PR/issue counts were taking ~8–10s and sometimes hit GitHub gateway **502/504** timeouts. A 30-repo first page is expected around ~3s; remaining pages still load via the existing background fetch-all loop. **`REPOS_PER_FETCH`** (1–100) is unchanged for overrides. **AGENTS.md** documents the new default and rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fcf37e9a12a440df0f0ac24d04e8cd3d9996942. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->