### PR TITLE
feat: toggle footer key reminders and invert bulk-select hint (GMC-50, GMC-51)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ gh-manager-cli/
 │   │   ├── hooks/            # RepoList logic extracted into focused hooks (GMC-28/GMC-39):
 │   │   │   ├── useTheme.ts          # Colour-theme hook (GMC-22)
 │   │   │   ├── useVirtualList.ts    # Windowing memo around the cursor
-│   │   │   ├── useListLayout.ts     # Terminal-width + list-height derivation
+│   │   │   ├── useListLayout.ts     # Terminal-width + list-height derivation (footer collapse GMC-50)
 │   │   │   ├── useForkEnrichment.ts # Batched fork ahead/behind enrichment effect (SWR-362)
 │   │   │   ├── useRefreshTick.ts    # Whole-minute tick for relative dates (SWR-377)
 │   │   │   ├── useBulkSelect.ts     # Bulk Select mode + selection map + helpers
@@ -120,7 +120,7 @@ gh-manager-cli/
 - Repository actions: delete, archive/unarchive, change visibility, sync forks
 - Organization and Enterprise GitHub support
 - Modal-based UI for sorting, filtering, and actions
-- Persistent UI preferences (sort, density, visibility filter, fork tracking, colour theme)
+- Persistent UI preferences (sort, density, visibility filter, fork tracking, colour theme, footer collapse)
 - Real-time rate limit monitoring for GraphQL and REST APIs
 
 ### Planned Enhancements
@@ -190,6 +190,7 @@ The project has no formal roadmap or task board — feature work is driven by us
 - `Shift+S`: toggle between own repos and starred repos (personal context only)
   - Footer hint shows `Shift+S Starred` in normal mode and `Shift+S My Repos` in starred mode; hidden in org context
 - `R`: refresh list (purges cache)
+- `H`: toggle the help footer between a single line of important keys (including `H More keys`) and the full reminder set; persists across restarts. Default is collapsed so the list has more room.
 - `Q`: quit (Esc cancels an open modal or exits search mode; does not quit)
 
 ### Bulk Select Mode
@@ -207,6 +208,7 @@ The project has no formal roadmap or task board — feature work is driven by us
 - `Shift+M`: bulk transfer (move) the selected repos to another owner/org
 - `Del` / `Backspace`: bulk delete the selected repos
 - Navigation (arrows, PageUp/Down, `Ctrl+G`, `G`) still works
+- `H`: toggle the help footer (same as outside bulk mode)
 
 Bulk actions reuse the same global shortcuts as single-repo mode and require at least one selected repo. There is no separate action-picker modal.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Full docs live in the [wiki](wiki/README.md):
 - **Repository actions** — info, open, rename, transfer, copy URL, delete, archive, change visibility, star, sync fork
 - **Bulk Select mode** (`B`) — star, archive, change visibility, delete, and transfer many repos at once
 - **Organisation & Enterprise support** — switch contexts (`W`), Internal visibility, ENT badge
