### PR TITLE
fix: discard stale background fetch pages on org/scope switch (GMC-43) [semantic pr title]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,8 @@ gh-manager-cli/
 │   │   │   ├── useRefreshTick.ts    # Whole-minute tick for relative dates (SWR-377)
 │   │   │   ├── useBulkSelect.ts     # Bulk Select mode + selection map + helpers
 │   │   │   ├── useRepoData.ts       # Core data layer: list/starred state, fetchPage,
-│   │   │   │                        #   rate limits, PAGE_SIZE, initial context fetch (GMC-39)
+│   │   │   │                        #   rate limits, PAGE_SIZE, initial context fetch (GMC-39),
+│   │   │   │                        #   fetch-generation guard against stale pages (GMC-43)
 │   │   │   └── useRepoListInput.ts  # The whole keyboard dispatcher (useInput) (GMC-39)
 │   │   └── components/
 │   │       ├── auth/          # Auth method selector, OAuth progress
@@ -151,6 +152,7 @@ See the living roadmap in [TODOs.md](./TODOs.md) for the canonical, up-to-date l
 - GraphQL query against `viewer.repositories` with `ownerAffiliations: OWNER` and `orderBy: UPDATED_AT DESC`.
 - Page size: **30 per request** (default; configurable 1-100 via `REPOS_PER_FETCH`). Lowered from 100 in GMC-40 — a 100-repo first page with the inline open PR/issue counts (SWR-357) ran ~8-10s and intermittently tripped GitHub's gateway timeout (HTTP 502/504); 30 keeps the first page ~3s (with headroom for slower networks) and the rest still streams in via background fetch-all.
 - **Single pagination model — background fetch-all:** the first page renders immediately, then a background loop fetches every remaining page until `hasNextPage` is false, appending into the persisted cache. There is no scroll-position prefetch trigger for the owned/starred lists; the load is continuous and driven by the effect re-running as the list grows.
+- **Fetch-generation guard (GMC-43):** `useRepoData` keeps a generation counter per list (owned + starred). Every fresh load (org/scope switch, manual refresh, sort change) bumps it; a page request started under an older generation discards its response entirely — items, cursors, counts, error, and the loading-flag resets. The context-switch effect also drops `endCursor`/`hasNextPage` synchronously. Without this, an in-flight background page from the previous context appended foreign rows into the new list and overwrote the cursor, making the background loop walk two cursor chains at once (duplicated rows, loaded count > totalCount, garbled Ink render). Any new loader added to `useRepoData` must capture the generation before its `await` and check it before every state write.
 - Because the full set is cached, **sorting is client-side** (`filteredAndSorted`) with no server refetch on sort change; archive/visibility (private) filtering is also client-side.
 - On each page fetch, also read `totalCount` to reflect newly created repos and to show background-load progress (`loaded/total`).
 - Selected fields: name/nameWithOwner/description/visibility/isPrivate/isFork/isArchived/stargazerCount/forkCount/primaryLanguage/updatedAt/pushedAt/diskUsage, plus `parent { nameWithOwner }` and `defaultBranchRef { name }`.

--- a/TODOs.md
+++ b/TODOs.md
@@ -365,9 +365,9 @@ Legend:
 
 ## Done
 
-- [x] Fix repo list corruption on org/scope switch mid background fetch-all (GMC-43)
+- [x] Fix repo list corruption on org/scope switch mid-background fetch-all (GMC-43)
   - `useRepoData` now keeps a fetch-generation counter per list (owned + starred); every fresh load (context switch, refresh, sort change) bumps it and in-flight page requests from an older generation discard their responses entirely
-  - Context switch also drops the stale `endCursor`/`hasNextPage` synchronously so the background loop can't keep walking the previous context's cursor chain
+  - Context switch also drops the stale `endCursor`/`hasNextPage` synchronously, so the background loop can't keep walking the previous context's cursor chain
 - [x] Fork view filter and consolidated View Filters modal (`V`) (SWR-379)
   - Added a third client-side view filter for fork status (All / Forks only / Non-forks only) operating purely over `RepoNode.isFork` — zero new GraphQL/REST calls
   - Consolidated the previous standalone `V` visibility and `A` archive modals into a single **View Filters** modal with three grouped sections (Visibility, Archive, Fork)

--- a/TODOs.md
+++ b/TODOs.md
@@ -365,6 +365,9 @@ Legend:
 
 ## Done
 
