### PR TITLE
fix: expose the 'forks' option in the Sort modal (GMC-42) [semantic pr title]

### DIFF
--- a/src/ui/components/modals/SortModal.tsx
+++ b/src/ui/components/modals/SortModal.tsx
@@ -20,7 +20,7 @@ export default function SortModal({
   theme: themeProp,
 }: SortModalProps) {
   const { theme, c } = useTheme(themeProp?.name ?? 'default');
-  const options: SortKey[] = ['updated', 'pushed', 'name', 'stars'];
+  const options: SortKey[] = ['updated', 'pushed', 'name', 'stars', 'forks'];
 
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [focusedOption, setFocusedOption] = useState<SortKey | 'cancel'>('updated');
@@ -94,6 +94,7 @@ export default function SortModal({
       else if (upperInput === 'P') onSelect('pushed');
       else if (upperInput === 'N') onSelect('name');
       else if (upperInput === 'S') onSelect('stars');
+      else if (upperInput === 'F') onSelect('forks');
     }
   });
 
@@ -141,7 +142,7 @@ export default function SortModal({
 
       <Box marginTop={1}>
         <Text color={theme.muted} dimColor>
-          ↑↓/Enter • U/P/N/S • Esc
+          ↑↓/Enter • U/P/N/S/F • Esc
         </Text>
       </Box>
     </Box>

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -1355,7 +1355,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   useEffect(() => {
     const ui = getUIPrefs();
     if (ui.density !== undefined) setDensity(ui.density as 0 | 1 | 2);
-    if (ui.sortKey && ['updated','pushed','name','stars'].includes(ui.sortKey)) {
+    if (ui.sortKey && ['updated','pushed','name','stars','forks'].includes(ui.sortKey)) {
       setSortKey(ui.sortKey as SortKey);
     }
     if (ui.sortDir && (ui.sortDir === 'asc' || ui.sortDir === 'desc')) {

--- a/tests/ui/SortModal.test.tsx
+++ b/tests/ui/SortModal.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from 'ink-testing-library';
+import SortModal from '../../src/ui/components/modals/SortModal';
+
+// Mock useInput so we can drive the keyboard handler directly (avoids stdin.ref).
+vi.mock('ink', async () => {
+  const actual = await vi.importActual('ink');
+  return { ...actual, useInput: vi.fn() };
+});
+
+describe('SortModal', () => {
+  let mockUseInput: any;
+
+  beforeEach(async () => {
+    const ink = await import('ink');
+    mockUseInput = (ink as any).useInput;
+    mockUseInput.mockReset();
+  });
+
+  it('renders all five sort options, including Forks, and the F hint', () => {
+    mockUseInput.mockImplementation(() => {});
+    const { lastFrame, unmount } = render(
+      <SortModal currentSort="updated" onSelect={() => {}} onCancel={() => {}} />,
+    );
+    const out = lastFrame() || '';
+    expect(out).toContain('Last Updated');
+    expect(out).toContain('Last Pushed');
+    expect(out).toContain('Name');
+    expect(out).toContain('Stars');
+    expect(out).toContain('Forks');
+    expect(out).toContain('U/P/N/S/F'); // footer hint advertises the F shortcut
+    unmount();
+  });
+
+  it('selects forks when F is pressed', () => {
+    let handler: any;
+    mockUseInput.mockImplementation((cb: any) => { handler = cb; });
+    const onSelect = vi.fn();
+    const { unmount } = render(
+      <SortModal currentSort="updated" onSelect={onSelect} onCancel={() => {}} />,
+    );
+    handler('f', {});
+    expect(onSelect).toHaveBeenCalledWith('forks');
+    unmount();
+  });
+
+  it('marks forks as the current sort when selected', () => {
+    mockUseInput.mockImplementation(() => {});
+    const { lastFrame, unmount } = render(
+      <SortModal currentSort="forks" onSelect={() => {}} onCancel={() => {}} />,
+    );
+    const out = lastFrame() || '';
+    expect(out).toContain('Forks');
+    expect(out).toContain('✓'); // current-sort checkmark
+    unmount();
+  });
+
+  it('still maps the existing shortcuts (S → stars) — no regression', () => {
+    let handler: any;
+    mockUseInput.mockImplementation((cb: any) => { handler = cb; });
+    const onSelect = vi.fn();
+    const { unmount } = render(
+      <SortModal currentSort="updated" onSelect={onSelect} onCancel={() => {}} />,
+    );
+    handler('s', {});
+    expect(onSelect).toHaveBeenCalledWith('stars');
+    unmount();
+  });
+});


### PR DESCRIPTION
## Problem

`SortKey` includes `'forks'` and both `getButtonLabel` and `RepoList`'s `filteredAndSorted` already handle it (sorts by `forkCount`) — but the Sort modal's `options` array omitted `'forks'`, so **sort-by-forks was unreachable from the UI**, and a persisted `'forks'` sort wouldn't restore. Pre-existing on `main`; surfaced by a CodeRabbit review. Closes #107 / GMC-42.

## Fix

- **`SortModal`**: add `'forks'` to the `options` array (now renders + ↑↓-reachable), add the **`F`** keyboard shortcut, and advertise it in the footer hint (`U/P/N/S/F`).
- **`RepoList`**: add `'forks'` to the persisted-sortKey load whitelist so the choice survives restarts.

The `indexOf(currentSort)` focus guard already handled `-1`, so there was no crash — this makes the documented sort mode selectable.

## Test plan

- [x] `tests/ui/SortModal.test.tsx` — all five options render (incl. Forks), `F` selects forks, current-sort marking for forks, S→stars regression check
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 380/380
- [x] `pnpm build` clean
- [x] Local CodeRabbit review — no findings

Closes GMC-42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI and preference-whitelist changes only; sorting by forks was already implemented client-side.
> 
> **Overview**
> **Exposes sort-by-forks in the repo list UI**, which was already supported in types, client-side sorting (`forkCount`), and labels but could not be chosen from the Sort modal.
> 
> `SortModal` now includes **Forks** in the navigable options, maps **`F`** to select it, and updates the footer hint to **`U/P/N/S/F`**. **`RepoList`** whitelists **`forks`** when restoring a saved sort key so that preference survives restarts.
> 
> Adds **`tests/ui/SortModal.test.tsx`** covering all five options, the **F** shortcut, current-sort marking for forks, and **S → stars** regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9b51bc31bb1cd220bd273e86b0f1629a283eb83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added "forks" as a repository sorting option with an F keyboard shortcut.
* Updated help text to display the new F shortcut alongside existing sort options.

## Bug Fixes
* Fixed sort preference persistence to properly save and restore "sort by forks" selection when reloading the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->