-- **Fork ahead/behind tracking**, **colour themes** (`Shift+T`), **display density** (`T`), and **rate-limit monitoring**
+- **Fork ahead/behind tracking**, **colour themes** (`Shift+T`), **display density** (`T`), **collapsible key hints** (`H`), and **rate-limit monitoring**
 
 See the [Features](wiki/Features.md) and [Usage & Controls](wiki/Usage.md) pages for the full list and every keybinding.
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -18,6 +18,8 @@ interface UIPrefs {
   archiveFilter?: 'all' | 'unarchived' | 'archived';
   forkFilter?: 'all' | 'forks' | 'non-forks';
   theme?: ThemeName;
+  /** When true, the help footer shows a single hint line (GMC-50). */
+  footerCollapsed?: boolean;
 }
 
 export type TokenSource = 'pat' | 'oauth';

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -134,23 +134,26 @@ export interface ListLayout {
  * Compute the fixed layout heights for the repository list view (GMC-28).
  *
  * Behaviour-preserving extraction of the inline math previously in
- * `RepoList.tsx`. Header (2), footer (4) and container padding (2) are fixed;
- * the filter bar and bulk-select bar each reserve 2 extra lines when active,
- * plus a constant 2-line allowance. Both `contentHeight` and `listHeight` are
- * clamped to a minimum of 1 so tiny terminals never produce a non-positive
- * height.
+ * `RepoList.tsx`. Header (2) and container padding (2) are fixed. The footer
+ * reserves 4 lines when expanded and 2 when collapsed (GMC-50: one hint line
+ * plus a top margin). The filter bar and bulk-select bar each reserve 2 extra
+ * lines when active, plus a constant 2-line allowance. Both `contentHeight`
+ * and `listHeight` are clamped to a minimum of 1 so tiny terminals never
+ * produce a non-positive height.
  */
 export function computeListLayout(input: {
   columns?: number;
   maxVisibleRows?: number;
   filterMode: boolean;
   multiSelectMode: boolean;
+  /** One-line help footer (GMC-50). Defaults to expanded (legacy height). */
+  footerCollapsed?: boolean;
 }): ListLayout {
-  const { columns, maxVisibleRows, filterMode, multiSelectMode } = input;
+  const { columns, maxVisibleRows, filterMode, multiSelectMode, footerCollapsed = false } = input;
   const terminalWidth = columns ?? 80;
   const availableHeight = maxVisibleRows ?? 20;
   const headerHeight = 2; // Header bar + margin
-  const footerHeight = 4; // Footer with border + margin (flexible height)
+  const footerHeight = footerCollapsed ? 2 : 4; // Collapsed: margin + 1 hint line
   const containerPadding = 2; // Top and bottom padding inside container
   const contentHeight = Math.max(1, availableHeight - headerHeight - footerHeight - containerPadding);
   const listHeight = Math.max(1, contentHeight - (filterMode ? 2 : 0) - (multiSelectMode ? 2 : 0) - 2);

--- a/src/ui/components/repo/RepoListFooter.tsx
+++ b/src/ui/components/repo/RepoListFooter.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
 import { Box, Text } from 'ink';
-import chalk from 'chalk';
+import chalk, { type ChalkInstance } from 'chalk';
 import type { Theme } from '../../../config/themes';
 import type { OwnerContext } from '../../../config/config';
 import { truncate } from '../../../lib/utils';
+
+function chalkFor(color: string): ChalkInstance {
+  return (chalk as unknown as Record<string, ChalkInstance | undefined>)[color] ?? chalk.white;
+}
+
+function styleHint(text: string, color: string, dim?: boolean): string {
+  const paint = dim ? chalkFor(color).dim : chalkFor(color);
+  return paint(text);
+}
 
 /** Invert onto the Bulk Select row: black/bold text; Box supplies the full-width primary background. */
 function invertBulkHint(text: string, dim?: boolean): string {
@@ -79,12 +88,10 @@ export default function RepoListFooter({
           justifyContent="center"
           backgroundColor={multiSelectMode ? theme.primary : undefined}
         >
-          <Text
-            color={multiSelectMode ? undefined : hintColor}
-            dimColor={multiSelectMode ? undefined : hintDim}
-            wrap="truncate"
-          >
-            {multiSelectMode ? invertBulkHint(collapsedLine, hintDim) : collapsedLine}
+          <Text wrap="truncate">
+            {multiSelectMode
+              ? invertBulkHint(collapsedLine, hintDim)
+              : styleHint(collapsedLine, hintColor, hintDim)}
           </Text>
         </Box>
       </Box>
@@ -95,29 +102,32 @@ export default function RepoListFooter({
     <Box marginTop={1} paddingX={1} flexDirection="column">
       {/* Line 1: Basic navigation + collapse toggle (kept on line 1 so it is never truncated) */}
       <Box width={terminalWidth} justifyContent="center">
-        <Text color={hintColor} dimColor={hintDim}>
-          ↑↓ Navigate • Ctrl+G Top • G Bottom • ⏎/O Open • R Refresh • H Fewer keys
+        <Text>
+          {styleHint('↑↓ Navigate • Ctrl+G Top • G Bottom • ⏎/O Open • R Refresh • H Fewer keys', hintColor, hintDim)}
         </Text>
       </Box>
       {/* Line 2: Search and filtering */}
       <Box width={terminalWidth} justifyContent="center">
-        <Text color={hintColor} dimColor={hintDim}>
-          / Search{!filterActive && ' • S Sort • D Direction'} • T Density • Shift+T Theme • V View Filters
+        <Text>
+          {styleHint(`/ Search${!filterActive ? ' • S Sort • D Direction' : ''} • T Density • Shift+T Theme • V View Filters`, hintColor, hintDim)}
         </Text>
       </Box>
       {/* Line 3: Repository actions (stars toggle at start so it is never truncated) */}
       <Box width={terminalWidth} justifyContent="center">
-        <Text color={hintColor} dimColor={hintDim}>
-          {starsMode ?
-            'Shift+S My Repos • I Info • C Copy URL • L PRs/Issues • U Unstar Repository' :
-            `${ownerContext === 'personal' ? 'Shift+S Starred • ' : ''}I Info • C Copy URL • L PRs/Issues • Ctrl+S Un/Star • Ctrl+R Rename • Shift+M Transfer • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+F Sync Fork • P Jump to upstream`
-          }
+        <Text>
+          {styleHint(
+            starsMode
+              ? 'Shift+S My Repos • I Info • C Copy URL • L PRs/Issues • U Unstar Repository'
+              : `${ownerContext === 'personal' ? 'Shift+S Starred • ' : ''}I Info • C Copy URL • L PRs/Issues • Ctrl+S Un/Star • Ctrl+R Rename • Shift+M Transfer • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+F Sync Fork • P Jump to upstream`,
+            hintColor,
+            hintDim,
+          )}
         </Text>
       </Box>
       {/* Line 4: System controls */}
       <Box width={terminalWidth} justifyContent="center">
-        <Text color={hintColor} dimColor={hintDim}>
-          K Cache Info • W Org Switch{!starsMode ? ' • Ctrl+N New Repo' : ''} • Del/Backspace Delete • Ctrl+L Logout • Q Quit
+        <Text>
+          {styleHint(`K Cache Info • W Org Switch${!starsMode ? ' • Ctrl+N New Repo' : ''} • Del/Backspace Delete • Ctrl+L Logout • Q Quit`, hintColor, hintDim)}
         </Text>
       </Box>
       {/* Multi-select hint (shown when not in modal). Inactive matches the
@@ -129,25 +139,21 @@ export default function RepoListFooter({
           justifyContent="center"
           backgroundColor={multiSelectMode ? theme.primary : undefined}
         >
-          <Text
-            color={multiSelectMode ? undefined : hintColor}
-            dimColor={multiSelectMode ? undefined : hintDim}
-          >
+          <Text>
             {multiSelectMode
               ? invertBulkHint(
                   selectedCount > 0
                     ? `Space select • X unselect all • Ctrl+S star • Ctrl+A archive • Ctrl+V visibility${starsMode ? '' : ' • Shift+M transfer'} • Del delete • B/Esc exit (${selectedCount} selected${hiddenSelectedCount > 0 ? `, ${hiddenSelectedCount} not shown in search` : ''})`
                     : 'B/Esc exit bulk select • Space select (no selection)',
                 )
-              : 'B Bulk Select mode (star/archive/visibility/delete)'
-            }
+              : styleHint('B Bulk Select mode (star/archive/visibility/delete)', hintColor)}
           </Text>
         </Box>
       )}
       {/* Line 5: Sponsorship */}
       <Box width={terminalWidth} justifyContent="center" marginTop={1}>
-        <Text color={theme.warning} dimColor={hintDim}>
-          💖 Sponsor on GitHub: github.com/sponsors/wiiiimm
+        <Text>
+          {styleHint('💖 Sponsor on GitHub: github.com/sponsors/wiiiimm', theme.warning, hintDim)}
         </Text>
       </Box>
     </Box>

--- a/src/ui/components/repo/RepoListFooter.tsx
+++ b/src/ui/components/repo/RepoListFooter.tsx
@@ -64,13 +64,18 @@ export default function RepoListFooter({
           K Cache Info • W Org Switch{!starsMode ? ' • Ctrl+N New Repo' : ''} • Del/Backspace Delete • Ctrl+L Logout • Q Quit
         </Text>
       </Box>
-      {/* Multi-select hint (shown when not in modal). Inactive uses the same
-          theme.muted / dim-only-when-modal styling as the lines above (GMC-51);
-          active uses theme.primary so the emphasis stays on-theme. */}
+      {/* Multi-select hint (shown when not in modal). Inactive matches the
+          other reminder lines (theme.muted). Active inverts theme.primary
+          onto the whole row so Bulk Select reads as "on" (GMC-51). */}
       {!modalOpen && (
-        <Box width={terminalWidth} justifyContent="center">
+        <Box
+          width={terminalWidth}
+          justifyContent="center"
+          backgroundColor={multiSelectMode ? theme.primary : undefined}
+        >
           <Text
-            color={multiSelectMode ? theme.primary : theme.muted}
+            color={multiSelectMode ? 'black' : theme.muted}
+            bold={multiSelectMode || undefined}
             dimColor={modalOpen ? true : undefined}
           >
             {multiSelectMode

--- a/src/ui/components/repo/RepoListFooter.tsx
+++ b/src/ui/components/repo/RepoListFooter.tsx
@@ -17,12 +17,15 @@ export interface RepoListFooterProps {
   selectedCount: number;
   /** Selected repos not visible under the current search. */
   hiddenSelectedCount: number;
+  /** When true, render a single hint line (GMC-50). */
+  footerCollapsed: boolean;
 }
 
 /**
  * The static help footer beneath the repository list (GMC-28): keyboard-hint
  * lines, the Bulk Select hint, and the sponsorship line. Purely presentational —
- * extracted verbatim from RepoList.
+ * extracted verbatim from RepoList. GMC-50 adds a collapsed one-line form so
+ * the list can reclaim the extra hint rows.
  */
 export default function RepoListFooter({
   terminalWidth,
@@ -34,24 +37,51 @@ export default function RepoListFooter({
   multiSelectMode,
   selectedCount,
   hiddenSelectedCount,
+  footerCollapsed,
 }: RepoListFooterProps) {
+  const hintColor = theme.muted;
+  const hintDim = modalOpen ? true : undefined;
+
+  if (footerCollapsed) {
+    const collapsedLine = multiSelectMode
+      ? '↑↓ Navigate • Space Select • B/Esc Exit • H More keys'
+      : '↑↓ Navigate • / Search • ⏎ Open • B Bulk • H More keys • Q Quit';
+    return (
+      <Box marginTop={1} paddingX={1} flexDirection="column">
+        <Box
+          width={terminalWidth}
+          justifyContent="center"
+          backgroundColor={multiSelectMode ? theme.primary : undefined}
+        >
+          <Text
+            color={multiSelectMode ? 'black' : hintColor}
+            bold={multiSelectMode || undefined}
+            dimColor={hintDim}
+          >
+            {collapsedLine}
+          </Text>
+        </Box>
+      </Box>
+    );
+  }
+
   return (
     <Box marginTop={1} paddingX={1} flexDirection="column">
-      {/* Line 1: Basic navigation */}
+      {/* Line 1: Basic navigation + collapse toggle (kept on line 1 so it is never truncated) */}
       <Box width={terminalWidth} justifyContent="center">
-        <Text color={theme.muted} dimColor={modalOpen ? true : undefined}>
-          ↑↓ Navigate • Ctrl+G Top • G Bottom • ⏎/O Open • R Refresh
+        <Text color={hintColor} dimColor={hintDim}>
+          ↑↓ Navigate • Ctrl+G Top • G Bottom • ⏎/O Open • R Refresh • H Fewer keys
         </Text>
       </Box>
       {/* Line 2: Search and filtering */}
       <Box width={terminalWidth} justifyContent="center">
-        <Text color={theme.muted} dimColor={modalOpen ? true : undefined}>
+        <Text color={hintColor} dimColor={hintDim}>
           / Search{!filterActive && ' • S Sort • D Direction'} • T Density • Shift+T Theme • V View Filters
         </Text>
       </Box>
       {/* Line 3: Repository actions (stars toggle at start so it is never truncated) */}
       <Box width={terminalWidth} justifyContent="center">
-        <Text color={theme.muted} dimColor={modalOpen ? true : undefined}>
+        <Text color={hintColor} dimColor={hintDim}>
           {starsMode ?
             'Shift+S My Repos • I Info • C Copy URL • L PRs/Issues • U Unstar Repository' :
             `${ownerContext === 'personal' ? 'Shift+S Starred • ' : ''}I Info • C Copy URL • L PRs/Issues • Ctrl+S Un/Star • Ctrl+R Rename • Shift+M Transfer • Ctrl+A Un/Archive • Ctrl+V Change Visibility • Ctrl+F Sync Fork • P Jump to upstream`
@@ -60,14 +90,24 @@ export default function RepoListFooter({
       </Box>
       {/* Line 4: System controls */}
       <Box width={terminalWidth} justifyContent="center">
-        <Text color={theme.muted} dimColor={modalOpen ? true : undefined}>
+        <Text color={hintColor} dimColor={hintDim}>
           K Cache Info • W Org Switch{!starsMode ? ' • Ctrl+N New Repo' : ''} • Del/Backspace Delete • Ctrl+L Logout • Q Quit
         </Text>
       </Box>
-      {/* Multi-select hint (shown when not in modal) */}
+      {/* Multi-select hint (shown when not in modal). Inactive matches the
+          other reminder lines (theme.muted). Active inverts theme.primary
+          onto the whole row so Bulk Select reads as "on" (GMC-51). */}
       {!modalOpen && (
-        <Box width={terminalWidth} justifyContent="center">
-          <Text color={multiSelectMode ? 'cyan' : 'gray'} dimColor={!multiSelectMode}>
+        <Box
+          width={terminalWidth}
+          justifyContent="center"
+          backgroundColor={multiSelectMode ? theme.primary : undefined}
+        >
+          <Text
+            color={multiSelectMode ? 'black' : hintColor}
+            bold={multiSelectMode || undefined}
+            dimColor={hintDim}
+          >
             {multiSelectMode
               ? (selectedCount > 0
                   ? `Space select • X unselect all • Ctrl+S star • Ctrl+A archive • Ctrl+V visibility${starsMode ? '' : ' • Shift+M transfer'} • Del delete • B/Esc exit (${selectedCount} selected${hiddenSelectedCount > 0 ? `, ${hiddenSelectedCount} not shown in search` : ''})`
@@ -79,7 +119,7 @@ export default function RepoListFooter({
       )}
       {/* Line 5: Sponsorship */}
       <Box width={terminalWidth} justifyContent="center" marginTop={1}>
-        <Text color={theme.warning} dimColor={modalOpen ? true : undefined}>
+        <Text color={theme.warning} dimColor={hintDim}>
           💖 Sponsor on GitHub: github.com/sponsors/wiiiimm
         </Text>
       </Box>

--- a/src/ui/components/repo/RepoListFooter.tsx
+++ b/src/ui/components/repo/RepoListFooter.tsx
@@ -64,10 +64,15 @@ export default function RepoListFooter({
           K Cache Info • W Org Switch{!starsMode ? ' • Ctrl+N New Repo' : ''} • Del/Backspace Delete • Ctrl+L Logout • Q Quit
         </Text>
       </Box>
-      {/* Multi-select hint (shown when not in modal) */}
+      {/* Multi-select hint (shown when not in modal). Inactive uses the same
+          theme.muted / dim-only-when-modal styling as the lines above (GMC-51);
+          active uses theme.primary so the emphasis stays on-theme. */}
       {!modalOpen && (
         <Box width={terminalWidth} justifyContent="center">
-          <Text color={multiSelectMode ? 'cyan' : 'gray'} dimColor={!multiSelectMode}>
+          <Text
+            color={multiSelectMode ? theme.primary : theme.muted}
+            dimColor={modalOpen ? true : undefined}
+          >
             {multiSelectMode
               ? (selectedCount > 0
                   ? `Space select • X unselect all • Ctrl+S star • Ctrl+A archive • Ctrl+V visibility${starsMode ? '' : ' • Shift+M transfer'} • Del delete • B/Esc exit (${selectedCount} selected${hiddenSelectedCount > 0 ? `, ${hiddenSelectedCount} not shown in search` : ''})`

--- a/src/ui/components/repo/RepoListFooter.tsx
+++ b/src/ui/components/repo/RepoListFooter.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Box, Text } from 'ink';
 import type { Theme } from '../../../config/themes';
 import type { OwnerContext } from '../../../config/config';
+import { truncate } from '../../../lib/utils';
 
 export interface RepoListFooterProps {
   terminalWidth: number;
@@ -19,6 +20,26 @@ export interface RepoListFooterProps {
   hiddenSelectedCount: number;
   /** When true, render a single hint line (GMC-50). */
   footerCollapsed: boolean;
+}
+
+/**
+ * Collapsed footer hint that always fits one terminal row (GMC-50).
+ *
+ * `computeListLayout` reserves a single hint line when collapsed, so wrapping
+ * on narrow terminals would make the list overestimate available height.
+ * Prefer the full wording when it fits; otherwise a compact variant; always
+ * hard-truncate to the usable width (`terminalWidth` minus `paddingX={1}`).
+ */
+export function collapsedFooterHint(multiSelectMode: boolean, terminalWidth: number): string {
+  const full = multiSelectMode
+    ? '↑↓ Navigate • Space Select • B/Esc Exit • H More keys'
+    : '↑↓ Navigate • / Search • ⏎ Open • B Bulk • H More keys • Q Quit';
+  const compact = multiSelectMode
+    ? '↑↓ • Space • B/Esc Exit • H More keys'
+    : '↑↓ • / • ⏎ • B Bulk • H More keys • Q';
+  const maxLen = Math.max(1, terminalWidth - 2);
+  const preferred = full.length <= maxLen ? full : compact;
+  return truncate(preferred, maxLen);
 }
 
 /**
@@ -43,9 +64,7 @@ export default function RepoListFooter({
   const hintDim = modalOpen ? true : undefined;
 
   if (footerCollapsed) {
-    const collapsedLine = multiSelectMode
-      ? '↑↓ Navigate • Space Select • B/Esc Exit • H More keys'
-      : '↑↓ Navigate • / Search • ⏎ Open • B Bulk • H More keys • Q Quit';
+    const collapsedLine = collapsedFooterHint(multiSelectMode, terminalWidth);
     return (
       <Box marginTop={1} paddingX={1} flexDirection="column">
         <Box
@@ -57,6 +76,7 @@ export default function RepoListFooter({
             color={multiSelectMode ? 'black' : hintColor}
             bold={multiSelectMode || undefined}
             dimColor={hintDim}
+            wrap="truncate"
           >
             {collapsedLine}
           </Text>

--- a/src/ui/components/repo/RepoListFooter.tsx
+++ b/src/ui/components/repo/RepoListFooter.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
 import { Box, Text } from 'ink';
+import chalk from 'chalk';
 import type { Theme } from '../../../config/themes';
 import type { OwnerContext } from '../../../config/config';
 import { truncate } from '../../../lib/utils';
+
+/** Invert onto the Bulk Select row: black/bold text; Box supplies the full-width primary background. */
+function invertBulkHint(text: string, dim?: boolean): string {
+  const paint = dim ? chalk.black.bold.dim : chalk.black.bold;
+  return paint(text);
+}
 
 export interface RepoListFooterProps {
   terminalWidth: number;
@@ -73,12 +80,11 @@ export default function RepoListFooter({
           backgroundColor={multiSelectMode ? theme.primary : undefined}
         >
           <Text
-            color={multiSelectMode ? 'black' : hintColor}
-            bold={multiSelectMode || undefined}
-            dimColor={hintDim}
+            color={multiSelectMode ? undefined : hintColor}
+            dimColor={multiSelectMode ? undefined : hintDim}
             wrap="truncate"
           >
-            {collapsedLine}
+            {multiSelectMode ? invertBulkHint(collapsedLine, hintDim) : collapsedLine}
           </Text>
         </Box>
       </Box>
@@ -124,14 +130,15 @@ export default function RepoListFooter({
           backgroundColor={multiSelectMode ? theme.primary : undefined}
         >
           <Text
-            color={multiSelectMode ? 'black' : hintColor}
-            bold={multiSelectMode || undefined}
-            dimColor={hintDim}
+            color={multiSelectMode ? undefined : hintColor}
+            dimColor={multiSelectMode ? undefined : hintDim}
           >
             {multiSelectMode
-              ? (selectedCount > 0
-                  ? `Space select • X unselect all • Ctrl+S star • Ctrl+A archive • Ctrl+V visibility${starsMode ? '' : ' • Shift+M transfer'} • Del delete • B/Esc exit (${selectedCount} selected${hiddenSelectedCount > 0 ? `, ${hiddenSelectedCount} not shown in search` : ''})`
-                  : 'B/Esc exit bulk select • Space select (no selection)')
+              ? invertBulkHint(
+                  selectedCount > 0
+                    ? `Space select • X unselect all • Ctrl+S star • Ctrl+A archive • Ctrl+V visibility${starsMode ? '' : ' • Shift+M transfer'} • Del delete • B/Esc exit (${selectedCount} selected${hiddenSelectedCount > 0 ? `, ${hiddenSelectedCount} not shown in search` : ''})`
+                    : 'B/Esc exit bulk select • Space select (no selection)',
+                )
               : 'B Bulk Select mode (star/archive/visibility/delete)'
             }
           </Text>

--- a/src/ui/hooks/useListLayout.ts
+++ b/src/ui/hooks/useListLayout.ts
@@ -9,19 +9,21 @@ import { computeListLayout, type ListLayout } from '../../lib/utils';
  * inline `terminalWidth` / `availableHeight` / `contentHeight` / `listHeight`
  * math that previously lived in `RepoList.tsx`.
  *
- * @param columns         Terminal width (`stdout.columns`); 80 when unknown.
- * @param maxVisibleRows  View height passed from the host; 20 when unknown.
- * @param filterMode      Whether the filter input bar is shown (reserves 2 lines).
- * @param multiSelectMode Whether the bulk-select bar is shown (reserves 2 lines).
+ * @param columns          Terminal width (`stdout.columns`); 80 when unknown.
+ * @param maxVisibleRows   View height passed from the host; 20 when unknown.
+ * @param filterMode       Whether the filter input bar is shown (reserves 2 lines).
+ * @param multiSelectMode  Whether the bulk-select bar is shown (reserves 2 lines).
+ * @param footerCollapsed  Whether the help footer is the one-line form (GMC-50).
  */
 export function useListLayout(
   columns: number | undefined,
   maxVisibleRows: number | undefined,
   filterMode: boolean,
   multiSelectMode: boolean,
+  footerCollapsed: boolean = false,
 ): ListLayout {
   return useMemo(
-    () => computeListLayout({ columns, maxVisibleRows, filterMode, multiSelectMode }),
-    [columns, maxVisibleRows, filterMode, multiSelectMode],
+    () => computeListLayout({ columns, maxVisibleRows, filterMode, multiSelectMode, footerCollapsed }),
+    [columns, maxVisibleRows, filterMode, multiSelectMode, footerCollapsed],
   );
 }

--- a/src/ui/hooks/useRepoListInput.ts
+++ b/src/ui/hooks/useRepoListInput.ts
@@ -63,6 +63,10 @@ export interface RepoListInputParams {
   themeToastTimerRef: React.MutableRefObject<NodeJS.Timeout | null>;
   setDensity: Dispatch<0 | 1 | 2>;
 
+  // Footer key-reminder collapse (GMC-50)
+  footerCollapsed: boolean;
+  setFooterCollapsed: Dispatch<boolean>;
+
   // Bulk select mode
   multiSelectMode: boolean;
   setMultiSelectMode: Dispatch<boolean>;
@@ -199,6 +203,7 @@ export function useRepoListInput(p: RepoListInputParams) {
     filter, setFilter, filterMode, setFilterMode, filterActive, clearViewFilters,
     starsMode, setStarsMode,
     themeName, setThemeName, setThemeToast, themeToastTimerRef, setDensity,
+    footerCollapsed, setFooterCollapsed,
     multiSelectMode, setMultiSelectMode, selectedRepos, setSelectedRepos,
     enterMultiSelectMode, exitMultiSelectMode, toggleRepoSelection,
     startBulkArchive, startBulkDelete, startBulkStar, startBulkTransfer, startBulkVisibility,
@@ -541,6 +546,16 @@ export function useRepoListInput(p: RepoListInputParams) {
     // Esc exits multi-select mode (if not in filter/search)
     if (key.escape && multiSelectMode) {
       exitMultiSelectMode(true);
+      return;
+    }
+
+    // Toggle collapsed/expanded footer hints (GMC-50). Available in both
+    // normal and Bulk Select modes; ignored while a modal or search input
+    // owns the keyboard (those paths return earlier).
+    if (input && input.toUpperCase() === 'H' && !key.ctrl) {
+      const next = !footerCollapsed;
+      setFooterCollapsed(next);
+      storeUIPrefs({ footerCollapsed: next });
       return;
     }
 

--- a/src/ui/views/RepoList.tsx
+++ b/src/ui/views/RepoList.tsx
@@ -82,6 +82,8 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
   // Theme state
   const [themeName, setThemeName] = useState<ThemeName>('default');
   const [themeToast, setThemeToast] = useState<string | null>(null);
+  // Help footer starts collapsed so the list has more vertical room (GMC-50).
+  const [footerCollapsed, setFooterCollapsed] = useState(true);
   const themeToastTimerRef = useRef<NodeJS.Timeout | null>(null);
   const { theme, c: tc } = useTheme(themeName);
   
@@ -1143,6 +1145,11 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     if (ui.theme && ['default', 'ocean', 'forest', 'monochrome'].includes(ui.theme)) {
       setThemeName(ui.theme);
     }
+
+    // Load footer collapse (GMC-50). Default is collapsed when unset.
+    if (typeof ui.footerCollapsed === 'boolean') {
+      setFooterCollapsed(ui.footerCollapsed);
+    }
     
     // Load organization context
     if (ui.ownerContext) {
@@ -1311,7 +1318,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
 
   // Calculate fixed heights for layout sections and list area (extracted to useListLayout, GMC-28)
   const { terminalWidth, availableHeight, containerPadding, contentHeight, listHeight } =
-    useListLayout(stdout?.columns, maxVisibleRows, filterMode, multiSelectMode);
+    useListLayout(stdout?.columns, maxVisibleRows, filterMode, multiSelectMode, footerCollapsed);
 
   const spacingLines = density; // map density to spacer lines
 
@@ -1370,6 +1377,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
     filter, setFilter, filterMode, setFilterMode, filterActive, clearViewFilters,
     starsMode, setStarsMode,
     themeName, setThemeName, setThemeToast, themeToastTimerRef, setDensity,
+    footerCollapsed, setFooterCollapsed,
     multiSelectMode, setMultiSelectMode, selectedRepos, setSelectedRepos,
     enterMultiSelectMode, exitMultiSelectMode, toggleRepoSelection,
     startBulkArchive, startBulkDelete, startBulkStar, startBulkTransfer, startBulkVisibility,
@@ -2301,7 +2309,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         )}
       </Box>
 
-      {/* Help footer - 5 lines (extracted to RepoListFooter, GMC-28) */}
+      {/* Help footer (extracted to RepoListFooter, GMC-28; collapse toggle GMC-50) */}
       <RepoListFooter
         terminalWidth={terminalWidth}
         theme={theme}
@@ -2312,6 +2320,7 @@ export default function RepoList({ token, maxVisibleRows, onLogout, viewerLogin,
         multiSelectMode={multiSelectMode}
         selectedCount={selectedRepos.size}
         hiddenSelectedCount={hiddenSelectedCount}
+        footerCollapsed={footerCollapsed}
       />
 
       {/* Debug panel */}

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -355,6 +355,37 @@ describe('config', () => {
       const prefs = getUIPrefs();
       expect(prefs.forkFilter).toBe('non-forks');
     });
+
+    it('persists footerCollapsed alongside other UI prefs (GMC-50)', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        token: 'token',
+        ui: { theme: 'ocean', density: 1 }
+      }));
+
+      storeUIPrefs({ footerCollapsed: false });
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.any(String),
+        JSON.stringify({
+          token: 'token',
+          ui: {
+            theme: 'ocean',
+            density: 1,
+            footerCollapsed: false,
+          }
+        }, null, 2),
+        'utf8'
+      );
+    });
+
+    it('restores footerCollapsed from saved UI prefs on read', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        ui: { footerCollapsed: false }
+      }));
+
+      const prefs = getUIPrefs();
+      expect(prefs.footerCollapsed).toBe(false);
+    });
   });
 
   describe('getTokenSource', () => {

--- a/tests/ui/RepoListFooter.test.tsx
+++ b/tests/ui/RepoListFooter.test.tsx
@@ -71,4 +71,41 @@ describe('RepoListFooter', () => {
     expect(lastFrame() || '').toContain('(2 selected, 1 not shown in search)');
     unmount();
   });
+
+  it('styles the inactive Bulk Select hint like the other reminder lines (GMC-51)', () => {
+    const { lastFrame, unmount } = render(<RepoListFooter {...baseProps} />);
+    const out = lastFrame() || '';
+    const lineOf = (needle: string) => out.split('\n').find(l => l.includes(needle)) || '';
+    const navLine = lineOf('↑↓ Navigate');
+    const bulkLine = lineOf('B Bulk Select mode');
+    // Must not apply Ink dim (SGR 2) — that was what made this row look darker.
+    expect(bulkLine).not.toMatch(/\x1b\[2m/);
+    // Same colour open sequence as the navigation hint (theme.muted).
+    const colour = (line: string) => line.match(/\x1b\[[0-9;]*m/)?.[0];
+    expect(colour(bulkLine)).toBe(colour(navLine));
+    unmount();
+  });
+
+  it('uses the theme mute colour (not hardcoded gray) on Ocean (GMC-51)', () => {
+    const { lastFrame, unmount } = render(
+      <RepoListFooter {...baseProps} theme={getTheme('ocean')} />,
+    );
+    const bulkLine = (lastFrame() || '').split('\n').find(l => l.includes('B Bulk Select mode')) || '';
+    // Ocean muted is 'blue' (34); the old hardcoded gray was 90.
+    expect(bulkLine).toMatch(/\x1b\[34m/);
+    expect(bulkLine).not.toMatch(/\x1b\[90m/);
+    expect(bulkLine).not.toMatch(/\x1b\[2m/);
+    unmount();
+  });
+
+  it('emphasises the active Bulk Select hint with the theme primary colour', () => {
+    const { lastFrame, unmount } = render(
+      <RepoListFooter {...baseProps} theme={getTheme('forest')} multiSelectMode={true} />,
+    );
+    const bulkLine = (lastFrame() || '').split('\n').find(l => l.includes('B/Esc exit bulk select')) || '';
+    // Forest primary is 'green' (32), not the old hardcoded cyan (36).
+    expect(bulkLine).toMatch(/\x1b\[32m/);
+    expect(bulkLine).not.toMatch(/\x1b\[36m/);
+    unmount();
+  });
 });

--- a/tests/ui/RepoListFooter.test.tsx
+++ b/tests/ui/RepoListFooter.test.tsx
@@ -128,10 +128,11 @@ describe('RepoListFooter', () => {
     });
 
     it('switches to a compact wording that still fits one row when narrow', () => {
+      // Normal full line is 63 chars (needs ≤61 usable cols); bulk full is 53.
       const normal = collapsedFooterHint(false, 60);
-      const bulk = collapsedFooterHint(true, 60);
+      const bulk = collapsedFooterHint(true, 50);
       expect(normal.length).toBeLessThanOrEqual(58);
-      expect(bulk.length).toBeLessThanOrEqual(58);
+      expect(bulk.length).toBeLessThanOrEqual(48);
       expect(normal).toContain('H More keys');
       expect(bulk).toContain('H More keys');
       expect(normal).not.toContain('Navigate');

--- a/tests/ui/RepoListFooter.test.tsx
+++ b/tests/ui/RepoListFooter.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { render } from 'ink-testing-library';
-import RepoListFooter from '../../src/ui/components/repo/RepoListFooter';
+import RepoListFooter, { collapsedFooterHint } from '../../src/ui/components/repo/RepoListFooter';
 import { getTheme } from '../../src/config/themes';
 import type { OwnerContext } from '../../src/config/config';
 
@@ -105,6 +105,37 @@ describe('RepoListFooter', () => {
       expect(out).not.toContain('Q Quit');
       expect(out).not.toContain('Ctrl+S star');
       unmount();
+    });
+
+    it('stays on one rendered hint line at ≤60 columns (no wrap)', () => {
+      const { lastFrame, unmount } = render(
+        <RepoListFooter {...baseProps} terminalWidth={60} footerCollapsed={true} />,
+      );
+      const lines = (lastFrame() || '').split('\n').filter((l) => l.trim().length > 0);
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toContain('H More keys');
+      expect(collapsedFooterHint(false, 60).length).toBeLessThanOrEqual(58);
+      unmount();
+    });
+
+    it('uses the full collapsed wording when the terminal is wide enough', () => {
+      expect(collapsedFooterHint(false, 120)).toBe(
+        '↑↓ Navigate • / Search • ⏎ Open • B Bulk • H More keys • Q Quit',
+      );
+      expect(collapsedFooterHint(true, 120)).toBe(
+        '↑↓ Navigate • Space Select • B/Esc Exit • H More keys',
+      );
+    });
+
+    it('switches to a compact wording that still fits one row when narrow', () => {
+      const normal = collapsedFooterHint(false, 60);
+      const bulk = collapsedFooterHint(true, 60);
+      expect(normal.length).toBeLessThanOrEqual(58);
+      expect(bulk.length).toBeLessThanOrEqual(58);
+      expect(normal).toContain('H More keys');
+      expect(bulk).toContain('H More keys');
+      expect(normal).not.toContain('Navigate');
+      expect(bulk).not.toContain('Navigate');
     });
   });
 

--- a/tests/ui/RepoListFooter.test.tsx
+++ b/tests/ui/RepoListFooter.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render } from 'ink-testing-library';
+import chalk from 'chalk';
 import RepoListFooter, { collapsedFooterHint } from '../../src/ui/components/repo/RepoListFooter';
 import { getTheme } from '../../src/config/themes';
 import type { OwnerContext } from '../../src/config/config';
@@ -21,6 +22,19 @@ const baseProps = {
 };
 
 describe('RepoListFooter', () => {
+  let prevChalkLevel: number;
+
+  beforeEach(() => {
+    // Force ANSI so colour assertions cannot pass vacuously when NO_COLOR is set
+    // or stdout is not a TTY (GMC-51 / CodeRabbit).
+    prevChalkLevel = chalk.level;
+    chalk.level = 1;
+  });
+
+  afterEach(() => {
+    chalk.level = prevChalkLevel;
+  });
+
   it('renders the core navigation, search and sponsor hint lines', () => {
     const { lastFrame, unmount } = render(<RepoListFooter {...baseProps} />);
     const out = lastFrame() || '';
@@ -149,7 +163,11 @@ describe('RepoListFooter', () => {
     // Must not apply Ink dim (SGR 2) — that was what made this row look darker.
     expect(bulkLine).not.toMatch(/\x1b\[2m/);
     const colour = (line: string) => line.match(/\x1b\[[0-9;]*m/)?.[0];
-    expect(colour(bulkLine)).toBe(colour(navLine));
+    const bulkColour = colour(bulkLine);
+    const navColour = colour(navLine);
+    expect(bulkColour).toBeDefined();
+    expect(navColour).toBeDefined();
+    expect(bulkColour).toBe(navColour);
     unmount();
   });
 

--- a/tests/ui/RepoListFooter.test.tsx
+++ b/tests/ui/RepoListFooter.test.tsx
@@ -98,13 +98,16 @@ describe('RepoListFooter', () => {
     unmount();
   });
 
-  it('emphasises the active Bulk Select hint with the theme primary colour', () => {
+  it('inverts the active Bulk Select row onto the theme primary colour (GMC-51)', () => {
     const { lastFrame, unmount } = render(
       <RepoListFooter {...baseProps} theme={getTheme('forest')} multiSelectMode={true} />,
     );
-    const bulkLine = (lastFrame() || '').split('\n').find(l => l.includes('B/Esc exit bulk select')) || '';
-    // Forest primary is 'green' (32), not the old hardcoded cyan (36).
-    expect(bulkLine).toMatch(/\x1b\[32m/);
+    const out = lastFrame() || '';
+    const bulkLine = out.split('\n').find(l => l.includes('B/Esc exit bulk select')) || '';
+    // Forest primary is green: background 42 + black foreground 30.
+    // Must not keep the old hardcoded cyan (36) text-only treatment.
+    expect(bulkLine).toMatch(/\x1b\[42m/);
+    expect(bulkLine).toMatch(/\x1b\[30m/);
     expect(bulkLine).not.toMatch(/\x1b\[36m/);
     unmount();
   });

--- a/tests/ui/RepoListFooter.test.tsx
+++ b/tests/ui/RepoListFooter.test.tsx
@@ -17,6 +17,7 @@ const baseProps = {
   multiSelectMode: false,
   selectedCount: 0,
   hiddenSelectedCount: 0,
+  footerCollapsed: false,
 };
 
 describe('RepoListFooter', () => {
@@ -69,6 +70,64 @@ describe('RepoListFooter', () => {
       <RepoListFooter {...baseProps} multiSelectMode={true} selectedCount={2} hiddenSelectedCount={1} />,
     );
     expect(lastFrame() || '').toContain('(2 selected, 1 not shown in search)');
+    unmount();
+  });
+
+  it('shows the collapse toggle on the first expanded hint line', () => {
+    const { lastFrame, unmount } = render(<RepoListFooter {...baseProps} />);
+    expect(lastFrame() || '').toContain('H Fewer keys');
+    unmount();
+  });
+
+  describe('collapsed (GMC-50)', () => {
+    it('renders a single hint line that includes the toggle key', () => {
+      const { lastFrame, unmount } = render(<RepoListFooter {...baseProps} footerCollapsed={true} />);
+      const out = lastFrame() || '';
+      expect(out).toContain('↑↓ Navigate');
+      expect(out).toContain('/ Search');
+      expect(out).toContain('H More keys');
+      expect(out).toContain('Q Quit');
+      expect(out).not.toContain('S Sort • D Direction');
+      expect(out).not.toContain('H Fewer keys');
+      expect(out).not.toContain('github.com/sponsors/wiiiimm');
+      expect(out).not.toContain('B Bulk Select mode');
+      unmount();
+    });
+
+    it('shows bulk-relevant keys (not the full action dump) in Bulk Select mode', () => {
+      const { lastFrame, unmount } = render(
+        <RepoListFooter {...baseProps} footerCollapsed={true} multiSelectMode={true} selectedCount={2} />,
+      );
+      const out = lastFrame() || '';
+      expect(out).toContain('Space Select');
+      expect(out).toContain('B/Esc Exit');
+      expect(out).toContain('H More keys');
+      expect(out).not.toContain('Q Quit');
+      expect(out).not.toContain('Ctrl+S star');
+      unmount();
+    });
+  });
+
+  it('styles the inactive Bulk Select hint like the other reminder lines (GMC-51)', () => {
+    const { lastFrame, unmount } = render(<RepoListFooter {...baseProps} />);
+    const out = lastFrame() || '';
+    const lineOf = (needle: string) => out.split('\n').find(l => l.includes(needle)) || '';
+    const navLine = lineOf('↑↓ Navigate');
+    const bulkLine = lineOf('B Bulk Select mode');
+    expect(bulkLine).not.toMatch(/\x1b\[2m/);
+    const colour = (line: string) => line.match(/\x1b\[[0-9;]*m/)?.[0];
+    expect(colour(bulkLine)).toBe(colour(navLine));
+    unmount();
+  });
+
+  it('inverts the active Bulk Select row onto the theme primary colour (GMC-51)', () => {
+    const { lastFrame, unmount } = render(
+      <RepoListFooter {...baseProps} theme={getTheme('forest')} multiSelectMode={true} />,
+    );
+    const bulkLine = (lastFrame() || '').split('\n').find(l => l.includes('B/Esc exit bulk select')) || '';
+    expect(bulkLine).toMatch(/\x1b\[42m/);
+    expect(bulkLine).toMatch(/\x1b\[30m/);
+    expect(bulkLine).not.toMatch(/\x1b\[36m/);
     unmount();
   });
 });

--- a/tests/ui/useListLayout.test.tsx
+++ b/tests/ui/useListLayout.test.tsx
@@ -12,15 +12,17 @@ function Harness({
   maxVisibleRows,
   filterMode,
   multiSelectMode,
+  footerCollapsed,
   sink,
 }: {
   columns?: number;
   maxVisibleRows?: number;
   filterMode: boolean;
   multiSelectMode: boolean;
+  footerCollapsed?: boolean;
   sink: ListLayout[];
 }) {
-  const layout = useListLayout(columns, maxVisibleRows, filterMode, multiSelectMode);
+  const layout = useListLayout(columns, maxVisibleRows, filterMode, multiSelectMode, footerCollapsed);
   sink.push(layout);
   return <Text>{`${layout.terminalWidth}x${layout.listHeight}`}</Text>;
 }
@@ -58,5 +60,27 @@ describe('useListLayout', () => {
     const after = sink[sink.length - 1];
     expect(after).not.toBe(before);
     expect(after.listHeight).toBe(before.listHeight - 2);
+  });
+
+  it('recomputes a taller list when the footer collapses (GMC-50)', () => {
+    const sink: ListLayout[] = [];
+    const { rerender, unmount } = render(
+      <Harness columns={100} maxVisibleRows={30} filterMode={false} multiSelectMode={false} sink={sink} />,
+    );
+    const expanded = sink[sink.length - 1];
+    rerender(
+      <Harness
+        columns={100}
+        maxVisibleRows={30}
+        filterMode={false}
+        multiSelectMode={false}
+        footerCollapsed={true}
+        sink={sink}
+      />,
+    );
+    const collapsed = sink[sink.length - 1];
+    expect(collapsed).not.toBe(expanded);
+    expect(collapsed.listHeight).toBe(expanded.listHeight + 2);
+    unmount();
   });
 });

--- a/tests/ui/useRepoListInput.test.tsx
+++ b/tests/ui/useRepoListInput.test.tsx
@@ -339,6 +339,18 @@ describe('useRepoListInput', () => {
     );
     press('h', {});
     expect(setFooterCollapsed).not.toHaveBeenCalled();
+    expect(storeUIPrefs).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('ignores H while the search input owns keyboard input', () => {
+    const setFooterCollapsed = vi.fn();
+    const { unmount } = render(
+      <Harness params={makeParams({ filterMode: true, setFooterCollapsed })} />,
+    );
+    press('h', {});
+    expect(setFooterCollapsed).not.toHaveBeenCalled();
+    expect(storeUIPrefs).not.toHaveBeenCalled();
     unmount();
   });
 });

--- a/tests/ui/useRepoListInput.test.tsx
+++ b/tests/ui/useRepoListInput.test.tsx
@@ -13,6 +13,11 @@ vi.mock('../../src/lib/logger', () => ({
   logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
 }));
 
+vi.mock('../../src/config/config', async () => {
+  const actual = await vi.importActual<typeof import('../../src/config/config')>('../../src/config/config');
+  return { ...actual, storeUIPrefs: vi.fn() };
+});
+
 vi.mock('../../src/services/github', () => ({
   getRepositoryFromCache: vi.fn().mockResolvedValue(null),
   inspectCacheStatus: vi.fn().mockResolvedValue(undefined),
@@ -20,6 +25,7 @@ vi.mock('../../src/services/github', () => ({
 }));
 
 import { useRepoListInput, type RepoListInputParams } from '../../src/ui/hooks/useRepoListInput';
+import { storeUIPrefs } from '../../src/config/config';
 
 const repo = (slug: string, over: Record<string, unknown> = {}) => ({
   id: `R_${slug}`,
@@ -63,6 +69,8 @@ function makeParams(overrides: Partial<RepoListInputParams> = {}): RepoListInput
     setThemeToast: vi.fn(),
     themeToastTimerRef: { current: null },
     setDensity: vi.fn(),
+    footerCollapsed: true,
+    setFooterCollapsed: vi.fn(),
     multiSelectMode: false,
     setMultiSelectMode: vi.fn(),
     selectedRepos: new Map(),
@@ -185,6 +193,7 @@ describe('useRepoListInput', () => {
     const mockUseInput = (ink as any).useInput;
     mockUseInput.mockReset();
     mockUseInput.mockImplementation((cb: any) => { handler = cb; });
+    vi.mocked(storeUIPrefs).mockClear();
   });
 
   const press = (input: string, key: Record<string, boolean> = {}) => handler(input, key);
@@ -298,6 +307,38 @@ describe('useRepoListInput', () => {
     );
     press('x', {});
     expect(setBulkProgressOpen).toHaveBeenCalledWith(false);
+    unmount();
+  });
+
+  it('H toggles the footer collapse and persists the preference (GMC-50)', () => {
+    const setFooterCollapsed = vi.fn();
+    const { unmount } = render(
+      <Harness params={makeParams({ footerCollapsed: true, setFooterCollapsed })} />,
+    );
+    press('h', {});
+    expect(setFooterCollapsed).toHaveBeenCalledWith(false);
+    expect(storeUIPrefs).toHaveBeenCalledWith({ footerCollapsed: false });
+    unmount();
+  });
+
+  it('H still toggles the footer while in Bulk Select mode', () => {
+    const setFooterCollapsed = vi.fn();
+    const { unmount } = render(
+      <Harness params={makeParams({ multiSelectMode: true, footerCollapsed: false, setFooterCollapsed })} />,
+    );
+    press('h', {});
+    expect(setFooterCollapsed).toHaveBeenCalledWith(true);
+    expect(storeUIPrefs).toHaveBeenCalledWith({ footerCollapsed: true });
+    unmount();
+  });
+
+  it('ignores H while a modal is open', () => {
+    const setFooterCollapsed = vi.fn();
+    const { unmount } = render(
+      <Harness params={makeParams({ deleteMode: true, setFooterCollapsed })} />,
+    );
+    press('h', {});
+    expect(setFooterCollapsed).not.toHaveBeenCalled();
     unmount();
   });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -339,4 +339,17 @@ describe('computeListLayout', () => {
     expect(layout.contentHeight).toBe(1); // max(1, 5 - 8)
     expect(layout.listHeight).toBe(1); // max(1, 1 - 2 - 2 - 2)
   });
+
+  it('grows listHeight when the footer is collapsed (GMC-50)', () => {
+    const expanded = computeListLayout({ maxVisibleRows: 40, filterMode: false, multiSelectMode: false });
+    const collapsed = computeListLayout({
+      maxVisibleRows: 40,
+      filterMode: false,
+      multiSelectMode: false,
+      footerCollapsed: true,
+    });
+    // Collapsed footer reserves 2 lines instead of 4, so the list gains 2 rows.
+    expect(collapsed.listHeight).toBe(expanded.listHeight + 2);
+    expect(collapsed.contentHeight).toBe(expanded.contentHeight + 2);
+  });
 });

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -20,6 +20,7 @@ A complete overview of what gh-manager-cli can do, grouped by area.
 - **Keyboard Navigation:** full keyboard control (arrow keys, PageUp/Down, `Ctrl+G`/`G`).
 - **Display Density:** toggle compact/cozy/comfy spacing (`T`).
 - **Colour Themes:** four themes (Default, Ocean, Forest, Monochrome) cycled with `Shift+T`, persisted across restarts; theme-aware selected-row highlight tuned per theme for readable contrast.
+- **Collapsible key hints:** `H` collapses the help footer to one line of important shortcuts (including the toggle itself) so more repositories fit on screen; expands back to the full reminder set. Persists across restarts.
 - **Visual Indicators:** fork status, private/internal/archived badges, language colours, visibility status.
 - **Enterprise Support:** full support for GitHub Enterprise with Internal repository visibility.
 - **Organisation Context:** switch between personal and organisation accounts with an ENT badge for enterprise orgs.
@@ -29,7 +30,7 @@ A complete overview of what gh-manager-cli can do, grouped by area.
 
 ## Technical Features
 
-- **Preference Persistence:** UI settings (sort, density, visibility/archive/fork filters, fork commit tracking, colour theme) saved between sessions.
+- **Preference Persistence:** UI settings (sort, density, visibility/archive/fork filters, fork commit tracking, colour theme, footer collapse) saved between sessions.
 - **Client-side Filtering & Sorting:** once the account is cached via background fetch-all, visibility/archive/fork filtering and all sorting run locally over the complete set — instant, with no server refetch.
 - **Cross-platform:** works on macOS, Linux, and Windows.
 - **Secure Storage:** token stored with proper file permissions (0600).

--- a/wiki/Usage.md
+++ b/wiki/Usage.md
@@ -28,6 +28,7 @@ See also: [Features](Features.md) · [Token & Security](Token-and-Security.md) �
 - **Fork Status**: always enabled — shows commits ahead and behind upstream once enrichment completes. Unrelated to the fork view filter.
 - **View Filters**: `V` opens the consolidated View Filters modal with three grouped sections — Visibility (All / Public / Private[/Internal for enterprise]), Archive (All / Unarchived / Archived), and Fork (All / Forks only / Non-forks only). Move between groups with ↑↓, change a group's value live with ←→ (radio-style), then Enter (or `Y`/Apply) to apply and close, Esc/`C` to cancel. The Visibility group is hidden in stars mode; Archive and Fork remain available. All three selections persist across restarts, and reset to All when you switch organisation or scope (own ↔ starred).
 - **Stars Mode**: `Shift+S` (personal account only) toggles between your own repos and your starred repos. The footer hint shows `Shift+S Starred` in normal mode and `Shift+S My Repos` in starred mode.
+- **Help footer**: `H` toggles the key-reminder footer between a single line of important shortcuts (including `H More keys`) and the full set. Collapsed is the default so more repositories fit on screen; the preference persists across restarts. Works in Bulk Select mode too.
 
 ## Navigation & Account
 
@@ -56,7 +57,7 @@ See also: [Features](Features.md) · [Token & Security](Token-and-Security.md) �
 ## Bulk Operations (Bulk Select mode)
 
 - `B` enters/exits Bulk Select mode (exits and clears the selection). `Esc` also exits and clears.
-- Within bulk mode every other shortcut is disabled; only navigation + these work: `Space` toggles selection on the cursor row; `X` unselects all (stays in bulk mode); navigation (arrows, PageUp/Down, `Ctrl+G`, `G`) still works.
+- Within bulk mode every other shortcut is disabled; only navigation + these work: `Space` toggles selection on the cursor row; `X` unselects all (stays in bulk mode); navigation (arrows, PageUp/Down, `Ctrl+G`, `G`) still works; `H` still toggles the help footer.
 - Bulk actions reuse the global shortcuts: `Ctrl+S` star/unstar, `Ctrl+A` archive/unarchive, `Ctrl+V` visibility, `Del`/`Backspace` delete, `Shift+M` transfer (move) to another owner/org. Each requires at least one selected repo.
 - Star and archive are toggles: if all selected share the same state, the opposite is applied directly; if the selection is mixed, an intent modal asks the explicit target. Visibility always shows a target picker (Public / Private / Internal — Internal only for enterprise orgs). Transfer opens a destination picker (personal account + visible orgs, plus a manual-entry fallback).
 - Selections persist across search, filter, and sort changes (stored as full node objects by id). They are cleared on org/scope switch and stars mode toggle.


### PR DESCRIPTION
## Summary

The help footer always showed ~6 hint lines, even when you already know the shortcuts. **`H`** now toggles it between:

- **Collapsed (default):** one line of important keys, including `H More keys` so people can discover the expand.
  - Normal: `↑↓ Navigate • / Search • ⏎ Open • B Bulk • H More keys • Q Quit`
  - Bulk Select: `↑↓ Navigate • Space Select • B/Esc Exit • H More keys`
- **Expanded:** the full reminder set, with `H Fewer keys` on the first line.

The preference is stored in config (`footerCollapsed`) and survives restarts. `computeListLayout` / `useListLayout` reserve 2 lines when collapsed instead of 4, so `listHeight` grows and more repos fit.

`H` works in Bulk Select mode. It is ignored while a modal or the search box owns the keyboard.

Linear: https://linear.app/stealth-company/issue/GMC-50/toggle-footer-key-reminders-collapsed-one-line-hints-to-reclaim-list

## Note vs #150 (GMC-51)

This PR also keeps the Bulk Select row invert (`theme.primary` background + black text when the mode is on) so landing this after [#150](https://github.com/wiiiimm/gh-manager-cli/pull/150) does not restore the old dimmed-gray hint. The two PRs both touch `RepoListFooter.tsx` — merge either first; the other will need a small rebase.

## Tests

- Collapsed footer is a single line that includes the toggle key; expanded still shows the full set.
- `H` toggles and persists; ignored while a modal is open; still works in Bulk Select.
- `listHeight` is 2 rows larger when collapsed.
- Inactive Bulk Select hint matches the other reminder lines; active row inverts onto the theme primary colour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a compact, collapsible help footer for key hints.
  - Press **H** to toggle between compact and full hints, including in Bulk Select mode.
  - Your footer preference is now saved and restored automatically.
  - Collapsing the footer provides more space for repository items.

- **Documentation**
  - Updated usage guidance and feature documentation for the new shortcut and persistent setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->