### PR TITLE
fix: package standalone binaries against node22 (GMC-52) [semantic pr title]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,7 @@ jobs:
     if: ${{ startsWith(github.event.head_commit.message, 'chore(release):') }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
@@ -133,11 +134,10 @@ jobs:
       - name: Build application
         run: pnpm run build
 
-      - name: Install pkg globally
-        run: npm install -g @yao-pkg/pkg
-
       - name: Create binary
-        run: pkg dist/index.js --targets node20-${{ matrix.platform }}-${{ matrix.arch }} --output gh-manager-cli-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.ext }}
+        # node22: pkg-fetch v3.6 no longer ships node20-*-win-x64 (GMC-52).
+        # Use the project-pinned @yao-pkg/pkg rather than a floating global latest.
+        run: pnpm exec pkg dist/index.js --targets node22-${{ matrix.platform }}-${{ matrix.arch }} --output gh-manager-cli-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.ext }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,7 +280,7 @@ First run prompts for a PAT if not provided via env vars. The token is validated
 - `package.json` defines `bin: { "gh-manager-cli": "dist/index.js" }`.
 - For local dev: `pnpm link` exposes `gh-manager-cli` on PATH.
 - For publish: `npm publish` (after setting version and adding README).
-- **Standalone binaries:** `pnpm build:binaries` uses `@yao-pkg/pkg` (the maintained fork of the archived `vercel/pkg`) and emits `node20-*` targets. The CLI itself runs on Node >=20 (`engines.node`), but the `@yao-pkg/pkg` packager requires **Node >=22** to run, so the `build:binaries` script and the release workflow's binary job must run on Node 22+. End users running the CLI are unaffected.
+- **Standalone binaries:** `pnpm build:binaries` uses `@yao-pkg/pkg` (the maintained fork of the archived `vercel/pkg`) and emits `node22-*` targets. The CLI itself runs on Node >=20 (`engines.node`); the packager and its prebuilt bases are Node 22 (pkg-fetch v3.6 no longer ships `node20-*-win-x64`). End users of the npm CLI are unaffected.
 
 ## Development Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,7 +280,7 @@ First run prompts for a PAT if not provided via env vars. The token is validated
 - `package.json` defines `bin: { "gh-manager-cli": "dist/index.js" }`.
 - For local dev: `pnpm link` exposes `gh-manager-cli` on PATH.
 - For publish: `npm publish` (after setting version and adding README).
-- **Standalone binaries:** `pnpm build:binaries` uses `@yao-pkg/pkg` (the maintained fork of the archived `vercel/pkg`) and emits `node22-*` targets. The CLI itself runs on Node >=20 (`engines.node`); the packager and its prebuilt bases are Node 22 (pkg-fetch v3.6 no longer ships `node20-*-win-x64`). End users of the npm CLI are unaffected.
+- **Standalone binaries:** `pnpm build:binaries` uses `@yao-pkg/pkg@6.20.0` (the maintained fork of the archived `vercel/pkg`) and emits `node22-*` targets. The CLI itself runs on Node >=20 (`engines.node`). Building binaries requires **Node.js 22 or later**: `@yao-pkg/pkg@6.20.0` / pkg-fetch v3.6 no longer ships `node20-*-win-x64`, so the script and the release workflow's binary job must run on Node 22+. End users of the npm CLI are unaffected.
 
 ## Development Workflow
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "type": "module",
   "scripts": {
     "build": "tsup",
-    "build:binaries": "npm run build && pkg dist/index.js --targets node20-linux-x64,node20-macos-x64,node20-windows-x64 --out-path ./binaries",
+    "build:binaries": "pnpm run build && pnpm exec pkg dist/index.js --targets node22-linux-x64,node22-macos-x64,node22-windows-x64 --out-path ./binaries",
     "dev": "tsup --watch",
     "start": "node dist/index.js",
     "start:debug": "GH_MANAGER_DEBUG=1 node dist/index.js",

--- a/tests/build-binaries.test.ts
+++ b/tests/build-binaries.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+interface PackageJson {
+  scripts?: Record<string, string>;
+  engines?: { node?: string };
+  devDependencies?: Record<string, string>;
+}
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(join(repoRoot, relativePath), 'utf8');
+}
+
+describe('standalone binary packaging (GMC-52)', () => {
+  const pkg = JSON.parse(readRepoFile('package.json')) as PackageJson;
+  const buildBinaries = pkg.scripts?.['build:binaries'] ?? '';
+  const releaseWorkflow = readRepoFile('.github/workflows/release.yml');
+  const expectedTargets = [
+    'node22-linux-x64',
+    'node22-macos-x64',
+    'node22-windows-x64',
+  ];
+
+  it('pins @yao-pkg/pkg instead of a floating global pkg', () => {
+    expect(pkg.devDependencies?.['@yao-pkg/pkg']).toMatch(/^\^?6\./);
+    expect(buildBinaries).toContain('pnpm exec pkg');
+    expect(buildBinaries).not.toMatch(/npm install -g/);
+    expect(releaseWorkflow).toContain('pnpm exec pkg');
+    expect(releaseWorkflow).not.toMatch(/npm install -g @yao-pkg\/pkg/);
+  });
+
+  it('targets node22 bases that pkg-fetch still publishes', () => {
+    expect(buildBinaries).toContain(expectedTargets.join(','));
+    expect(buildBinaries).not.toMatch(/node20-/);
+    expect(releaseWorkflow).toMatch(/--targets node22-\$\{\{ matrix\.platform \}\}-\$\{\{ matrix\.arch \}\}/);
+    expect(releaseWorkflow).not.toMatch(/--targets node20-/);
+  });
+
+  it('keeps CLI engines on Node 20 while binaries require Node 22', () => {
+    expect(pkg.engines?.node).toBe('>=20');
+    expect(releaseWorkflow).toMatch(/node-version:\s*'22'/);
+  });
+});


### PR DESCRIPTION
## Summary

[Release Pipeline run 31704404521](https://github.com/wiiiimm/gh-manager-cli/actions/runs/31704404521) failed on **build (windows-latest)** while creating the standalone `.exe`.

`@yao-pkg/pkg` requested `v3.6 / node-v20.20.2-win-x64` from pkg-fetch and got **404**. It then tried to compile Node from source on the runner (no Visual Studio) and died. The JS `pnpm run build` step had already succeeded. Ubuntu/macOS binary jobs were cancelled; GitHub Release extras were skipped.

Recent [pkg-fetch v3.6](https://github.com/yao-pkg/pkg-fetch/releases/tag/v3.6) rolling assets are Node **22 / 24 / 26** — Node 20 Windows is gone. The workflow already installs Node 22 to *run* pkg.

## Change

- pkg targets `node20-*` → `node22-*` in the release workflow and `pnpm build:binaries`
- `pnpm exec pkg` (project-pinned `@yao-pkg/pkg`) instead of `npm install -g @yao-pkg/pkg` (floating latest)
- `strategy.fail-fast: false` so one OS does not cancel the others

Linear: https://linear.app/stealth-company/issue/GMC-52/fix-windows-release-binary-pkg-node20-windows-x64-base-is-404

The 1.53.0 npm package from semantic-release is unaffected. Re-running the Release Pipeline on `main` after this lands should attach the binaries to the existing GitHub release (`gh release view` already exists → upload with `--clobber`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standalone binaries are now built for Node.js 22.

* **Bug Fixes**
  * Binary builds now use the project’s pinned packaging tool for more consistent results.
  * Platform builds continue independently if one target fails.

* **Documentation**
  * Updated build documentation to reflect the new Node.js 22 binary targets while retaining Node.js 20 as the CLI runtime requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->