+- [x] Fix repo list corruption on org/scope switch mid background fetch-all (GMC-43)
+  - `useRepoData` now keeps a fetch-generation counter per list (owned + starred); every fresh load (context switch, refresh, sort change) bumps it and in-flight page requests from an older generation discard their responses entirely
+  - Context switch also drops the stale `endCursor`/`hasNextPage` synchronously so the background loop can't keep walking the previous context's cursor chain
 - [x] Fork view filter and consolidated View Filters modal (`V`) (SWR-379)
   - Added a third client-side view filter for fork status (All / Forks only / Non-forks only) operating purely over `RepoNode.isFork` — zero new GraphQL/REST calls
   - Consolidated the previous standalone `V` visibility and `A` archive modals into a single **View Filters** modal with three grouped sections (Visibility, Archive, Fork)

--- a/src/ui/hooks/useRepoData.ts
+++ b/src/ui/hooks/useRepoData.ts
@@ -131,13 +131,23 @@ export function useRepoData(params: RepoDataParams) {
   const fetchGenRef = useRef(0);
   const starredFetchGenRef = useRef(0);
 
+  // The context key of the latest render. The generation bump above lives in
+  // the context-change effect, which only runs AFTER the render committed by
+  // a context switch — a stale page resolving in that gap would still pass
+  // the generation check. This ref is updated during render itself, so a
+  // request started under another context is recognised as foreign even
+  // before the effect has run.
+  const contextKey = ownerContext !== 'personal' ? `org:${ownerContext.login}` : 'personal';
+  const contextKeyRef = useRef(contextKey);
+  contextKeyRef.current = contextKey;
+
   // Fetch starred repositories
   async function fetchStarredRepositories(after?: string | null, reset = false) {
     const gen = reset || !after ? ++starredFetchGenRef.current : starredFetchGenRef.current;
     setStarredLoading(true);
     try {
       const page = await getStarredRepositories(client, PAGE_SIZE, after ?? undefined);
-      if (gen !== starredFetchGenRef.current) return; // superseded by a newer load — discard
+      if (gen !== starredFetchGenRef.current || contextKey !== contextKeyRef.current) return; // superseded — discard
 
       setStarredItems(prev => (reset || !after ? page.nodes : [...prev, ...page.nodes]));
       setStarredEndCursor(page.endCursor ?? null);
@@ -151,7 +161,7 @@ export function useRepoData(params: RepoDataParams) {
 
       setStarredLoading(false);
     } catch (e: unknown) {
-      if (gen !== starredFetchGenRef.current) return; // superseded — discard
+      if (gen !== starredFetchGenRef.current || contextKey !== contextKeyRef.current) return; // superseded — discard
       setStarredLoading(false);
       setError((e instanceof Error ? e.message : null) || 'Failed to fetch starred repositories');
     }
@@ -206,7 +216,7 @@ export function useRepoData(params: RepoDataParams) {
         orgLogin
       );
 
-      if (gen !== fetchGenRef.current) return; // superseded by a newer load — discard
+      if (gen !== fetchGenRef.current || contextKey !== contextKeyRef.current) return; // superseded — discard
 
       // A fresh list load (refresh, sort change, org switch, first page)
       // replaces items with un-enriched nodes — clear the enrichment tracker
@@ -227,7 +237,7 @@ export function useRepoData(params: RepoDataParams) {
       // Check if organization is enterprise (first page only)
       if (!after && orgLogin) {
         checkOrganizationIsEnterprise(client, orgLogin).then(isEnt => {
-          if (gen !== fetchGenRef.current) return; // superseded — discard
+          if (gen !== fetchGenRef.current || contextKey !== contextKeyRef.current) return; // superseded — discard
           setIsEnterpriseOrg(isEnt);
         });
       }
@@ -270,13 +280,13 @@ export function useRepoData(params: RepoDataParams) {
         error: apiErr?.message,
         stack: apiErr?.stack,
       });
-      if (gen !== fetchGenRef.current) return; // superseded — discard
+      if (gen !== fetchGenRef.current || contextKey !== contextKeyRef.current) return; // superseded — discard
       setError('Failed to load repositories. Check network or token.');
     } finally {
       // A discarded request must not clear the loading flags either: the
       // superseding load owns them now, and clearing early re-opens the
       // background-loop gate while that load is still in flight.
-      if (gen === fetchGenRef.current) {
+      if (gen === fetchGenRef.current && contextKey === contextKeyRef.current) {
         setLoading(false);
         setSortingLoading(false);
         setRefreshing(false);

--- a/src/ui/hooks/useRepoData.ts
+++ b/src/ui/hooks/useRepoData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type React from 'react';
 import {
   makeClient,
@@ -120,11 +120,24 @@ export function useRepoData(params: RepoDataParams) {
   const [starredTotalCount, setStarredTotalCount] = useState<number>(0);
   const [starredLoading, setStarredLoading] = useState(false);
 
+  // Fetch-generation guards (GMC-43). Every fresh load (context switch, manual
+  // refresh, sort change) bumps the generation; a page request started under an
+  // older generation discards its response entirely instead of applying it.
+  // Without this, a background fetch-all page from the previous org/scope
+  // resolves after the switch, appends foreign rows into the new list, and
+  // overwrites endCursor/hasNextPage with the old context's pagination — so the
+  // background loop walks two cursor chains at once (duplicated/interleaved
+  // rows, loaded count exceeding totalCount).
+  const fetchGenRef = useRef(0);
+  const starredFetchGenRef = useRef(0);
+
   // Fetch starred repositories
   async function fetchStarredRepositories(after?: string | null, reset = false) {
+    const gen = reset || !after ? ++starredFetchGenRef.current : starredFetchGenRef.current;
     setStarredLoading(true);
     try {
       const page = await getStarredRepositories(client, PAGE_SIZE, after ?? undefined);
+      if (gen !== starredFetchGenRef.current) return; // superseded by a newer load — discard
 
       setStarredItems(prev => (reset || !after ? page.nodes : [...prev, ...page.nodes]));
       setStarredEndCursor(page.endCursor ?? null);
@@ -138,6 +151,7 @@ export function useRepoData(params: RepoDataParams) {
 
       setStarredLoading(false);
     } catch (e: unknown) {
+      if (gen !== starredFetchGenRef.current) return; // superseded — discard
       setStarredLoading(false);
       setError((e instanceof Error ? e.message : null) || 'Failed to fetch starred repositories');
     }
@@ -159,6 +173,8 @@ export function useRepoData(params: RepoDataParams) {
       viewerLogin,
       ownerContext
     });
+
+    const gen = reset || !after ? ++fetchGenRef.current : fetchGenRef.current;
 
     if (isSortChange) {
       setSortingLoading(true);
@@ -190,6 +206,8 @@ export function useRepoData(params: RepoDataParams) {
         orgLogin
       );
 
+      if (gen !== fetchGenRef.current) return; // superseded by a newer load — discard
+
       // A fresh list load (refresh, sort change, org switch, first page)
       // replaces items with un-enriched nodes — clear the enrichment tracker
       // so forks get their ahead/behind counts recomputed against the new data.
@@ -209,6 +227,7 @@ export function useRepoData(params: RepoDataParams) {
       // Check if organization is enterprise (first page only)
       if (!after && orgLogin) {
         checkOrganizationIsEnterprise(client, orgLogin).then(isEnt => {
+          if (gen !== fetchGenRef.current) return; // superseded — discard
           setIsEnterpriseOrg(isEnt);
         });
       }
@@ -251,12 +270,18 @@ export function useRepoData(params: RepoDataParams) {
         error: apiErr?.message,
         stack: apiErr?.stack,
       });
+      if (gen !== fetchGenRef.current) return; // superseded — discard
       setError('Failed to load repositories. Check network or token.');
     } finally {
-      setLoading(false);
-      setSortingLoading(false);
-      setRefreshing(false);
-      setLoadingMore(false);
+      // A discarded request must not clear the loading flags either: the
+      // superseding load owns them now, and clearing early re-opens the
+      // background-loop gate while that load is still in flight.
+      if (gen === fetchGenRef.current) {
+        setLoading(false);
+        setSortingLoading(false);
+        setRefreshing(false);
+        setLoadingMore(false);
+      }
     }
   };
 
@@ -281,6 +306,19 @@ export function useRepoData(params: RepoDataParams) {
       });
       policy = isFresh(key) ? 'cache-first' : 'network-only';
     } catch {}
+
+    // Kill all in-flight page requests from the previous context (GMC-43):
+    // their responses are discarded by the generation guard, and dropping the
+    // stale pagination state here stops the background fetch-all loop from
+    // walking the old context's cursor chain before the fresh load lands.
+    fetchGenRef.current++;
+    starredFetchGenRef.current++;
+    setEndCursor(null);
+    setHasNextPage(false);
+    setLoadingMore(false);
+    setStarredEndCursor(null);
+    setStarredHasNextPage(false);
+    setStarredLoading(false);
 
     // Reset cursor when changing context
     onContextSwitch();

--- a/tests/ui/useRepoData.test.tsx
+++ b/tests/ui/useRepoData.test.tsx
@@ -82,6 +82,17 @@ const page = (nodes: any[], over: Record<string, unknown> = {}) => ({
   ...over,
 });
 
+// A promise whose settlement the test controls, to hold a page request
+// in flight across a scope switch or refresh.
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+const flush = () => new Promise(r => setTimeout(r, 0));
+
 describe('useRepoData', () => {
   beforeEach(() => {
     fetchUnifiedMock.mockReset();
@@ -184,6 +195,158 @@ describe('useRepoData', () => {
     expect(h.starredHasNextPage).toBe(true);
     expect(h.starredTotalCount).toBe(9);
     expect(h.rateLimit?.remaining).toBe(4990);
+    unmount();
+  });
+});
+
+describe('useRepoData fetch-generation guard (GMC-43)', () => {
+  beforeEach(() => {
+    fetchUnifiedMock.mockReset();
+    starredMock.mockReset();
+    enterpriseMock.mockReset();
+    enterpriseMock.mockResolvedValue(false);
+  });
+
+  it('discards an in-flight background page when the owner context switches', async () => {
+    let h!: Hook;
+    const d1 = deferred<any>();
+    fetchUnifiedMock.mockReturnValueOnce(d1.promise as any);
+    const { rerender, unmount } = render(<Harness onHook={x => { h = x; }} />);
+    await flush();
+    d1.resolve(page([repo('mine-1')], { hasNextPage: true, endCursor: 'me-c1', totalCount: 5 }));
+    await flush();
+    expect(h.items.map(i => i.nameWithOwner)).toEqual(['o/mine-1']);
+
+    // The background fetch-all loop requests the next page of this context…
+    const dStale = deferred<any>();
+    fetchUnifiedMock.mockReturnValueOnce(dStale.promise as any);
+    h.fetchPage('me-c1');
+    await flush();
+    expect(h.loadingMore).toBe(true);
+
+    // …but the user switches scope before it lands. The switch must drop the
+    // old pagination state synchronously and start a fresh load.
+    const dFresh = deferred<any>();
+    fetchUnifiedMock.mockReturnValueOnce(dFresh.promise as any);
+    rerender(<Harness onHook={x => { h = x; }} ownerContext={stableOrgContext} />);
+    await flush();
+    expect(h.endCursor).toBeNull();
+    expect(h.hasNextPage).toBe(false);
+    expect(h.loadingMore).toBe(false);
+    expect(h.loading).toBe(true);
+
+    // The stale page resolves: nothing may be appended, no cursor overwritten,
+    // and the fresh load's loading flag must stay up.
+    dStale.resolve(page([repo('mine-2')], { hasNextPage: true, endCursor: 'me-c2', totalCount: 5 }));
+    await flush();
+    expect(h.items.map(i => i.nameWithOwner)).toEqual(['o/mine-1']); // untouched (the view clears items itself)
+    expect(h.endCursor).toBeNull();
+    expect(h.hasNextPage).toBe(false);
+    expect(h.loading).toBe(true);
+
+    // The new context's first page applies normally.
+    dFresh.resolve(page([repo('org-1')], { hasNextPage: true, endCursor: 'org-c1', totalCount: 3 }));
+    await flush();
+    expect(h.items.map(i => i.nameWithOwner)).toEqual(['o/org-1']);
+    expect(h.endCursor).toBe('org-c1');
+    expect(h.hasNextPage).toBe(true);
+    expect(h.loading).toBe(false);
+    unmount();
+  });
+
+  it('discards an in-flight background page when a manual refresh starts', async () => {
+    let h!: Hook;
+    const d1 = deferred<any>();
+    fetchUnifiedMock.mockReturnValueOnce(d1.promise as any);
+    const { unmount } = render(<Harness onHook={x => { h = x; }} />);
+    await flush();
+    d1.resolve(page([repo('a')], { hasNextPage: true, endCursor: 'c1', totalCount: 3 }));
+    await flush();
+
+    const dStale = deferred<any>();
+    fetchUnifiedMock.mockReturnValueOnce(dStale.promise as any);
+    h.fetchPage('c1');
+    await flush();
+
+    const dRefresh = deferred<any>();
+    fetchUnifiedMock.mockReturnValueOnce(dRefresh.promise as any);
+    h.fetchPage(null, true, false, undefined, 'network-only');
+    await flush();
+
+    dStale.resolve(page([repo('b')], { hasNextPage: true, endCursor: 'c2', totalCount: 3 }));
+    await flush();
+    expect(h.items.map(i => i.nameWithOwner)).toEqual(['o/a']);
+    expect(h.loading).toBe(true); // the stale finally must not clear the refresh's flag
+
+    dRefresh.resolve(page([repo('a2')], { totalCount: 1 }));
+    await flush();
+    expect(h.items.map(i => i.nameWithOwner)).toEqual(['o/a2']);
+    expect(h.loading).toBe(false);
+    unmount();
+  });
+
+  it('a stale request that fails does not surface an error over the fresh load', async () => {
+    let h!: Hook;
+    const d1 = deferred<any>();
+    fetchUnifiedMock.mockReturnValueOnce(d1.promise as any);
+    const { unmount } = render(<Harness onHook={x => { h = x; }} />);
+    await flush();
+    d1.resolve(page([repo('a')], { hasNextPage: true, endCursor: 'c1' }));
+    await flush();
+
+    const dStale = deferred<any>();
+    fetchUnifiedMock.mockReturnValueOnce(dStale.promise as any);
+    h.fetchPage('c1');
+    await flush();
+
+    const dRefresh = deferred<any>();
+    fetchUnifiedMock.mockReturnValueOnce(dRefresh.promise as any);
+    h.fetchPage(null, true, false, undefined, 'network-only');
+    await flush();
+
+    dStale.reject(new Error('boom'));
+    await flush();
+    expect(h.error).toBeNull();
+
+    dRefresh.resolve(page([repo('a2')]));
+    await flush();
+    expect(h.items.map(i => i.nameWithOwner)).toEqual(['o/a2']);
+    expect(h.error).toBeNull();
+    unmount();
+  });
+
+  it('discards an in-flight starred page when the owner context switches', async () => {
+    let h!: Hook;
+    fetchUnifiedMock.mockResolvedValue(page([]) as any);
+    const { rerender, unmount } = render(<Harness onHook={x => { h = x; }} />);
+    await vi.waitFor(() => expect(h.loading).toBe(false));
+
+    const dStar1 = deferred<any>();
+    starredMock.mockReturnValueOnce(dStar1.promise as any);
+    h.fetchStarredRepositories(null, true);
+    await flush();
+    dStar1.resolve(page([repo('s1')], { hasNextPage: true, endCursor: 's-c1', totalCount: 2 }));
+    await flush();
+    expect(h.starredItems.map(i => i.nameWithOwner)).toEqual(['o/s1']);
+
+    const dStarStale = deferred<any>();
+    starredMock.mockReturnValueOnce(dStarStale.promise as any);
+    h.fetchStarredRepositories('s-c1');
+    await flush();
+    expect(h.starredLoading).toBe(true);
+
+    rerender(<Harness onHook={x => { h = x; }} ownerContext={stableOrgContext} />);
+    await flush();
+    expect(h.starredEndCursor).toBeNull();
+    expect(h.starredHasNextPage).toBe(false);
+    expect(h.starredLoading).toBe(false);
+
+    dStarStale.resolve(page([repo('s2')], { hasNextPage: true, endCursor: 's-c2', totalCount: 2 }));
+    await flush();
+    expect(h.starredItems.map(i => i.nameWithOwner)).toEqual(['o/s1']); // untouched (the view clears on switch)
+    expect(h.starredEndCursor).toBeNull();
+    expect(h.starredHasNextPage).toBe(false);
+    expect(h.starredLoading).toBe(false);
     unmount();
   });
 });

--- a/tests/ui/useRepoData.test.tsx
+++ b/tests/ui/useRepoData.test.tsx
@@ -254,6 +254,48 @@ describe('useRepoData fetch-generation guard (GMC-43)', () => {
     unmount();
   });
 
+  it('discards a page requested from a stale closure of the previous context', async () => {
+    let h!: Hook;
+    const d1 = deferred<any>();
+    fetchUnifiedMock.mockReturnValueOnce(d1.promise as any);
+    const { rerender, unmount } = render(<Harness onHook={x => { h = x; }} />);
+    await flush();
+    d1.resolve(page([repo('mine-1')], { hasNextPage: true, endCursor: 'me-c1', totalCount: 5 }));
+    await flush();
+
+    // Keep a closure bound to the personal context, then switch to the org.
+    const hPersonal = h;
+    const dFresh = deferred<any>();
+    fetchUnifiedMock.mockReturnValueOnce(dFresh.promise as any);
+    rerender(<Harness onHook={x => { h = x; }} ownerContext={stableOrgContext} />);
+    await flush();
+    expect(h.loading).toBe(true);
+
+    // A stale closure (e.g. the background loop firing in the gap before its
+    // deps refresh, or before the context effect has bumped the generation)
+    // requests the next page of the OLD context. Pagination calls don't bump
+    // the generation, so only the render-time context-key guard can identify
+    // this request as foreign.
+    const dStale = deferred<any>();
+    fetchUnifiedMock.mockReturnValueOnce(dStale.promise as any);
+    hPersonal.fetchPage('me-c1');
+    await flush();
+
+    dStale.resolve(page([repo('mine-2')], { hasNextPage: true, endCursor: 'me-c2', totalCount: 5 }));
+    await flush();
+    expect(h.items.map(i => i.nameWithOwner)).toEqual(['o/mine-1']); // foreign page not appended
+    expect(h.endCursor).toBeNull();
+    expect(h.hasNextPage).toBe(false);
+    expect(h.loading).toBe(true); // fresh load still in flight
+
+    dFresh.resolve(page([repo('org-1')], { totalCount: 1 }));
+    await flush();
+    expect(h.items.map(i => i.nameWithOwner)).toEqual(['o/org-1']);
+    expect(h.loading).toBe(false);
+    expect(h.loadingMore).toBe(false);
+    unmount();
+  });
+
   it('discards an in-flight background page when a manual refresh starts', async () => {
     let h!: Hook;
     const d1 = deferred<any>();


### PR DESCRIPTION
## Summary

Fixes the repo-list corruption seen when switching scope (org → personal) while the background fetch-all is still running — interleaved/duplicated rows, an impossible `281/143` loaded/total count, and a garbled Ink render that got worse when the background fetch finished.

Linear: [GMC-43](https://linear.app/stealths/issue/GMC-43/repo-list-corrupts-after-org-personal-scope-switch-stale-background)

## Root cause

`useRepoData.fetchPage` / `fetchStarredRepositories` applied responses unconditionally. An in-flight background page from the previous context resolved after the switch, appended foreign rows into the new list, and overwrote `endCursor`/`hasNextPage` with the old context's pagination — so the background fetch-all loop walked **two cursor chains at once**. A stale request's `finally` also cleared the loading flags early, re-opening the loop gate and causing duplicate page fetches.

## Fix

- `useRepoData` keeps a fetch-generation counter per list (owned + starred). Every fresh load (context switch, manual refresh `R`, sort change) bumps it; a request started under an older generation discards its response entirely — items, cursors, counts, error, enterprise-check result, and the loading-flag resets.
- The context-switch effect bumps both generations and drops `endCursor`/`hasNextPage`/`loadingMore` (and the starred equivalents) synchronously, so the background loop can't fire against the new context with the old cursor.

## Tests

Five new cases in `tests/ui/useRepoData.test.tsx` (455 total passing):
- current-generation pages still append normally (pre-existing coverage)
- stale background page after an org/scope switch is fully discarded (items, cursors, loading flag)
- stale background page after a manual refresh is discarded
- a stale request that **fails** doesn't surface an error over the fresh load
- stale starred page after a scope switch is discarded

`pnpm test`, `pnpm typecheck`, `pnpm build` all pass; CodeRabbit review on the diff: 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core async list loading and pagination; behaviour is well covered by new tests but mistakes could still affect list integrity or loading UX.
> 
> **Overview**
> Fixes **repo list corruption** when switching organisation/scope or refreshing while **background fetch-all** is still paging (GMC-43).
> 
> `useRepoData` now uses **per-list fetch generations** (owned + starred) and a **render-time context key**: fresh loads bump the generation; any in-flight page from an older generation or context is **ignored** for items, cursors, counts, errors, enterprise checks, and loading flags. On context change, the effect **clears pagination state** (`endCursor`/`hasNextPage`/`loadingMore`, starred equivalents) so the background loop cannot continue the previous cursor chain. **Five deferred-promise tests** cover scope switch, stale closure, manual refresh, stale errors, and starred paging. Docs updated in `AGENTS.md` and `TODOs.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a8c031750b242609ad06cd7f182d50af8508380. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repository list corruption and stale data from applying after switching organisation, scope or sorting during background fetches.
  * Ensured loading indicators and pagination state are not prematurely cleared by outdated requests.

* **Documentation**
  * Clarified data-consistency safeguards for asynchronous repository operations and context switches.

* **Tests**
  * Added deterministic tests covering discarded in-flight fetches and preserved fresh-load state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->