### PR TITLE
fix: match bulk-select footer hint colour to other reminder lines (GMC-51) [semantic pr title]

### DIFF
--- a/src/ui/components/repo/RepoListFooter.tsx
+++ b/src/ui/components/repo/RepoListFooter.tsx
@@ -64,13 +64,18 @@ export default function RepoListFooter({
           K Cache Info • W Org Switch{!starsMode ? ' • Ctrl+N New Repo' : ''} • Del/Backspace Delete • Ctrl+L Logout • Q Quit
         </Text>
       </Box>
-      {/* Multi-select hint (shown when not in modal). Inactive uses the same
-          theme.muted / dim-only-when-modal styling as the lines above (GMC-51);
-          active uses theme.primary so the emphasis stays on-theme. */}
+      {/* Multi-select hint (shown when not in modal). Inactive matches the
+          other reminder lines (theme.muted). Active inverts theme.primary
+          onto the whole row so Bulk Select reads as "on" (GMC-51). */}
       {!modalOpen && (
-        <Box width={terminalWidth} justifyContent="center">
+        <Box
+          width={terminalWidth}
+          justifyContent="center"
+          backgroundColor={multiSelectMode ? theme.primary : undefined}
+        >
           <Text
-            color={multiSelectMode ? theme.primary : theme.muted}
+            color={multiSelectMode ? 'black' : theme.muted}
+            bold={multiSelectMode || undefined}
             dimColor={modalOpen ? true : undefined}
           >
             {multiSelectMode

--- a/src/ui/components/repo/RepoListFooter.tsx
+++ b/src/ui/components/repo/RepoListFooter.tsx
@@ -64,10 +64,15 @@ export default function RepoListFooter({
           K Cache Info • W Org Switch{!starsMode ? ' • Ctrl+N New Repo' : ''} • Del/Backspace Delete • Ctrl+L Logout • Q Quit
         </Text>
       </Box>
-      {/* Multi-select hint (shown when not in modal) */}
+      {/* Multi-select hint (shown when not in modal). Inactive uses the same
+          theme.muted / dim-only-when-modal styling as the lines above (GMC-51);
+          active uses theme.primary so the emphasis stays on-theme. */}
       {!modalOpen && (
         <Box width={terminalWidth} justifyContent="center">
-          <Text color={multiSelectMode ? 'cyan' : 'gray'} dimColor={!multiSelectMode}>
+          <Text
+            color={multiSelectMode ? theme.primary : theme.muted}
+            dimColor={modalOpen ? true : undefined}
+          >
             {multiSelectMode
               ? (selectedCount > 0
                   ? `Space select • X unselect all • Ctrl+S star • Ctrl+A archive • Ctrl+V visibility${starsMode ? '' : ' • Shift+M transfer'} • Del delete • B/Esc exit (${selectedCount} selected${hiddenSelectedCount > 0 ? `, ${hiddenSelectedCount} not shown in search` : ''})`

--- a/tests/ui/RepoListFooter.test.tsx
+++ b/tests/ui/RepoListFooter.test.tsx
@@ -71,4 +71,41 @@ describe('RepoListFooter', () => {
     expect(lastFrame() || '').toContain('(2 selected, 1 not shown in search)');
     unmount();
   });
+
+  it('styles the inactive Bulk Select hint like the other reminder lines (GMC-51)', () => {
+    const { lastFrame, unmount } = render(<RepoListFooter {...baseProps} />);
+    const out = lastFrame() || '';
+    const lineOf = (needle: string) => out.split('\n').find(l => l.includes(needle)) || '';
+    const navLine = lineOf('↑↓ Navigate');
+    const bulkLine = lineOf('B Bulk Select mode');
+    // Must not apply Ink dim (SGR 2) — that was what made this row look darker.
+    expect(bulkLine).not.toMatch(/\x1b\[2m/);
+    // Same colour open sequence as the navigation hint (theme.muted).
+    const colour = (line: string) => line.match(/\x1b\[[0-9;]*m/)?.[0];
+    expect(colour(bulkLine)).toBe(colour(navLine));
+    unmount();
+  });
+
+  it('uses the theme mute colour (not hardcoded gray) on Ocean (GMC-51)', () => {
+    const { lastFrame, unmount } = render(
+      <RepoListFooter {...baseProps} theme={getTheme('ocean')} />,
+    );
+    const bulkLine = (lastFrame() || '').split('\n').find(l => l.includes('B Bulk Select mode')) || '';
+    // Ocean muted is 'blue' (34); the old hardcoded gray was 90.
+    expect(bulkLine).toMatch(/\x1b\[34m/);
+    expect(bulkLine).not.toMatch(/\x1b\[90m/);
+    expect(bulkLine).not.toMatch(/\x1b\[2m/);
+    unmount();
+  });
+
+  it('emphasises the active Bulk Select hint with the theme primary colour', () => {
+    const { lastFrame, unmount } = render(
+      <RepoListFooter {...baseProps} theme={getTheme('forest')} multiSelectMode={true} />,
+    );
+    const bulkLine = (lastFrame() || '').split('\n').find(l => l.includes('B/Esc exit bulk select')) || '';
+    // Forest primary is 'green' (32), not the old hardcoded cyan (36).
+    expect(bulkLine).toMatch(/\x1b\[32m/);
+    expect(bulkLine).not.toMatch(/\x1b\[36m/);
+    unmount();
+  });
 });

--- a/tests/ui/RepoListFooter.test.tsx
+++ b/tests/ui/RepoListFooter.test.tsx
@@ -98,13 +98,16 @@ describe('RepoListFooter', () => {
     unmount();
   });
 
-  it('emphasises the active Bulk Select hint with the theme primary colour', () => {
+  it('inverts the active Bulk Select row onto the theme primary colour (GMC-51)', () => {
     const { lastFrame, unmount } = render(
       <RepoListFooter {...baseProps} theme={getTheme('forest')} multiSelectMode={true} />,
     );
-    const bulkLine = (lastFrame() || '').split('\n').find(l => l.includes('B/Esc exit bulk select')) || '';
-    // Forest primary is 'green' (32), not the old hardcoded cyan (36).
-    expect(bulkLine).toMatch(/\x1b\[32m/);
+    const out = lastFrame() || '';
+    const bulkLine = out.split('\n').find(l => l.includes('B/Esc exit bulk select')) || '';
+    // Forest primary is green: background 42 + black foreground 30.
+    // Must not keep the old hardcoded cyan (36) text-only treatment.
+    expect(bulkLine).toMatch(/\x1b\[42m/);
+    expect(bulkLine).toMatch(/\x1b\[30m/);
     expect(bulkLine).not.toMatch(/\x1b\[36m/);
     unmount();
   });


### PR DESCRIPTION
## Summary

The expanded footer’s `B Bulk Select mode (star/archive/visibility/delete)` line rendered a different (darker) colour than the hint lines above it.

That was code, not a terminal quirk. The other reminder lines use `theme.muted` and only dim when a modal is open. The Bulk Select row used hardcoded `gray` plus `dimColor={!multiSelectMode}`, so it was always faint when Bulk Select was off — and the wrong hue on Ocean (`theme.muted` is blue there).

## Change

- Inactive: same `theme.muted` / dim-only-when-modal styling as the other hint lines.
- Active: `theme.primary` instead of hardcoded `cyan`, so Ocean/Forest/Monochrome stay on-theme.

Scoped to `RepoListFooter`. The in-list `[BULK SELECT]` status bar is unchanged.

Linear: https://linear.app/stealth-company/issue/GMC-51/match-bulk-select-footer-hint-colour-to-the-other-key-reminder-lines

## Tests

- Inactive Bulk Select hint is not dimmed and shares the same colour sequence as the navigation hint.
- Ocean uses the theme mute colour (blue), not hardcoded gray.
- Active Bulk Select hint uses the theme primary colour (asserted on Forest).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the multi-select hint to use the configured theme colours.
  * Aligned inactive hint dimming with other footer hints.
  * Active hints now consistently use the theme’s primary colour.

* **Tests**
  * Added coverage for hint styling across different themes and states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->